### PR TITLE
feat(web): redesign empty state with orange-themed icons

### DIFF
--- a/web/src/components/Empty.tsx
+++ b/web/src/components/Empty.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 import { cn } from '@/lib/utils'
+import { Inbox, type LucideIcon } from 'lucide-react'
 
 type EmptyProps = {
   title?: string
   description?: string
   action?: React.ReactNode
   className?: string
+  icon?: LucideIcon
   showImage?: boolean
 }
 
@@ -14,29 +16,41 @@ export default function Empty({
   description = 'No hay información para mostrar en este momento.',
   action,
   className,
+  icon: Icon = Inbox,
   showImage = true,
 }: EmptyProps) {
   return (
     <div className={cn('flex flex-col items-center justify-center px-4 py-20 text-center animate-fade-in', className)} role="status">
       {showImage && (
-        <div className="relative mb-8 group">
-          <div className="absolute inset-0 bg-brand-orange/20 blur-3xl rounded-full scale-150 opacity-10 group-hover:opacity-20 transition-opacity" aria-hidden="true" />
-          <img
-            src="/assets/empty-state.png"
-            alt="Ilustración de estado vacío - No hay información disponible"
-            className="w-48 h-48 object-contain drop-shadow-2xl relative z-10 hover:scale-105 transition-transform duration-500"
-          />
+        <div className="relative mb-8 group" aria-hidden="true">
+          {/* Outer glow */}
+          <div className="absolute inset-0 bg-brand-orange/10 blur-3xl rounded-full scale-150 group-hover:bg-brand-orange/15 transition-all duration-500" />
+
+          {/* Decorative rings */}
+          <div className="relative">
+            <div className="absolute -inset-4 rounded-full border-2 border-dashed border-brand-orange/15 animate-[spin_25s_linear_infinite]" />
+            <div className="absolute -inset-8 rounded-full border border-brand-orange/8 animate-[spin_35s_linear_infinite_reverse]" />
+
+            {/* Main icon container */}
+            <div className="relative w-24 h-24 rounded-2xl bg-gradient-to-br from-brand-orange/15 to-brand-orange/5 dark:from-brand-orange/20 dark:to-brand-orange/8 flex items-center justify-center shadow-lg shadow-brand-orange/10 group-hover:scale-105 transition-transform duration-500 ring-1 ring-brand-orange/20">
+              <Icon className="w-10 h-10 text-brand-orange" strokeWidth={1.5} />
+            </div>
+
+            {/* Decorative dots */}
+            <div className="absolute -top-2 -right-2 w-3 h-3 rounded-full bg-brand-orange/30 animate-pulse" />
+            <div className="absolute -bottom-1 -left-3 w-2 h-2 rounded-full bg-brand-orange/20 animate-pulse [animation-delay:1s]" />
+          </div>
         </div>
       )}
-      
+
       <div className="max-w-md relative z-10">
-        <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-3">
+        <h3 className="text-xl font-semibold text-text mb-2">
           {title}
         </h3>
-        <p className="text-gray-500 dark:text-gray-400 text-base mb-8 leading-relaxed">
+        <p className="text-text-secondary text-sm mb-8 leading-relaxed">
           {description}
         </p>
-        
+
         {action && (
           <div className="flex justify-center transition-all duration-300 hover:translate-y-[-2px]">
             {action}

--- a/web/src/pages/Calendar/CalendarView.tsx
+++ b/web/src/pages/Calendar/CalendarView.tsx
@@ -518,6 +518,7 @@ export const CalendarView: React.FC = () => {
               </div>
             ) : filteredListEvents.length === 0 ? (
               <Empty
+                icon={CalendarDays}
                 title="No se encontraron eventos"
                 description={
                   searchTerm || statusFilter !== "all"

--- a/web/src/pages/Clients/ClientList.tsx
+++ b/web/src/pages/Clients/ClientList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { clientService } from "../../services/clientService";
 import { Client } from "../../types/entities";
-import { Plus, Search, Edit, Trash2, Phone, Mail, Download } from "lucide-react";
+import { Plus, Search, Edit, Trash2, Phone, Mail, Download, Users } from "lucide-react";
 import { exportToCsv } from "../../lib/exportCsv";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { logError } from "../../lib/errorHandler";
@@ -172,6 +172,7 @@ export const ClientList: React.FC = () => {
           />
         ) : filteredClients.length === 0 ? (
           <Empty
+            icon={Users}
             title="No se encontraron clientes"
             description={
               searchTerm

--- a/web/src/pages/Inventory/InventoryList.tsx
+++ b/web/src/pages/Inventory/InventoryList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { inventoryService } from "../../services/inventoryService";
 import { InventoryItem } from "../../types/entities";
-import { Plus, Search, Edit, Trash2, AlertTriangle, Download } from "lucide-react";
+import { Plus, Search, Edit, Trash2, AlertTriangle, Download, Package } from "lucide-react";
 import { exportToCsv } from "../../lib/exportCsv";
 import clsx from "clsx";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
@@ -240,6 +240,7 @@ export const InventoryList: React.FC = () => {
           />
         ) : filteredItems.length === 0 ? (
           <Empty
+            icon={Package}
             title="No se encontraron ingredientes"
             description={
               searchTerm

--- a/web/src/pages/Products/ProductList.tsx
+++ b/web/src/pages/Products/ProductList.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { productService } from '../../services/productService';
 import { Product } from '../../types/entities';
-import { Plus, Search, Edit, Trash2, Package, Download } from 'lucide-react';
+import { Plus, Search, Edit, Trash2, Package, Download, UtensilsCrossed } from 'lucide-react';
 import { exportToCsv } from '../../lib/exportCsv';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { logError } from '../../lib/errorHandler';
@@ -160,8 +160,9 @@ export const ProductList: React.FC = () => {
             ]}
           />
         ) : filteredProducts.length === 0 ? (
-          <Empty 
-            title="No hay productos" 
+          <Empty
+            icon={UtensilsCrossed}
+            title="No hay productos"
             description={searchTerm ? "No se encontraron productos con ese criterio." : "Comienza agregando tu primer producto."}
             action={!searchTerm ? (
               <Link

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { Search as SearchIcon, Users, ChevronRight, Loader2 } from "lucide-react";
+import { Search as SearchIcon, Users, ChevronRight, Loader2, SearchX } from "lucide-react";
 import { format, parseISO } from 'date-fns';
 import { es } from 'date-fns/locale';
 import Empty from '../components/Empty';
@@ -78,6 +78,7 @@ export const SearchPage: React.FC = () => {
   if (!query) {
     return (
       <Empty
+        icon={SearchIcon}
         title="Busca en toda tu operación"
         description="Escribe un término en la barra superior para encontrar clientes, eventos, productos e inventario."
       />
@@ -105,6 +106,7 @@ export const SearchPage: React.FC = () => {
   if (!totalResults) {
     return (
       <Empty
+        icon={SearchX}
         title="Sin resultados"
         description={`No encontramos coincidencias para "${query}".`}
       />


### PR DESCRIPTION
Replace the generic glass cube PNG with context-specific Lucide icons in a branded orange container with decorative rings and animated dots.

Each page now shows a relevant icon: Users for clients, UtensilsCrossed for products, Package for inventory, CalendarDays for events, and Search/SearchX for the search page.

https://claude.ai/code/session_01EmmNfGpXfCAWj3Qk9LsSAm