### PR TITLE
feat(inventory): split inventory list into separate consumables and e…

### DIFF
--- a/mobile/src/screens/catalog/InventoryListScreen.tsx
+++ b/mobile/src/screens/catalog/InventoryListScreen.tsx
@@ -4,7 +4,7 @@ import {
   View,
   Text,
   StyleSheet,
-  FlatList,
+  SectionList,
   TouchableOpacity,
   TextInput,
   RefreshControl,
@@ -17,14 +17,15 @@ import {
   Plus,
   AlertTriangle,
   Package,
-  Edit2,
+  ShoppingCart,
+  Wrench,
 } from "lucide-react-native";
 import { InventoryStackParamList } from "../../types/navigation";
 import { InventoryItem } from "../../types/entities";
 import { inventoryService } from "../../services/inventoryService";
 import { useToast } from "../../hooks/useToast";
 import { logError } from "../../lib/errorHandler";
-import { EmptyState, SkeletonList, SwipeableRow, SegmentedControl, SortSelector } from "../../components/shared";
+import { EmptyState, SkeletonList, SwipeableRow, SortSelector } from "../../components/shared";
 import { useTheme } from "../../hooks/useTheme";
 import { colors } from "../../theme/colors";
 import { spacing } from "../../theme/spacing";
@@ -33,6 +34,12 @@ import { shadows } from "../../theme/shadows";
 
 type Props = NativeStackScreenProps<InventoryStackParamList, "InventoryList">;
 
+interface InventorySection {
+  title: string;
+  type: "ingredient" | "equipment";
+  data: InventoryItem[];
+}
+
 export default function InventoryListScreen({ navigation }: Props) {
   const addToast = useToast((s) => s.addToast);
   const { isDark } = useTheme();
@@ -40,13 +47,10 @@ export default function InventoryListScreen({ navigation }: Props) {
   const styles = getStyles(palette);
 
   const [items, setItems] = useState<InventoryItem[]>([]);
-  const [filteredItems, setFilteredItems] = useState<InventoryItem[]>([]);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [showLowStockOnly, setShowLowStockOnly] = useState(false);
-  const [typeFilterIndex, setTypeFilterIndex] = useState(0);
-  const typeSegments = ["Todos", "Ingredientes", "Equipo"];
   const [sortKey, setSortKey] = useState("ingredient_name");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
@@ -55,7 +59,6 @@ export default function InventoryListScreen({ navigation }: Props) {
     { key: "current_stock", label: "Stock actual" },
     { key: "minimum_stock", label: "Stock mínimo" },
     { key: "unit_cost", label: "Costo unitario" },
-    { key: "type", label: "Tipo" },
   ], []);
 
   const loadItems = useCallback(async () => {
@@ -77,17 +80,11 @@ export default function InventoryListScreen({ navigation }: Props) {
     }, [loadItems]),
   );
 
-  useEffect(() => {
+  const sortedSections = useMemo(() => {
     let filtered = items;
 
     if (showLowStockOnly) {
       filtered = filtered.filter(item => item.current_stock <= item.minimum_stock);
-    }
-
-    if (typeFilterIndex === 1) {
-      filtered = filtered.filter(item => item.type === 'ingredient');
-    } else if (typeFilterIndex === 2) {
-      filtered = filtered.filter(item => item.type === 'equipment');
     }
 
     if (search.trim()) {
@@ -111,9 +108,6 @@ export default function InventoryListScreen({ navigation }: Props) {
         case "unit_cost":
           cmp = (a.unit_cost ?? 0) - (b.unit_cost ?? 0);
           break;
-        case "type":
-          cmp = a.type.localeCompare(b.type);
-          break;
         case "ingredient_name":
         default:
           cmp = a.ingredient_name.localeCompare(b.ingredient_name);
@@ -122,8 +116,21 @@ export default function InventoryListScreen({ navigation }: Props) {
       return sortOrder === "asc" ? cmp : -cmp;
     });
 
-    setFilteredItems(sorted);
-  }, [search, items, showLowStockOnly, typeFilterIndex, sortKey, sortOrder]);
+    const ingredientItems = sorted.filter(item => item.type === "ingredient");
+    const equipmentItems = sorted.filter(item => item.type === "equipment");
+
+    const sections: InventorySection[] = [];
+    if (ingredientItems.length > 0) {
+      sections.push({ title: "Consumibles", type: "ingredient", data: ingredientItems });
+    }
+    if (equipmentItems.length > 0) {
+      sections.push({ title: "Equipos", type: "equipment", data: equipmentItems });
+    }
+
+    return sections;
+  }, [search, items, showLowStockOnly, sortKey, sortOrder]);
+
+  const totalFilteredItems = sortedSections.reduce((sum, s) => sum + s.data.length, 0);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -159,13 +166,7 @@ export default function InventoryListScreen({ navigation }: Props) {
             <Text style={styles.cardName} numberOfLines={1}>
               {item.ingredient_name}
             </Text>
-            <View style={styles.cardRow}>
-              <View style={[styles.typeBadge, item.type === 'equipment' && styles.typeBadgeEquip]}>
-                <Text style={styles.typeText}>
-                  {item.type === 'equipment' ? 'Equipo' : 'Ingrediente'}
-                </Text>
-              </View>
-            </View>
+            <Text style={styles.cardUnit}>{item.unit}</Text>
           </View>
           <View style={styles.stockInfo}>
             <Text style={[styles.stockValue, isLowStock && styles.stockValueLow]}>
@@ -183,7 +184,29 @@ export default function InventoryListScreen({ navigation }: Props) {
         </Animated.View>
       );
     },
-    [navigation],
+    [navigation, palette, styles],
+  );
+
+  const renderSectionHeader = useCallback(
+    ({ section }: { section: InventorySection }) => {
+      const isEquipment = section.type === "equipment";
+      const Icon = isEquipment ? Wrench : ShoppingCart;
+      const iconColor = isEquipment ? palette.info : palette.primary;
+      const bgColor = isEquipment ? palette.infoBg : palette.primaryLight;
+
+      return (
+        <View style={styles.sectionHeader}>
+          <View style={[styles.sectionIconBox, { backgroundColor: bgColor }]}>
+            <Icon color={iconColor} size={16} />
+          </View>
+          <Text style={styles.sectionTitle}>{section.title}</Text>
+          <View style={styles.sectionCountBadge}>
+            <Text style={styles.sectionCountText}>{section.data.length}</Text>
+          </View>
+        </View>
+      );
+    },
+    [palette, styles],
   );
 
   if (loading && items.length === 0) {
@@ -218,14 +241,6 @@ export default function InventoryListScreen({ navigation }: Props) {
         </View>
       </View>
 
-      <View style={styles.segmentContainer}>
-        <SegmentedControl
-          segments={typeSegments}
-          selectedIndex={typeFilterIndex}
-          onChange={setTypeFilterIndex}
-        />
-      </View>
-
       {lowStockCount > 0 && (
         <TouchableOpacity
           style={styles.alertBanner}
@@ -243,15 +258,17 @@ export default function InventoryListScreen({ navigation }: Props) {
         </TouchableOpacity>
       )}
 
-      <FlatList
-        data={filteredItems}
+      <SectionList
+        sections={sortedSections}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
         contentContainerStyle={
-          filteredItems.length === 0
+          totalFilteredItems === 0
             ? styles.emptyContent
             : styles.listContent
         }
+        stickySectionHeadersEnabled={false}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
@@ -314,10 +331,6 @@ const getStyles = (palette: typeof colors.light) => StyleSheet.create({
     color: palette.text,
     padding: 0,
   },
-  segmentContainer: {
-    paddingHorizontal: spacing.lg,
-    paddingBottom: spacing.sm,
-  },
   alertBanner: {
     flexDirection: "row",
     alignItems: "center",
@@ -348,6 +361,37 @@ const getStyles = (palette: typeof colors.light) => StyleSheet.create({
     flex: 1,
     paddingHorizontal: spacing.lg,
   },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: spacing.md,
+    paddingTop: spacing.lg,
+    gap: spacing.sm,
+  },
+  sectionIconBox: {
+    width: 28,
+    height: 28,
+    borderRadius: spacing.borderRadius.md,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  sectionTitle: {
+    ...typography.subheadline,
+    fontWeight: "700",
+    color: palette.text,
+    flex: 1,
+  },
+  sectionCountBadge: {
+    backgroundColor: palette.surface,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: spacing.borderRadius.sm,
+  },
+  sectionCountText: {
+    ...typography.caption,
+    color: palette.textSecondary,
+    fontWeight: "600",
+  },
   card: {
     flexDirection: "row",
     alignItems: "center",
@@ -374,34 +418,16 @@ const getStyles = (palette: typeof colors.light) => StyleSheet.create({
   },
   cardBody: {
     flex: 1,
-    gap: 3,
+    gap: 2,
   },
   cardName: {
     ...typography.subheadline,
     fontWeight: "500",
     color: palette.text,
   },
-  cardRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.xs,
-  },
-  typeBadge: {
-    backgroundColor: palette.surface,
-    paddingHorizontal: spacing.xs + 2,
-    paddingVertical: 1,
-    borderRadius: spacing.borderRadius.sm,
-  },
-  typeBadgeEquip: {
-    backgroundColor: palette.infoBg,
-  },
-  typeText: {
+  cardUnit: {
     ...typography.caption,
     color: palette.textSecondary,
-    fontWeight: "600",
-    textTransform: "uppercase",
-    fontSize: 9,
-    letterSpacing: 0.3,
   },
   stockInfo: {
     alignItems: "flex-end",

--- a/web/src/pages/Inventory/InventoryList.test.tsx
+++ b/web/src/pages/Inventory/InventoryList.test.tsx
@@ -58,6 +58,25 @@ describe('InventoryList', () => {
     vi.clearAllMocks();
   });
 
+  it('renders items separated into two sections', async () => {
+    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+
+    renderList();
+
+    await waitFor(() => {
+      expect(screen.getByText('Harina')).toBeInTheDocument();
+    });
+
+    // Verify section headers
+    expect(screen.getByText('Consumibles')).toBeInTheDocument();
+    expect(screen.getByText('Equipos')).toBeInTheDocument();
+
+    // Verify items exist
+    expect(screen.getByText('Harina')).toBeInTheDocument();
+    expect(screen.getByText('Azucar')).toBeInTheDocument();
+    expect(screen.getByText('Horno')).toBeInTheDocument();
+  });
+
   it('renders items and low stock warning', async () => {
     (inventoryService.getAll as any).mockResolvedValue([
       {
@@ -106,7 +125,7 @@ describe('InventoryList', () => {
       expect(screen.getByText('Azucar')).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Buscar ingrediente...'), {
+    fireEvent.change(screen.getByPlaceholderText('Buscar en inventario...'), {
       target: { value: 'Harina' },
     });
 
@@ -152,10 +171,10 @@ describe('InventoryList', () => {
     await waitFor(() => {
       expect(logError).toHaveBeenCalledWith('Error fetching inventory', expect.any(Error));
     });
-    expect(screen.getByText(/No se encontraron ingredientes/i)).toBeInTheDocument();
+    expect(screen.getByText(/No se encontraron ítems/i)).toBeInTheDocument();
   });
 
-  it('shows equipment badge and delete error handling', async () => {
+  it('shows equipment section and delete error handling', async () => {
     (inventoryService.getAll as any).mockResolvedValue([
       {
         id: '1',
@@ -175,7 +194,7 @@ describe('InventoryList', () => {
       expect(screen.getByText('Horno')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Equipo')).toBeInTheDocument();
+    expect(screen.getByText('Equipos')).toBeInTheDocument();
     expect(screen.getByText('$0.00')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Eliminar Horno/i }));
@@ -214,7 +233,7 @@ describe('InventoryList', () => {
     expect(screen.queryByRole('dialog', { name: 'Eliminar ingrediente' })).not.toBeInTheDocument();
   });
 
-  it('renders ingredient badge and unit label', async () => {
+  it('renders consumibles section with unit label', async () => {
     (inventoryService.getAll as any).mockResolvedValue([
       {
         id: '1',
@@ -233,14 +252,33 @@ describe('InventoryList', () => {
       expect(screen.getByText('Harina')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Ingrediente')).toBeInTheDocument();
+    expect(screen.getByText('Consumibles')).toBeInTheDocument();
     expect(screen.getByText(/Unidad: kg/i)).toBeInTheDocument();
   });
 
-  // ---------- NEW TESTS FOR COVERAGE: sorting columns ----------
+  // ---------- sorting tests ----------
 
-  it('sorts by minimum_stock column when header is clicked', async () => {
-    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+  it('sorts consumibles section by minimum_stock column', async () => {
+    (inventoryService.getAll as any).mockResolvedValue([
+      {
+        id: '1',
+        ingredient_name: 'Harina',
+        unit: 'kg',
+        type: 'ingredient',
+        current_stock: 10,
+        minimum_stock: 5,
+        unit_cost: 10,
+      },
+      {
+        id: '2',
+        ingredient_name: 'Azucar',
+        unit: 'kg',
+        type: 'ingredient',
+        current_stock: 2,
+        minimum_stock: 3,
+        unit_cost: 8,
+      },
+    ]);
 
     renderList();
 
@@ -248,21 +286,28 @@ describe('InventoryList', () => {
       expect(screen.getByText('Harina')).toBeInTheDocument();
     });
 
-    // Click "Stock Minimo" column header to sort ascending
     const minStockHeader = screen.getByText('Stock Mínimo');
     fireEvent.click(minStockHeader);
 
-    // Verify that the aria-sort attribute changes
     const minStockTh = minStockHeader.closest('th');
     expect(minStockTh).toHaveAttribute('aria-sort', 'ascending');
 
-    // Click again to sort descending
     fireEvent.click(minStockHeader);
     expect(minStockTh).toHaveAttribute('aria-sort', 'descending');
   });
 
   it('sorts by unit_cost column when header is clicked', async () => {
-    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+    (inventoryService.getAll as any).mockResolvedValue([
+      {
+        id: '1',
+        ingredient_name: 'Harina',
+        unit: 'kg',
+        type: 'ingredient',
+        current_stock: 10,
+        minimum_stock: 1,
+        unit_cost: 10,
+      },
+    ]);
 
     renderList();
 
@@ -270,36 +315,28 @@ describe('InventoryList', () => {
       expect(screen.getByText('Harina')).toBeInTheDocument();
     });
 
-    // Click "Costo Unitario" column header to sort ascending
     const unitCostHeader = screen.getByText('Costo Unitario');
     fireEvent.click(unitCostHeader);
 
     const unitCostTh = unitCostHeader.closest('th');
     expect(unitCostTh).toHaveAttribute('aria-sort', 'ascending');
 
-    // Click again to toggle to descending
     fireEvent.click(unitCostHeader);
     expect(unitCostTh).toHaveAttribute('aria-sort', 'descending');
   });
 
-  it('sorts by type column when header is clicked', async () => {
-    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
-
-    renderList();
-
-    await waitFor(() => {
-      expect(screen.getByText('Harina')).toBeInTheDocument();
-    });
-
-    const typeHeader = screen.getByText('Tipo');
-    fireEvent.click(typeHeader);
-
-    const typeTh = typeHeader.closest('th');
-    expect(typeTh).toHaveAttribute('aria-sort', 'ascending');
-  });
-
   it('sorts by current_stock column when header is clicked', async () => {
-    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+    (inventoryService.getAll as any).mockResolvedValue([
+      {
+        id: '1',
+        ingredient_name: 'Harina',
+        unit: 'kg',
+        type: 'ingredient',
+        current_stock: 10,
+        minimum_stock: 1,
+        unit_cost: 10,
+      },
+    ]);
 
     renderList();
 
@@ -315,7 +352,17 @@ describe('InventoryList', () => {
   });
 
   it('sorts by ingredient_name and toggles sort order', async () => {
-    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+    (inventoryService.getAll as any).mockResolvedValue([
+      {
+        id: '1',
+        ingredient_name: 'Harina',
+        unit: 'kg',
+        type: 'ingredient',
+        current_stock: 10,
+        minimum_stock: 1,
+        unit_cost: 10,
+      },
+    ]);
 
     renderList();
 
@@ -323,32 +370,35 @@ describe('InventoryList', () => {
       expect(screen.getByText('Harina')).toBeInTheDocument();
     });
 
-    // ingredient_name is the initial sort key, so it should already be ascending
     const nameHeader = screen.getByText('Ítem');
     const nameTh = nameHeader.closest('th');
     expect(nameTh).toHaveAttribute('aria-sort', 'ascending');
 
-    // Click to toggle to descending
     fireEvent.click(nameHeader);
     expect(nameTh).toHaveAttribute('aria-sort', 'descending');
 
-    // Click again to toggle back to ascending
     fireEvent.click(nameHeader);
     expect(nameTh).toHaveAttribute('aria-sort', 'ascending');
   });
 
   it('shows "none" aria-sort on columns that are not currently sorted', async () => {
-    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+    (inventoryService.getAll as any).mockResolvedValue([
+      {
+        id: '1',
+        ingredient_name: 'Harina',
+        unit: 'kg',
+        type: 'ingredient',
+        current_stock: 10,
+        minimum_stock: 1,
+        unit_cost: 10,
+      },
+    ]);
 
     renderList();
 
     await waitFor(() => {
       expect(screen.getByText('Harina')).toBeInTheDocument();
     });
-
-    // Default sort is ingredient_name, so other columns should be "none"
-    const typeHeader = screen.getByText('Tipo');
-    expect(typeHeader.closest('th')).toHaveAttribute('aria-sort', 'none');
 
     const minStockHeader = screen.getByText('Stock Mínimo');
     expect(minStockHeader.closest('th')).toHaveAttribute('aria-sort', 'none');
@@ -384,11 +434,11 @@ describe('InventoryList', () => {
       expect(screen.getByText('Harina')).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Buscar ingrediente...'), {
+    fireEvent.change(screen.getByPlaceholderText('Buscar en inventario...'), {
       target: { value: 'ZZZ no existe' },
     });
 
-    expect(screen.getByText(/No se encontraron ingredientes/i)).toBeInTheDocument();
+    expect(screen.getByText(/No se encontraron ítems/i)).toBeInTheDocument();
     expect(screen.getByText(/Intenta ajustar los términos de búsqueda/i)).toBeInTheDocument();
   });
 
@@ -398,12 +448,11 @@ describe('InventoryList', () => {
     renderList();
 
     await waitFor(() => {
-      expect(screen.getByText(/No se encontraron ingredientes/i)).toBeInTheDocument();
+      expect(screen.getByText(/No se encontraron ítems/i)).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/Comienza agregando tu primer ingrediente/i)).toBeInTheDocument();
-    // The empty state should have the "Agregar Ingrediente" link
-    expect(screen.getByText('Agregar Ingrediente')).toBeInTheDocument();
+    expect(screen.getByText(/Comienza agregando tu primer ítem/i)).toBeInTheDocument();
+    expect(screen.getByText('Agregar Ítem')).toBeInTheDocument();
   });
 
   it('does not show low stock warning when all items have sufficient stock', async () => {
@@ -487,11 +536,9 @@ describe('InventoryList', () => {
       expect(screen.getByText('Sal')).toBeInTheDocument();
     });
 
-    // Check "Nuevo Ingrediente" link
-    const newLink = screen.getByRole('link', { name: /Nuevo Ingrediente/i });
+    const newLink = screen.getByRole('link', { name: /Nuevo Ítem/i });
     expect(newLink).toHaveAttribute('href', '/inventory/new');
 
-    // Check edit link
     const editLink = screen.getByRole('link', { name: /Editar Sal/i });
     expect(editLink).toHaveAttribute('href', '/inventory/inv-42/edit');
   });
@@ -524,7 +571,55 @@ describe('InventoryList', () => {
     renderList();
 
     await waitFor(() => {
-      expect(screen.getByText(/No se encontraron ingredientes/i)).toBeInTheDocument();
+      expect(screen.getByText(/No se encontraron ítems/i)).toBeInTheDocument();
     });
+  });
+
+  it('shows empty section message when only one type exists', async () => {
+    (inventoryService.getAll as any).mockResolvedValue([
+      {
+        id: '1',
+        ingredient_name: 'Horno',
+        unit: 'pieza',
+        type: 'equipment',
+        current_stock: 3,
+        minimum_stock: 1,
+        unit_cost: 5000,
+      },
+    ]);
+
+    renderList();
+
+    await waitFor(() => {
+      expect(screen.getByText('Horno')).toBeInTheDocument();
+    });
+
+    // Equipment section should be visible
+    expect(screen.getByText('Equipos')).toBeInTheDocument();
+    // Consumibles section should show empty message
+    expect(screen.getByText(/No hay ingredientes/i)).toBeInTheDocument();
+  });
+
+  it('sorts equipment section independently from consumibles', async () => {
+    (inventoryService.getAll as any).mockResolvedValue(sampleItems);
+
+    renderList();
+
+    await waitFor(() => {
+      expect(screen.getByText('Harina')).toBeInTheDocument();
+    });
+
+    // There should be two tables — get all Stock Actual headers
+    const stockHeaders = screen.getAllByText('Stock Actual');
+    expect(stockHeaders.length).toBe(2);
+
+    // Click the equipment section's Stock Actual header (second one)
+    fireEvent.click(stockHeaders[1]);
+    const equipTh = stockHeaders[1].closest('th');
+    expect(equipTh).toHaveAttribute('aria-sort', 'ascending');
+
+    // The consumibles section's header should still be "none"
+    const ingredientTh = stockHeaders[0].closest('th');
+    expect(ingredientTh).toHaveAttribute('aria-sort', 'none');
   });
 });

--- a/web/src/pages/Inventory/InventoryList.tsx
+++ b/web/src/pages/Inventory/InventoryList.tsx
@@ -2,17 +2,41 @@ import React, { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { inventoryService } from "../../services/inventoryService";
 import { InventoryItem } from "../../types/entities";
-import { Plus, Search, Edit, Trash2, AlertTriangle, Download, Package } from "lucide-react";
+import { Plus, Search, Edit, Trash2, AlertTriangle, Download, Package, Wrench, ShoppingBasket } from "lucide-react";
 import { exportToCsv } from "../../lib/exportCsv";
 import clsx from "clsx";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { logError } from "../../lib/errorHandler";
 import Empty from "../../components/Empty";
 import { useToast } from "../../hooks/useToast";
-import { usePagination } from "../../hooks/usePagination";
-import { Pagination } from "../../components/Pagination";
 import { ArrowUp, ArrowDown } from "lucide-react";
 import { SkeletonTable } from "../../components/Skeleton";
+
+type SortKey = "ingredient_name" | "current_stock" | "minimum_stock" | "unit_cost";
+type SortOrder = "asc" | "desc";
+
+function sortItems(items: InventoryItem[], key: SortKey, order: SortOrder): InventoryItem[] {
+  const sorted = [...items].sort((a, b) => {
+    let cmp = 0;
+    switch (key) {
+      case "current_stock":
+        cmp = a.current_stock - b.current_stock;
+        break;
+      case "minimum_stock":
+        cmp = a.minimum_stock - b.minimum_stock;
+        break;
+      case "unit_cost":
+        cmp = (a.unit_cost ?? 0) - (b.unit_cost ?? 0);
+        break;
+      case "ingredient_name":
+      default:
+        cmp = a.ingredient_name.localeCompare(b.ingredient_name);
+        break;
+    }
+    return order === "asc" ? cmp : -cmp;
+  });
+  return sorted;
+}
 
 export const InventoryList: React.FC = () => {
   const navigate = useNavigate();
@@ -24,6 +48,9 @@ export const InventoryList: React.FC = () => {
   const [adjustingItem, setAdjustingItem] = useState<InventoryItem | null>(null);
   const [adjustmentValue, setAdjustmentValue] = useState<string>("");
   const { addToast } = useToast();
+
+  const [ingredientSort, setIngredientSort] = useState<{ key: SortKey; order: SortOrder }>({ key: "ingredient_name", order: "asc" });
+  const [equipmentSort, setEquipmentSort] = useState<{ key: SortKey; order: SortOrder }>({ key: "ingredient_name", order: "asc" });
 
   useEffect(() => {
     fetchInventory();
@@ -67,7 +94,7 @@ export const InventoryList: React.FC = () => {
 
   const handleAdjustStock = async () => {
     if (!adjustingItem || !adjustmentValue) return;
-    
+
     const change = parseFloat(adjustmentValue);
     if (isNaN(change)) {
       addToast("Por favor ingresa un número válido.", "error");
@@ -79,11 +106,11 @@ export const InventoryList: React.FC = () => {
       await inventoryService.update(adjustingItem.id, {
         current_stock: newStock
       });
-      
-      setItems(prev => prev.map(item => 
+
+      setItems(prev => prev.map(item =>
         item.id === adjustingItem.id ? { ...item, current_stock: newStock } : item
       ));
-      
+
       addToast(`Stock de ${adjustingItem.ingredient_name} actualizado.`, "success");
       setAdjustingItem(null);
       setAdjustmentValue("");
@@ -97,25 +124,34 @@ export const InventoryList: React.FC = () => {
     item.ingredient_name.toLowerCase().includes(searchTerm.toLowerCase()),
   );
 
-  const {
-    currentData: paginatedItems,
-    currentPage,
-    totalPages,
-    totalItems,
-    handlePageChange,
-    handleSort,
-    sortKey,
-    sortOrder,
-  } = usePagination({
-    data: filteredItems,
-    itemsPerPage: 10,
-    initialSortKey: "ingredient_name",
-    initialSortOrder: "asc",
-  });
+  const ingredients = sortItems(
+    filteredItems.filter((item) => item.type === "ingredient"),
+    ingredientSort.key,
+    ingredientSort.order,
+  );
+  const equipment = sortItems(
+    filteredItems.filter((item) => item.type === "equipment"),
+    equipmentSort.key,
+    equipmentSort.order,
+  );
 
-  const renderSortIcon = (key: keyof InventoryItem) => {
-    if (sortKey !== key) return null;
-    return sortOrder === "asc" ? (
+  const handleIngredientSort = (key: SortKey) => {
+    setIngredientSort(prev => ({
+      key,
+      order: prev.key === key && prev.order === "asc" ? "desc" : "asc",
+    }));
+  };
+
+  const handleEquipmentSort = (key: SortKey) => {
+    setEquipmentSort(prev => ({
+      key,
+      order: prev.key === key && prev.order === "asc" ? "desc" : "asc",
+    }));
+  };
+
+  const renderSortIcon = (key: SortKey, sort: { key: SortKey; order: SortOrder }) => {
+    if (sort.key !== key) return null;
+    return sort.order === "asc" ? (
       <ArrowUp className="inline h-3 w-3 ml-1" aria-hidden="true" />
     ) : (
       <ArrowDown className="inline h-3 w-3 ml-1" aria-hidden="true" />
@@ -123,11 +159,145 @@ export const InventoryList: React.FC = () => {
   };
 
   const getSortAriaSort = (
-    key: keyof InventoryItem,
+    key: SortKey,
+    sort: { key: SortKey; order: SortOrder },
   ): "ascending" | "descending" | "none" => {
-    if (sortKey !== key) return "none";
-    return sortOrder === "asc" ? "ascending" : "descending";
+    if (sort.key !== key) return "none";
+    return sort.order === "asc" ? "ascending" : "descending";
   };
+
+  const renderTable = (
+    sectionItems: InventoryItem[],
+    sort: { key: SortKey; order: SortOrder },
+    onSort: (key: SortKey) => void,
+  ) => (
+    <div className="overflow-x-auto">
+      <table
+        className="min-w-full divide-y divide-border"
+        aria-label="Tabla de inventario"
+      >
+        <thead className="bg-surface-alt">
+          <tr>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
+              onClick={() => onSort("ingredient_name")}
+              aria-sort={getSortAriaSort("ingredient_name", sort)}
+            >
+              Ítem {renderSortIcon("ingredient_name", sort)}
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
+              onClick={() => onSort("current_stock")}
+              aria-sort={getSortAriaSort("current_stock", sort)}
+            >
+              Stock Actual {renderSortIcon("current_stock", sort)}
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
+              onClick={() => onSort("minimum_stock")}
+              aria-sort={getSortAriaSort("minimum_stock", sort)}
+            >
+              Stock Mínimo {renderSortIcon("minimum_stock", sort)}
+            </th>
+            <th
+              scope="col"
+              className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
+              onClick={() => onSort("unit_cost")}
+              aria-sort={getSortAriaSort("unit_cost", sort)}
+            >
+              Costo Unitario {renderSortIcon("unit_cost", sort)}
+            </th>
+            <th scope="col" className="relative px-6 py-3 text-text-secondary">
+              <span className="sr-only">Acciones</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-card divide-y divide-border">
+          {sectionItems.map((item) => {
+            const isLowStock = item.current_stock <= item.minimum_stock;
+            return (
+              <tr
+                key={item.id}
+                className="hover:bg-surface-alt/50 transition-colors cursor-pointer"
+                onClick={() => navigate(`/inventory/${item.id}`)}
+              >
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-text">
+                    {item.ingredient_name}
+                  </div>
+                  <div className="text-sm text-text-secondary">
+                    Unidad: {item.unit}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="flex items-center">
+                    <span
+                      className={clsx(
+                        "text-sm font-medium",
+                        isLowStock
+                          ? "text-red-600 dark:text-red-400 font-bold"
+                          : "text-text",
+                      )}
+                    >
+                      {item.current_stock}
+                    </span>
+                    {isLowStock && (
+                      <AlertTriangle
+                        className="h-4 w-4 text-red-500 ml-2"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
+                  {item.minimum_stock}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
+                  ${item.unit_cost?.toFixed(2) || "0.00"}
+                </td>
+                <td
+                  className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="flex justify-end space-x-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setAdjustingItem(item);
+                        setAdjustmentValue("");
+                      }}
+                      className="text-brand-orange hover:bg-brand-orange/10 p-1.5 rounded-lg transition-colors mr-1"
+                      title="Ajustar Stock"
+                    >
+                      <Plus className="h-4 w-4" />
+                    </button>
+                    <Link
+                      to={`/inventory/${item.id}/edit`}
+                      className="p-1.5 text-text-secondary hover:text-brand-orange hover:bg-surface-alt rounded-lg transition-colors inline-block"
+                      aria-label={`Editar ${item.ingredient_name}`}
+                    >
+                      <Edit className="h-5 w-5" aria-hidden="true" />
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => requestDelete(item.id)}
+                      className="p-1.5 text-text-secondary hover:text-error hover:bg-error/10 rounded-lg transition-colors inline-block"
+                      aria-label={`Eliminar ${item.ingredient_name}`}
+                    >
+                      <Trash2 className="h-5 w-5" aria-hidden="true" />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
 
   return (
     <div className="space-y-6">
@@ -175,7 +345,7 @@ export const InventoryList: React.FC = () => {
             className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-xl text-white bg-brand-orange hover:bg-orange-600 shadow-xs transition-colors"
           >
             <Plus className="h-5 w-5 mr-2" aria-hidden="true" />
-            Nuevo Ingrediente
+            Nuevo Ítem
           </Link>
         </div>
       </div>
@@ -209,7 +379,7 @@ export const InventoryList: React.FC = () => {
 
       <div className="relative max-w-md">
         <label htmlFor="inventory-search" className="sr-only">
-          Buscar ingredientes
+          Buscar en inventario
         </label>
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <Search className="h-5 w-5 text-text-secondary" aria-hidden="true" />
@@ -218,34 +388,35 @@ export const InventoryList: React.FC = () => {
           id="inventory-search"
           type="search"
           className="block w-full pl-10 pr-3 py-2 border border-border rounded-xl leading-5 bg-card text-text placeholder-text-secondary focus:outline-hidden focus:ring-brand-orange focus:border-brand-orange sm:text-sm transition duration-150 ease-in-out"
-          placeholder="Buscar ingrediente..."
+          placeholder="Buscar en inventario..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
-          aria-label="Buscar ingredientes por nombre"
+          aria-label="Buscar ítems por nombre"
         />
       </div>
 
-      <div className="bg-card shadow-sm overflow-hidden rounded-3xl border border-border">
-        {loading ? (
+      {loading ? (
+        <div className="bg-card shadow-sm overflow-hidden rounded-3xl border border-border">
           <SkeletonTable
             rows={6}
             columns={[
               { width: "w-40" },
-              { width: "w-24", badge: true },
               { width: "w-20" },
               { width: "w-20" },
               { width: "w-24" },
               { width: "w-20" },
             ]}
           />
-        ) : filteredItems.length === 0 ? (
+        </div>
+      ) : filteredItems.length === 0 ? (
+        <div className="bg-card shadow-sm overflow-hidden rounded-3xl border border-border">
           <Empty
             icon={Package}
-            title="No se encontraron ingredientes"
+            title="No se encontraron ítems"
             description={
               searchTerm
                 ? "Intenta ajustar los términos de búsqueda."
-                : "Comienza agregando tu primer ingrediente al inventario."
+                : "Comienza agregando tu primer ítem al inventario."
             }
             action={
               !searchTerm ? (
@@ -254,175 +425,65 @@ export const InventoryList: React.FC = () => {
                   className="inline-flex items-center justify-center px-4 py-2 border border-transparent text-sm font-medium rounded-xl text-white bg-brand-orange hover:bg-orange-600 shadow-xs"
                 >
                   <Plus className="h-5 w-5 mr-2" aria-hidden="true" />
-                  Agregar Ingrediente
+                  Agregar Ítem
                 </Link>
               ) : undefined
             }
           />
-        ) : (
-          <div className="overflow-x-auto">
-            <table
-              className="min-w-full divide-y divide-border"
-              aria-label="Tabla de inventario"
-            >
-              <caption className="sr-only">
-                Lista de inventario con {totalItems} resultados. Mostrando
-                página {currentPage} de {totalPages}.
-              </caption>
-              <thead className="bg-surface-alt">
-                <tr>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
-                    onClick={() => handleSort("ingredient_name")}
-                    aria-sort={getSortAriaSort("ingredient_name")}
-                  >
-                    Ítem {renderSortIcon("ingredient_name")}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
-                    onClick={() => handleSort("type")}
-                    aria-sort={getSortAriaSort("type")}
-                  >
-                    Tipo {renderSortIcon("type")}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
-                    onClick={() => handleSort("current_stock")}
-                    aria-sort={getSortAriaSort("current_stock")}
-                  >
-                    Stock Actual {renderSortIcon("current_stock")}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
-                    onClick={() => handleSort("minimum_stock")}
-                    aria-sort={getSortAriaSort("minimum_stock")}
-                  >
-                    Stock Mínimo {renderSortIcon("minimum_stock")}
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-text-secondary uppercase tracking-wider cursor-pointer hover:bg-surface-alt/50 transition-colors"
-                    onClick={() => handleSort("unit_cost")}
-                    aria-sort={getSortAriaSort("unit_cost")}
-                  >
-                    Costo Unitario {renderSortIcon("unit_cost")}
-                  </th>
-                  <th scope="col" className="relative px-6 py-3 text-text-secondary">
-                    <span className="sr-only">Acciones</span>
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-card divide-y divide-border">
-                {paginatedItems.map((item) => {
-                  const isLowStock = item.current_stock <= item.minimum_stock;
-                  return (
-                    <tr
-                      key={item.id}
-                      className="hover:bg-surface-alt/50 transition-colors cursor-pointer"
-                      onClick={() => navigate(`/inventory/${item.id}`)}
-                    >
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm font-medium text-text">
-                          {item.ingredient_name}
-                        </div>
-                        <div className="text-sm text-text-secondary">
-                          Unidad: {item.unit}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span
-                          className={clsx(
-                            "px-2.5 py-0.5 inline-flex text-xs font-semibold rounded-full border",
-                            item.type === "equipment"
-                              ? "bg-purple-500/10 text-purple-500 border-purple-500/20"
-                              : "bg-brand-orange/10 text-brand-orange border-brand-orange/20",
-                          )}
-                        >
-                          {item.type === "equipment" ? "Equipo" : "Ingrediente"}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="flex items-center">
-                          <span
-                            className={clsx(
-                              "text-sm font-medium",
-                              isLowStock
-                                ? "text-red-600 dark:text-red-400 font-bold"
-                                : "text-text",
-                            )}
-                          >
-                            {item.current_stock}
-                          </span>
-                          {isLowStock && (
-                            <AlertTriangle
-                              className="h-4 w-4 text-red-500 ml-2"
-                              aria-hidden="true"
-                            />
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
-                        {item.minimum_stock}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
-                        ${item.unit_cost?.toFixed(2) || "0.00"}
-                      </td>
-                      <td 
-                        className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <div className="flex justify-end space-x-2">
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setAdjustingItem(item);
-                              setAdjustmentValue("");
-                            }}
-                            className="text-brand-orange hover:bg-brand-orange/10 p-1.5 rounded-lg transition-colors mr-1"
-                            title="Ajustar Stock"
-                          >
-                            <Plus className="h-4 w-4" />
-                          </button>
-                          <Link
-                            to={`/inventory/${item.id}/edit`}
-                            className="p-1.5 text-text-secondary hover:text-brand-orange hover:bg-surface-alt rounded-lg transition-colors inline-block"
-                            aria-label={`Editar ${item.ingredient_name}`}
-                          >
-                            <Edit className="h-5 w-5" aria-hidden="true" />
-                          </Link>
-                          <button
-                            type="button"
-                            onClick={() => requestDelete(item.id)}
-                            className="p-1.5 text-text-secondary hover:text-error hover:bg-error/10 rounded-lg transition-colors inline-block"
-                            aria-label={`Eliminar ${item.ingredient_name}`}
-                          >
-                            <Trash2 className="h-5 w-5" aria-hidden="true" />
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        )}
-        {!loading && filteredItems.length > 0 && (
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            itemsPerPage={10}
-            onPageChange={handlePageChange}
-          />
-        )}
-      </div>
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {/* Consumibles / Ingredientes Section */}
+          <section>
+            <div className="flex items-center gap-3 mb-3">
+              <div className="flex items-center justify-center w-9 h-9 rounded-xl bg-brand-orange/10">
+                <ShoppingBasket className="h-5 w-5 text-brand-orange" aria-hidden="true" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-text">Consumibles</h2>
+                <p className="text-xs text-text-secondary">
+                  {ingredients.length} {ingredients.length === 1 ? "ingrediente" : "ingredientes"}
+                </p>
+              </div>
+            </div>
+            <div className="bg-card shadow-sm overflow-hidden rounded-3xl border border-border">
+              {ingredients.length === 0 ? (
+                <div className="px-6 py-8 text-center text-sm text-text-secondary">
+                  No hay ingredientes{searchTerm ? " que coincidan con la búsqueda" : " registrados"}.
+                </div>
+              ) : (
+                renderTable(ingredients, ingredientSort, handleIngredientSort)
+              )}
+            </div>
+          </section>
 
-      {/* Stock Adjustment Modal (Simpler version for now) */}
+          {/* Equipos Section */}
+          <section>
+            <div className="flex items-center gap-3 mb-3">
+              <div className="flex items-center justify-center w-9 h-9 rounded-xl bg-purple-500/10">
+                <Wrench className="h-5 w-5 text-purple-500" aria-hidden="true" />
+              </div>
+              <div>
+                <h2 className="text-lg font-semibold text-text">Equipos</h2>
+                <p className="text-xs text-text-secondary">
+                  {equipment.length} {equipment.length === 1 ? "equipo" : "equipos"}
+                </p>
+              </div>
+            </div>
+            <div className="bg-card shadow-sm overflow-hidden rounded-3xl border border-border">
+              {equipment.length === 0 ? (
+                <div className="px-6 py-8 text-center text-sm text-text-secondary">
+                  No hay equipos{searchTerm ? " que coincidan con la búsqueda" : " registrados"}.
+                </div>
+              ) : (
+                renderTable(equipment, equipmentSort, handleEquipmentSort)
+              )}
+            </div>
+          </section>
+        </div>
+      )}
+
+      {/* Stock Adjustment Modal */}
       {adjustingItem && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
           <div className="bg-card w-full max-w-sm rounded-3xl border border-border shadow-2xl p-6 animate-in fade-in zoom-in duration-200">
@@ -430,7 +491,7 @@ export const InventoryList: React.FC = () => {
             <p className="text-sm text-text-secondary mb-4">
               {adjustingItem.ingredient_name} ({adjustingItem.current_stock} {adjustingItem.unit})
             </p>
-            
+
             <div className="space-y-4">
               <div>
                 <label className="block text-xs font-semibold uppercase tracking-wider text-text-secondary mb-1">
@@ -449,7 +510,7 @@ export const InventoryList: React.FC = () => {
                   }}
                 />
               </div>
-              
+
               <div className="flex gap-3 pt-2">
                 <button
                   type="button"


### PR DESCRIPTION
…quipment sections

Separates the single inventory list into two well-defined sections on the same screen: "Consumibles" (ingredients) and "Equipos" (equipment), making it clearer for users to distinguish between item types.

Web changes:
- Split table into two independent sections with distinct headers and icons
- Each section has independent column sorting
- Removed "Tipo" column (now implicit from section header)
- Replaced pagination with full section display

Mobile changes:
- Switched from FlatList to SectionList with section headers
- Removed SegmentedControl type filter (now visually separated)
- Added section headers with icons and item counts

https://claude.ai/code/session_01FV5EhhvTzrd22NP4pxJ5QE