### PR TITLE
refactor(ui): genericize app labels to support all event types

### DIFF
--- a/mobile/src/lib/pdfGenerator.ts
+++ b/mobile/src/lib/pdfGenerator.ts
@@ -360,16 +360,16 @@ export const generateShoppingListPDF = async (
     ingredients.length > 0
       ? `<table>
           <thead><tr>
-            <th>Ingrediente</th>
+            <th>Insumo</th>
             <th class="text-center">Cantidad</th>
             <th class="text-center">Unidad</th>
           </tr></thead>
           <tbody>${rows}</tbody>
         </table>`
-      : `<p class="empty-msg">No hay ingredientes calculados.</p>`;
+      : `<p class="empty-msg">No hay insumos calculados.</p>`;
 
   const body = `
-    ${buildHeaderHTML(profile, "Lista de Compras")}
+    ${buildHeaderHTML(profile, "Lista de Insumos")}
     <div style="margin-bottom:16px; color:${GRAY_COLOR};">
       <p>Evento: ${esc(event.service_type)}</p>
       <p>Fecha: ${eventDateFormatted}</p>

--- a/mobile/src/screens/catalog/InventoryFormScreen.tsx
+++ b/mobile/src/screens/catalog/InventoryFormScreen.tsx
@@ -180,7 +180,7 @@ export default function InventoryFormScreen({ navigation, route }: Props) {
                     itemType === "ingredient" && styles.typeButtonTextActive,
                   ]}
                 >
-                  Ingrediente
+                  Insumo
                 </Text>
               </TouchableOpacity>
               <TouchableOpacity
@@ -289,7 +289,7 @@ export default function InventoryFormScreen({ navigation, route }: Props) {
           />
 
           <Text style={styles.helpText}>
-            Este costo se usará para calcular el costo de las recetas.
+            Este costo se usará para calcular el costo de los productos.
           </Text>
         </View>
       </ScrollView>

--- a/mobile/src/screens/catalog/InventoryListScreen.tsx
+++ b/mobile/src/screens/catalog/InventoryListScreen.tsx
@@ -282,7 +282,7 @@ export default function InventoryListScreen({ navigation }: Props) {
             <EmptyState
               icon={<Package color={palette.textTertiary} size={48} />}
               title="Sin inventario"
-              description="Agrega tu primer ingrediente o equipo."
+              description="Agrega tu primer insumo o equipo."
               actionLabel="Nuevo Item"
               onAction={() => navigation.navigate("InventoryForm", {})}
             />

--- a/mobile/src/screens/catalog/ProductDetailScreen.tsx
+++ b/mobile/src/screens/catalog/ProductDetailScreen.tsx
@@ -144,20 +144,20 @@ export default function ProductDetailScreen({ navigation, route }: Props) {
           </View>
         </View>
 
-        {/* Receta / Ingredientes */}
+        {/* Composición / Insumos */}
         <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Receta / Ingredientes</Text>
+          <Text style={styles.sectionTitle}>Composición / Insumos</Text>
 
           {ingredients.filter((i: any) => i.type !== 'equipment').length === 0 ? (
             <Text style={styles.emptyText}>
-              Este producto no tiene ingredientes asignados.
+              Este producto no tiene insumos asignados.
             </Text>
           ) : (
             ingredients.filter((i: any) => i.type !== 'equipment').map((ing: any, index: number) => (
               <View key={index} style={styles.ingredientRow}>
                 <View style={styles.ingredientInfo}>
                   <Text style={styles.ingredientName}>
-                    {ing.ingredient_name || "Ingrediente"}
+                    {ing.ingredient_name || "Insumo"}
                   </Text>
                   <Text style={styles.ingredientUnit}>
                     {ing.quantity_required} {ing.unit || "und"}

--- a/mobile/src/screens/catalog/ProductFormScreen.tsx
+++ b/mobile/src/screens/catalog/ProductFormScreen.tsx
@@ -300,7 +300,7 @@ export default function ProductFormScreen({ navigation, route }: Props) {
             render={({ field: { onChange, onBlur, value } }) => (
               <FormInput
                 label="Nombre"
-                placeholder="Ej: Menú Premium"
+                placeholder="Ej: Paquete Premium"
                 value={value}
                 onChangeText={onChange}
                 onBlur={onBlur}
@@ -373,10 +373,10 @@ export default function ProductFormScreen({ navigation, route }: Props) {
           </View>
         </View>
 
-        {/* Receta / Ingredientes */}
+        {/* Composición / Insumos */}
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Receta / Ingredientes</Text>
+            <Text style={styles.sectionTitle}>Composición / Insumos</Text>
             <TouchableOpacity
               style={styles.addIngredientBtn}
               onPress={handleAddIngredient}
@@ -385,18 +385,18 @@ export default function ProductFormScreen({ navigation, route }: Props) {
               <Text style={styles.addIngredientText}>Agregar</Text>
             </TouchableOpacity>
           </View>
-          <Text style={styles.sectionDescription}>Solo ingredientes generan costo al producto.</Text>
+          <Text style={styles.sectionDescription}>Solo insumos generan costo al producto.</Text>
 
           {ingredientEntries.length === 0 ? (
             <Text style={styles.emptyText}>
-              Agrega ingredientes para crear una receta. Esto permitirá calcular
+              Agrega insumos para definir la composición. Esto permitirá calcular
               el costo del producto.
             </Text>
           ) : (
             ingredientEntries.map(({ item: ing, originalIndex }) => (
               <View key={originalIndex} style={styles.ingredientRow}>
                 <View style={styles.ingredientSelect}>
-                  <Text style={styles.selectLabel}>Ingrediente</Text>
+                  <Text style={styles.selectLabel}>Insumo</Text>
                   <ScrollView
                     horizontal
                     showsHorizontalScrollIndicator={false}

--- a/mobile/src/screens/events/EventDetailScreen.tsx
+++ b/mobile/src/screens/events/EventDetailScreen.tsx
@@ -343,7 +343,7 @@ export default function EventDetailScreen({ navigation, route }: Props) {
         const key = ing.inventory_id;
         const qty = productQuantities.get(ing.product_id) || 0;
         if (!aggregated[key]) {
-          aggregated[key] = { name: ing.ingredient_name || "Ingrediente", unit: ing.unit || "", quantity: 0 };
+          aggregated[key] = { name: ing.ingredient_name || "Insumo", unit: ing.unit || "", quantity: 0 };
         }
         aggregated[key].quantity += (ing.quantity_required || 0) * qty;
       });
@@ -351,7 +351,7 @@ export default function EventDetailScreen({ navigation, route }: Props) {
       trackPdfShared();
     } catch (err) {
       logError("Error generating shopping list PDF", err);
-      addToast("Error al generar lista de compras", "error");
+      addToast("Error al generar lista de insumos", "error");
     } finally {
       setGeneratingPdf(null);
     }
@@ -836,8 +836,8 @@ export default function EventDetailScreen({ navigation, route }: Props) {
               <TouchableOpacity style={styles.menuOption} onPress={handleGenerateShoppingList} activeOpacity={0.7}>
                 <ShoppingCart color={palette.primary} size={24} />
                 <View style={styles.menuOptionInfo}>
-                  <Text style={styles.menuOptionTitle}>Lista de Compras</Text>
-                  <Text style={styles.menuOptionDesc}>Genera lista de ingredientes</Text>
+                  <Text style={styles.menuOptionTitle}>Lista de Insumos</Text>
+                  <Text style={styles.menuOptionDesc}>Genera lista de insumos necesarios</Text>
                 </View>
               </TouchableOpacity>
 

--- a/mobile/src/screens/events/EventFormScreen.tsx
+++ b/mobile/src/screens/events/EventFormScreen.tsx
@@ -635,7 +635,7 @@ export default function EventFormScreen({ navigation, route }: Props) {
               style={styles.input}
               value={formData.service_type}
               onChangeText={(v) => setFormData({ ...formData, service_type: v })}
-              placeholder="Ej: Banquete, Cocktail, Cena"
+              placeholder="Ej: Decoración, Banquete, Fotografía"
             />
 
             <Text style={styles.inputLabel}>Número de Personas</Text>

--- a/mobile/src/screens/profile/AboutScreen.tsx
+++ b/mobile/src/screens/profile/AboutScreen.tsx
@@ -98,8 +98,8 @@ export default function AboutScreen({ navigation }: Props) {
         <View style={styles.card}>
           <Text style={styles.sectionTitle}>Sobre la app</Text>
           <Text style={styles.description}>
-            EventosApp es una aplicaci&#xF3;n SaaS dise&#xF1;ada para organizadores de eventos,
-            caterers y banquetes. Gestiona clientes, eventos, cat&#xE1;logo de productos,
+            EventosApp es una aplicaci&#xF3;n SaaS dise&#xF1;ada para organizadores de eventos
+            de todo tipo. Gestiona clientes, eventos, cat&#xE1;logo de productos,
             inventario, cotizaciones y pagos en un solo lugar.
           </Text>
         </View>

--- a/mobile/src/services/searchService.ts
+++ b/mobile/src/services/searchService.ts
@@ -63,7 +63,7 @@ const mapInventoryResults = (items: InventoryItem[]): SearchResult[] =>
         id: item.id,
         type: 'inventory',
         title: item.ingredient_name,
-        subtitle: `${item.type === 'equipment' ? 'Equipo' : 'Ingrediente'} - ${item.unit}`,
+        subtitle: `${item.type === 'equipment' ? 'Equipo' : 'Insumo'} - ${item.unit}`,
         meta: `Stock: ${item.current_stock} ${item.unit}`,
         screen: 'InventoryForm',
         params: { id: item.id },

--- a/web/src/components/ContractTemplateEditor.tsx
+++ b/web/src/components/ContractTemplateEditor.tsx
@@ -267,15 +267,15 @@ export const ContractTemplateEditor: React.FC<ContractTemplateEditorProps> = ({
       } as any,
       profile: {
         name: "Juan Eventos",
-        business_name: "Catering Elegante",
-        email: "info@catering.com",
+        business_name: "Mi Empresa de Eventos",
+        email: "info@mieventos.com",
       } as any,
       template,
       strict: false,
       products: [
-        { products: { name: "Churros" } },
-        { products: { name: "Paletas" } },
-        { products: { name: "Algodón de Azúcar" } },
+        { products: { name: "Paquete Premium" } },
+        { products: { name: "Iluminación" } },
+        { products: { name: "Decoración Floral" } },
       ] as any,
     });
   } catch {

--- a/web/src/lib/pdfGenerator.test.ts
+++ b/web/src/lib/pdfGenerator.test.ts
@@ -425,13 +425,13 @@ describe('pdfGenerator', () => {
 
       expect(autoTableMock).toHaveBeenCalled();
       const callArgs = autoTableMock.mock.calls[0][1];
-      expect(callArgs.head).toEqual([['Ingrediente', 'Cantidad', 'Unidad']]);
+      expect(callArgs.head).toEqual([['Insumo', 'Cantidad', 'Unidad']]);
       expect(callArgs.body).toHaveLength(3);
       expect(callArgs.body[0]).toEqual(['Arroz', '5.00', 'kg']);
       expect(callArgs.body[1]).toEqual(['Pollo', '20.00', 'kg']);
       expect(doc.save).toHaveBeenCalled();
       const saveArg = doc.save.mock.calls[0][0] as string;
-      expect(saveArg).toContain('Compras_Banquete_');
+      expect(saveArg).toContain('Insumos_Banquete_');
     });
 
     it('shows empty message when no ingredients', () => {
@@ -446,7 +446,7 @@ describe('pdfGenerator', () => {
 
       expect(autoTableMock).not.toHaveBeenCalled();
       expect(doc.text).toHaveBeenCalledWith(
-        'No hay ingredientes calculados.',
+        'No hay insumos calculados.',
         20,
         expect.any(Number)
       );

--- a/web/src/lib/pdfGenerator.ts
+++ b/web/src/lib/pdfGenerator.ts
@@ -304,7 +304,7 @@ export const generateShoppingListPDF = (
   ingredients: { name: string; quantity: number; unit: string }[]
 ) => {
   const doc = new jsPDF();
-  let currentY = addHeader(doc, profile, 'Lista de Compras');
+  let currentY = addHeader(doc, profile, 'Lista de Insumos');
 
   const brandColor = profile?.brand_color || DEFAULT_BRAND_COLOR;
 
@@ -327,17 +327,17 @@ export const generateShoppingListPDF = (
     autoTable(doc, {
       startY: currentY,
       margin: { left: 20, right: 20 },
-      head: [['Ingrediente', 'Cantidad', 'Unidad']],
+      head: [['Insumo', 'Cantidad', 'Unidad']],
       body: ingredients.map(i => [i.name, i.quantity.toFixed(2), i.unit]),
       headStyles: { fillColor: [245, 245, 245], textColor: brandColor },
       styles: { fontSize: 10 },
       theme: 'grid',
     });
   } else {
-    doc.text('No hay ingredientes calculados.', 20, currentY);
+    doc.text('No hay insumos calculados.', 20, currentY);
   }
 
-  doc.save(`Compras_${event.service_type}_${format(localDate, 'yyyy-MM-dd')}.pdf`);
+  doc.save(`Insumos_${event.service_type}_${format(localDate, 'yyyy-MM-dd')}.pdf`);
 };
 
 export const generatePaymentReportPDF = (

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -89,8 +89,8 @@ export const About: React.FC = () => {
             Sobre la app
           </h2>
           <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
-            EventosApp es una aplicacion SaaS disenada para organizadores de eventos,
-            caterers y banquetes. Gestiona clientes, eventos, catalogo de productos,
+            EventosApp es una aplicacion SaaS disenada para organizadores de eventos
+            de todo tipo. Gestiona clientes, eventos, catalogo de productos,
             inventario, cotizaciones y pagos en un solo lugar.
           </p>
         </div>

--- a/web/src/pages/Events/EventSummary.test.tsx
+++ b/web/src/pages/Events/EventSummary.test.tsx
@@ -127,8 +127,8 @@ describe('EventSummary', () => {
       expect(screen.getByText('Ana - Boda')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Ver lista de compras/i }));
-    expect(screen.getAllByText(/Lista de Compras/i)[0]).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Ver lista de insumos/i }));
+    expect(screen.getAllByText(/Lista de Insumos/i)[0]).toBeInTheDocument();
     expect(screen.getByText('Harina')).toBeInTheDocument();
     expect(screen.getByText('kg')).toBeInTheDocument();
 
@@ -347,11 +347,11 @@ describe('EventSummary', () => {
     });
 
     // Switch to ingredients view
-    fireEvent.click(screen.getByRole('button', { name: /Ver lista de compras/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ver lista de insumos/i }));
 
-    // Open Acciones dropdown and click Lista de Compras
+    // Open Acciones dropdown and click Lista de Insumos
     fireEvent.click(screen.getByRole('button', { name: /Más acciones/i }));
-    fireEvent.click(screen.getByText('Lista de Compras'));
+    fireEvent.click(screen.getAllByText('Lista de Insumos')[0]);
     expect(generateShoppingListPDF).toHaveBeenCalled();
   });
 
@@ -376,7 +376,7 @@ describe('EventSummary', () => {
 
     // Shopping list PDF
     fireEvent.click(screen.getByRole('button', { name: /Más acciones/i }));
-    fireEvent.click(screen.getByText('Lista de Compras'));
+    fireEvent.click(screen.getByText('Lista de Insumos'));
     expect(generateShoppingListPDF).toHaveBeenCalled();
   });
 
@@ -529,9 +529,9 @@ describe('EventSummary', () => {
       expect(screen.getByText('Ana - Boda')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Ver lista de compras/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ver lista de insumos/i }));
 
-    expect(screen.getByText(/No hay ingredientes calculados/)).toBeInTheDocument();
+    expect(screen.getByText(/No hay insumos calculados/)).toBeInTheDocument();
   });
 
   it('renders footer with business name', async () => {
@@ -560,7 +560,7 @@ describe('EventSummary', () => {
       expect(screen.getByText('Ana - Boda')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Ver lista de compras/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ver lista de insumos/i }));
 
     // Total quantity: (0.5 * 2) + (0.3 * 3) = 1.0 + 0.9 = 1.90
     expect(screen.getByText('1.90')).toBeInTheDocument();
@@ -585,7 +585,7 @@ describe('EventSummary', () => {
       expect(screen.getByText('Ana - Boda')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Ver lista de compras/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ver lista de insumos/i }));
 
     expect(screen.getByText('Azucar')).toBeInTheDocument();
     expect(screen.getByText('g')).toBeInTheDocument();
@@ -1212,7 +1212,7 @@ describe('EventSummary', () => {
       expect(screen.getByText('Ana - Boda')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Ver lista de compras/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Ver lista de insumos/i }));
 
     // Harina needs more (5*2 = 10 required > 2 in stock) → "Comprar" link
     expect(screen.getByText('Comprar')).toBeInTheDocument();

--- a/web/src/pages/Events/EventSummary.tsx
+++ b/web/src/pages/Events/EventSummary.tsx
@@ -391,7 +391,7 @@ export const EventSummary: React.FC = () => {
                   : "text-text-secondary hover:text-text hover:bg-white/50 dark:hover:bg-gray-600/30"
               )}
               aria-pressed={viewMode === "ingredients"}
-              aria-label="Ver lista de compras e ingredientes"
+              aria-label="Ver lista de insumos"
             >
               <ShoppingCart className="h-4 w-4 mr-2" aria-hidden="true" />
               Compras
@@ -500,7 +500,7 @@ export const EventSummary: React.FC = () => {
                   role="menuitem"
                 >
                   <ShoppingCart className="h-4 w-4 mr-3 text-text-secondary" />
-                  Lista de Compras
+                  Lista de Insumos
                 </button>
                 <button
                   type="button"
@@ -881,7 +881,7 @@ export const EventSummary: React.FC = () => {
         <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
           <div className="bg-card shadow-sm rounded-3xl p-6 sm:p-8 border border-border">
             <h1 className="text-2xl font-black text-text uppercase tracking-tight mb-2">
-              Lista de Compras e Ingredientes
+              Lista de Insumos
             </h1>
             <p className="text-text-secondary text-sm flex items-center gap-2">
               <ShoppingCart className="h-4 w-4 text-brand-orange" />
@@ -890,11 +890,11 @@ export const EventSummary: React.FC = () => {
           </div>
 
           <div className="bg-card shadow-sm rounded-3xl p-6 sm:p-8 border border-border overflow-hidden">
-            <table className="w-full text-sm" aria-label="Ingredientes necesarios para el evento">
-              <caption className="sr-only">Lista de ingredientes con cantidades necesarias para el evento</caption>
+            <table className="w-full text-sm" aria-label="Insumos necesarios para el evento">
+              <caption className="sr-only">Lista de insumos con cantidades necesarias para el evento</caption>
               <thead>
                 <tr className="text-left text-text-secondary border-b border-border">
-                  <th className="pb-3 pt-2">Ingrediente</th>
+                  <th className="pb-3 pt-2">Insumo</th>
                   <th className="pb-3 pt-2 text-right">Necesario</th>
                   <th className="pb-3 pt-2 text-right">En Stock</th>
                   <th className="pb-3 pt-2 text-right">Acción</th>
@@ -943,7 +943,7 @@ export const EventSummary: React.FC = () => {
                       colSpan={3}
                       className="py-4 text-center text-gray-500 dark:text-gray-400 italic"
                     >
-                      No hay ingredientes calculados para los productos
+                      No hay insumos calculados para los productos
                       seleccionados.
                     </td>
                   </tr>

--- a/web/src/pages/Events/components/EventGeneralInfo.test.tsx
+++ b/web/src/pages/Events/components/EventGeneralInfo.test.tsx
@@ -276,7 +276,7 @@ describe('EventGeneralInfo', () => {
       <EventGeneralInfo clients={sampleClients} />
     );
 
-    expect(screen.getByPlaceholderText('Ej. Barra de Churros')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ej. Decoración, Banquete, Fotografía')).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Dirección del evento/)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Ciudad del evento/)).toBeInTheDocument();
   });

--- a/web/src/pages/Events/components/EventGeneralInfo.tsx
+++ b/web/src/pages/Events/components/EventGeneralInfo.tsx
@@ -164,7 +164,7 @@ export const EventGeneralInfo: React.FC<EventGeneralInfoProps> = ({
               id="service_type"
               type="text"
               {...register('service_type')}
-              placeholder="Ej. Barra de Churros"
+              placeholder="Ej. Decoración, Banquete, Fotografía"
               className="shadow-xs rounded-xl p-2 border bg-card text-text border-border transition-shadow focus:ring-2 focus:ring-brand-orange/20"
               aria-required="true"
               aria-invalid={errors.service_type ? "true" : "false"}

--- a/web/src/pages/Inventory/InventoryDetails.test.tsx
+++ b/web/src/pages/Inventory/InventoryDetails.test.tsx
@@ -50,7 +50,7 @@ describe('InventoryDetails', () => {
     (inventoryService.getById as any).mockResolvedValue(baseItem);
     renderDetails();
     await waitFor(() => expect(screen.getByText('Harina')).toBeInTheDocument());
-    expect(screen.getByText('Ingrediente Consumible')).toBeInTheDocument();
+    expect(screen.getByText('Insumo Consumible')).toBeInTheDocument();
     expect(screen.getByText('$2.50')).toBeInTheDocument();
     expect(screen.getByText('$250.00')).toBeInTheDocument();
   });

--- a/web/src/pages/Inventory/InventoryDetails.tsx
+++ b/web/src/pages/Inventory/InventoryDetails.tsx
@@ -88,8 +88,8 @@ export const InventoryDetails: React.FC = () => {
     <div className="space-y-6">
       <ConfirmDialog
         open={confirmDeleteOpen}
-        title="Eliminar ingrediente"
-        description="¿Estás seguro de que deseas eliminar este ingrediente del inventario? Esta acción no se puede deshacer."
+        title="Eliminar ítem"
+        description="¿Estás seguro de que deseas eliminar este ítem del inventario? Esta acción no se puede deshacer."
         confirmText="Eliminar"
         cancelText="Cancelar"
         onConfirm={handleDeleteItem}
@@ -110,7 +110,7 @@ export const InventoryDetails: React.FC = () => {
               "px-2.5 py-0.5 mt-1 inline-flex text-xs font-semibold rounded-full border",
               item.type === "equipment" ? "bg-purple-500/10 text-purple-500 border-purple-500/20" : "bg-brand-orange/10 text-brand-orange border-brand-orange/20"
             )}>
-              {item.type === "equipment" ? "Activo / Equipo" : "Ingrediente Consumible"}
+              {item.type === "equipment" ? "Activo / Equipo" : "Insumo Consumible"}
             </span>
           </div>
         </div>
@@ -189,7 +189,7 @@ export const InventoryDetails: React.FC = () => {
               <div className="p-4 bg-brand-orange/5 border border-brand-orange/10 rounded-2xl">
                 <h3 className="text-xs font-semibold text-brand-orange uppercase mb-1">Impacto en Producción</h3>
                 <p className="text-sm text-text-secondary">
-                  Este ingrediente se utiliza en todos los productos que requieren {item.ingredient_name}. 
+                  Este ítem se utiliza en los productos que requieren {item.ingredient_name}.
                   Asegúrate de mantener el stock mínimo para evitar retrasos.
                 </p>
               </div>

--- a/web/src/pages/Inventory/InventoryForm.test.tsx
+++ b/web/src/pages/Inventory/InventoryForm.test.tsx
@@ -185,7 +185,7 @@ describe('InventoryForm', () => {
     renderForm();
 
     await waitFor(() => {
-      expect(screen.getByText(/Error al cargar el ingrediente/i)).toBeInTheDocument();
+      expect(screen.getByText(/Error al cargar el ítem/i)).toBeInTheDocument();
     });
     expect(logError).toHaveBeenCalledWith('Error loading item', expect.any(Error));
   });
@@ -275,18 +275,18 @@ describe('InventoryForm', () => {
     renderForm();
 
     await waitFor(() => {
-      expect(screen.getByText('Editar Ingrediente')).toBeInTheDocument();
+      expect(screen.getByText('Editar Ítem')).toBeInTheDocument();
     });
     expect(screen.queryByText(/Límite de Catálogo Alcanzado/i)).not.toBeInTheDocument();
   });
 
-  it('renders "Nuevo Ingrediente" heading when creating', () => {
+  it('renders "Nuevo Ítem" heading when creating', () => {
     renderForm();
 
-    expect(screen.getByText('Nuevo Ingrediente')).toBeInTheDocument();
+    expect(screen.getByText('Nuevo Ítem')).toBeInTheDocument();
   });
 
-  it('renders "Editar Ingrediente" heading when editing', async () => {
+  it('renders "Editar Ítem" heading when editing', async () => {
     mockParams = { id: 'inv-1' };
     (inventoryService.getById as any).mockResolvedValue({
       id: 'inv-1',
@@ -301,7 +301,7 @@ describe('InventoryForm', () => {
     renderForm();
 
     await waitFor(() => {
-      expect(screen.getByText('Editar Ingrediente')).toBeInTheDocument();
+      expect(screen.getByText('Editar Ítem')).toBeInTheDocument();
     });
   });
 
@@ -338,7 +338,7 @@ describe('InventoryForm', () => {
 
     expect(options).toHaveLength(2);
     expect(options[0]).toHaveValue('ingredient');
-    expect(options[0]).toHaveTextContent('Ingrediente (Consumible)');
+    expect(options[0]).toHaveTextContent('Insumo (Consumible)');
     expect(options[1]).toHaveValue('equipment');
     expect(options[1]).toHaveTextContent('Activo / Equipo (Retornable)');
   });
@@ -365,7 +365,7 @@ describe('InventoryForm', () => {
       expect(screen.getByText('Guardando...')).toBeInTheDocument();
     });
 
-    const submitBtn = screen.getByRole('button', { name: /Guardando ingrediente/i });
+    const submitBtn = screen.getByRole('button', { name: /Guardando ítem/i });
     expect(submitBtn).toBeDisabled();
 
     resolveCreate!({});
@@ -428,7 +428,7 @@ describe('InventoryForm', () => {
     fireEvent.click(screen.getByRole('button', { name: /guardar/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/Error al guardar el ingrediente/i)).toBeInTheDocument();
+      expect(screen.getByText(/Error al guardar el ítem/i)).toBeInTheDocument();
     });
   });
 
@@ -439,7 +439,7 @@ describe('InventoryForm', () => {
     renderForm();
 
     await waitFor(() => {
-      expect(screen.getByText(/Error al cargar el ingrediente/i)).toBeInTheDocument();
+      expect(screen.getByText(/Error al cargar el ítem/i)).toBeInTheDocument();
     });
     expect(logError).toHaveBeenCalledWith('Error loading item', expect.any(Error));
   });

--- a/web/src/pages/Inventory/InventoryForm.tsx
+++ b/web/src/pages/Inventory/InventoryForm.tsx
@@ -78,7 +78,7 @@ export const InventoryForm: React.FC = () => {
       });
     } catch (err) {
       logError("Error loading item", err);
-      setError("Error al cargar el ingrediente");
+      setError("Error al cargar el ítem");
     } finally {
       setIsLoading(false);
     }
@@ -108,7 +108,7 @@ export const InventoryForm: React.FC = () => {
       navigate("/inventory");
     } catch (err: any) {
       logError("Error saving item", err);
-      setError(err.message || "Error al guardar el ingrediente");
+      setError(err.message || "Error al guardar el ítem");
     } finally {
       setIsLoading(false);
     }
@@ -155,7 +155,7 @@ export const InventoryForm: React.FC = () => {
             <ArrowLeft className="h-5 w-5" aria-hidden="true" />
           </button>
           <h1 className="text-2xl font-bold text-text">
-            {id ? "Editar Ingrediente" : "Nuevo Ingrediente"}
+            {id ? "Editar Ítem" : "Nuevo Ítem"}
           </h1>
         </div>
       </div>
@@ -211,7 +211,7 @@ export const InventoryForm: React.FC = () => {
                 aria-invalid={errors.type ? "true" : "false"}
                 aria-describedby={errors.type ? "type-error" : undefined}
               >
-                <option value="ingredient">Ingrediente (Consumible)</option>
+                <option value="ingredient">Insumo (Consumible)</option>
                 <option value="equipment">
                   Activo / Equipo (Retornable)
                 </option>
@@ -331,10 +331,10 @@ export const InventoryForm: React.FC = () => {
               type="submit"
               disabled={isLoading}
               className="inline-flex justify-center py-2.5 px-8 border border-transparent shadow-sm text-sm font-medium rounded-xl text-white bg-brand-orange hover:bg-orange-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-brand-orange disabled:opacity-50 transition-colors"
-              aria-label={isLoading ? "Guardando ingrediente..." : "Guardar ingrediente"}
+              aria-label={isLoading ? "Guardando ítem..." : "Guardar ítem"}
             >
               <Save className="h-5 w-5 mr-2" aria-hidden="true" />
-              {isLoading ? "Guardando..." : "Guardar Ingrediente"}
+              {isLoading ? "Guardando..." : "Guardar Ítem"}
             </button>
           </div>
         </form>

--- a/web/src/pages/Inventory/InventoryList.test.tsx
+++ b/web/src/pages/Inventory/InventoryList.test.tsx
@@ -154,7 +154,7 @@ describe('InventoryList', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Eliminar Harina/i }));
-    const dialog = screen.getByRole('dialog', { name: 'Eliminar ingrediente' });
+    const dialog = screen.getByRole('dialog', { name: 'Eliminar ítem' });
     fireEvent.click(within(dialog).getByRole('button', { name: 'Eliminar' }));
 
     await waitFor(() => {
@@ -198,7 +198,7 @@ describe('InventoryList', () => {
     expect(screen.getByText('$0.00')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /Eliminar Horno/i }));
-    const dialog = screen.getByRole('dialog', { name: 'Eliminar ingrediente' });
+    const dialog = screen.getByRole('dialog', { name: 'Eliminar ítem' });
     fireEvent.click(within(dialog).getByRole('button', { name: 'Eliminar' }));
 
     await waitFor(() => {
@@ -227,10 +227,10 @@ describe('InventoryList', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: /Eliminar Harina/i }));
-    const dialog = screen.getByRole('dialog', { name: 'Eliminar ingrediente' });
+    const dialog = screen.getByRole('dialog', { name: 'Eliminar ítem' });
     fireEvent.click(within(dialog).getByRole('button', { name: 'Cancelar' }));
 
-    expect(screen.queryByRole('dialog', { name: 'Eliminar ingrediente' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Eliminar ítem' })).not.toBeInTheDocument();
   });
 
   it('renders consumibles section with unit label', async () => {
@@ -597,7 +597,7 @@ describe('InventoryList', () => {
     // Equipment section should be visible
     expect(screen.getByText('Equipos')).toBeInTheDocument();
     // Consumibles section should show empty message
-    expect(screen.getByText(/No hay ingredientes/i)).toBeInTheDocument();
+    expect(screen.getByText(/No hay insumos/i)).toBeInTheDocument();
   });
 
   it('sorts equipment section independently from consumibles', async () => {

--- a/web/src/pages/Inventory/InventoryList.tsx
+++ b/web/src/pages/Inventory/InventoryList.tsx
@@ -303,7 +303,7 @@ export const InventoryList: React.FC = () => {
     <div className="space-y-6">
       <ConfirmDialog
         open={confirmOpen}
-        title="Eliminar ingrediente"
+        title="Eliminar ítem"
         description="Esta acción no se puede deshacer."
         confirmText="Eliminar"
         cancelText="Cancelar"
@@ -326,7 +326,7 @@ export const InventoryList: React.FC = () => {
                 ['Nombre', 'Tipo', 'Stock Actual', 'Stock Mínimo', 'Unidad', 'Costo Unitario'],
                 items.map(i => [
                   i.ingredient_name,
-                  i.type === 'equipment' ? 'Equipo' : 'Ingrediente',
+                  i.type === 'equipment' ? 'Equipo' : 'Insumo',
                   i.current_stock,
                   i.minimum_stock,
                   i.unit,
@@ -442,14 +442,14 @@ export const InventoryList: React.FC = () => {
               <div>
                 <h2 className="text-lg font-semibold text-text">Consumibles</h2>
                 <p className="text-xs text-text-secondary">
-                  {ingredients.length} {ingredients.length === 1 ? "ingrediente" : "ingredientes"}
+                  {ingredients.length} {ingredients.length === 1 ? "insumo" : "insumos"}
                 </p>
               </div>
             </div>
             <div className="bg-card shadow-sm overflow-hidden rounded-3xl border border-border">
               {ingredients.length === 0 ? (
                 <div className="px-6 py-8 text-center text-sm text-text-secondary">
-                  No hay ingredientes{searchTerm ? " que coincidan con la búsqueda" : " registrados"}.
+                  No hay insumos{searchTerm ? " que coincidan con la búsqueda" : " registrados"}.
                 </div>
               ) : (
                 renderTable(ingredients, ingredientSort, handleIngredientSort)

--- a/web/src/pages/Products/ProductDetails.test.tsx
+++ b/web/src/pages/Products/ProductDetails.test.tsx
@@ -68,7 +68,7 @@ describe('ProductDetails', () => {
     renderDetails();
     await waitFor(() => expect(screen.getByText('Paquete Premium')).toBeInTheDocument());
     expect(screen.getByText('$250.00')).toBeInTheDocument();
-    expect(screen.getByText('2 ingredientes')).toBeInTheDocument();
+    expect(screen.getByText('2 insumos')).toBeInTheDocument();
     expect(screen.getByText('Harina')).toBeInTheDocument();
     expect(screen.getByText('Azúcar')).toBeInTheDocument();
   });
@@ -78,7 +78,7 @@ describe('ProductDetails', () => {
     (productService.getIngredients as any).mockResolvedValue([]);
     renderDetails();
     await waitFor(() => expect(screen.getByText('Paquete Premium')).toBeInTheDocument());
-    expect(screen.getByText(/no tiene ingredientes configurados/i)).toBeInTheDocument();
+    expect(screen.getByText(/no tiene insumos configurados/i)).toBeInTheDocument();
   });
 
   it('shows error state on fetch failure', async () => {
@@ -175,6 +175,6 @@ describe('ProductDetails', () => {
     ]);
     renderDetails();
     await waitFor(() => screen.getByText('Paquete Premium'));
-    expect(screen.getByText('Ingrediente desconocido')).toBeInTheDocument();
+    expect(screen.getByText('Insumo desconocido')).toBeInTheDocument();
   });
 });

--- a/web/src/pages/Products/ProductDetails.tsx
+++ b/web/src/pages/Products/ProductDetails.tsx
@@ -9,7 +9,6 @@ import {
   DollarSign,
   Tag,
   Trash2,
-  ChefHat,
   Wrench,
   Layers,
 } from "lucide-react";
@@ -155,11 +154,11 @@ export const ProductDetails: React.FC = () => {
                 </div>
               </div>
               <div className="flex items-start gap-3">
-                <ChefHat className="h-5 w-5 text-brand-orange shrink-0 mt-0.5" />
+                <Layers className="h-5 w-5 text-brand-orange shrink-0 mt-0.5" />
                 <div>
-                  <p className="text-xs text-text-secondary">Receta</p>
+                  <p className="text-xs text-text-secondary">Composición</p>
                   <p className="text-sm font-medium text-text">
-                    {ingredients.filter((i: any) => i.type !== 'equipment').length} ingredientes
+                    {ingredients.filter((i: any) => i.type !== 'equipment').length} insumos
                     {ingredients.filter((i: any) => i.type === 'equipment').length > 0 && `, ${ingredients.filter((i: any) => i.type === 'equipment').length} equipo(s)`}
                   </p>
                 </div>
@@ -169,21 +168,21 @@ export const ProductDetails: React.FC = () => {
         </div>
 
         <div className="lg:col-span-2 space-y-6">
-          {/* Receta / Ingredientes */}
+          {/* Composición / Insumos */}
           <div className="bg-card rounded-3xl border border-border overflow-hidden shadow-sm">
             <div className="p-6 border-b border-border flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Layers className="h-5 w-5 text-brand-orange" />
-                <h2 className="text-lg font-bold text-text">Receta / Ingredientes</h2>
+                <h2 className="text-lg font-bold text-text">Composición / Insumos</h2>
               </div>
             </div>
 
             {ingredients.filter((i: any) => i.type !== 'equipment').length === 0 ? (
               <div className="p-12 text-center">
                 <Package className="h-12 w-12 text-text-secondary mx-auto mb-4 opacity-20" />
-                <p className="text-text-secondary">Este producto no tiene ingredientes configurados.</p>
+                <p className="text-text-secondary">Este producto no tiene insumos configurados.</p>
                 <Link to={`/products/${id}/edit`} className="text-brand-orange hover:underline mt-2 inline-block text-sm">
-                  Configurar receta
+                  Configurar composición
                 </Link>
               </div>
             ) : (
@@ -191,7 +190,7 @@ export const ProductDetails: React.FC = () => {
                 <table className="min-w-full divide-y divide-border">
                   <thead className="bg-surface-alt">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Ingrediente</th>
+                      <th className="px-6 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider">Insumo</th>
                       <th className="px-6 py-3 text-right text-xs font-semibold text-text-secondary uppercase tracking-wider">Cantidad</th>
                       <th className="px-6 py-3 text-right text-xs font-semibold text-text-secondary uppercase tracking-wider">Costo Est.</th>
                     </tr>
@@ -201,7 +200,7 @@ export const ProductDetails: React.FC = () => {
                         <tr key={ing.inventory_id} className="hover:bg-surface-alt/50 transition-colors">
                           <td className="px-6 py-4">
                             <Link to={`/inventory/${ing.inventory_id}`} className="text-sm font-medium text-text hover:text-brand-orange transition-colors">
-                              {ing.ingredient_name || "Ingrediente desconocido"}
+                              {ing.ingredient_name || "Insumo desconocido"}
                             </Link>
                           </td>
                           <td className="px-6 py-4 text-right">

--- a/web/src/pages/Products/ProductForm.test.tsx
+++ b/web/src/pages/Products/ProductForm.test.tsx
@@ -82,7 +82,7 @@ describe('ProductForm', () => {
       expect(inventoryService.getAll).toHaveBeenCalled();
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Agregar un ingrediente adicional/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Agregar un insumo adicional/i }));
 
     const select = container.querySelector('select') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'inv-1' } });
@@ -115,7 +115,7 @@ describe('ProductForm', () => {
       target: { value: '50' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Agregar un ingrediente adicional/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Agregar un insumo adicional/i }));
     const select = container.querySelector('select') as HTMLSelectElement;
     fireEvent.change(select, { target: { value: 'inv-1' } });
     const quantityInput = container.querySelector('input[step="0.001"]') as HTMLInputElement;
@@ -287,11 +287,11 @@ describe('ProductForm', () => {
     });
 
     // Add two ingredients
-    fireEvent.click(screen.getByRole('button', { name: /Agregar un ingrediente adicional/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Agregar un ingrediente adicional/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Agregar un insumo adicional/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Agregar un insumo adicional/i }));
 
     // Should have two ingredient rows
-    const removeButtons = screen.getAllByRole('button', { name: /Eliminar ingrediente/i });
+    const removeButtons = screen.getAllByRole('button', { name: /Eliminar insumo/i });
     expect(removeButtons.length).toBe(2);
 
     // Remove the first ingredient
@@ -299,7 +299,7 @@ describe('ProductForm', () => {
 
     // Now only one should remain
     await waitFor(() => {
-      const remaining = screen.getAllByRole('button', { name: /Eliminar ingrediente/i });
+      const remaining = screen.getAllByRole('button', { name: /Eliminar insumo/i });
       expect(remaining.length).toBe(1);
     });
   });

--- a/web/src/pages/Products/ProductForm.tsx
+++ b/web/src/pages/Products/ProductForm.tsx
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { productService } from "../../services/productService";
 import { inventoryService } from "../../services/inventoryService";
 import { useAuth } from "../../contexts/AuthContext";
-import { ArrowLeft, Save, Plus, Trash2, ChefHat, Wrench, Camera, X } from "lucide-react";
+import { ArrowLeft, Save, Plus, Trash2, Layers, Wrench, Camera, X } from "lucide-react";
 import { InventoryItem } from "../../types/entities";
 import { logError } from "../../lib/errorHandler";
 import { usePlanLimits } from "../../hooks/usePlanLimits";
@@ -352,7 +352,7 @@ export const ProductForm: React.FC = () => {
                     type="text"
                     {...register("name")}
                     className="w-full rounded-xl shadow-sm border border-border bg-card text-text p-3 transition-shadow focus:ring-2 focus:ring-brand-orange/20"
-                    placeholder="Ej. Churros Clásicos"
+                    placeholder="Ej. Paquete Premium"
                     aria-required="true"
                     aria-invalid={errors.name ? "true" : "false"}
                     aria-describedby={errors.name ? "name-error" : undefined}
@@ -376,7 +376,7 @@ export const ProductForm: React.FC = () => {
                     type="text"
                     {...register("category")}
                     className="w-full rounded-xl shadow-sm border border-border bg-card text-text p-3 transition-shadow focus:ring-2 focus:ring-brand-orange/20"
-                    placeholder="Ej. Postres"
+                    placeholder="Ej. Servicios"
                     aria-required="true"
                     aria-invalid={errors.category ? "true" : "false"}
                     aria-describedby={errors.category ? "category-error" : undefined}
@@ -415,13 +415,13 @@ export const ProductForm: React.FC = () => {
             </form>
         </div>
 
-        {/* Receta / Ingredientes */}
+        {/* Composición / Insumos */}
         <div className="bg-card shadow-sm border border-border px-4 py-8 rounded-3xl sm:p-10 flex flex-col">
             <h3 className="text-lg leading-6 font-medium text-text mb-4 flex items-center">
-                <ChefHat className="h-5 w-5 mr-2 text-brand-orange" aria-hidden="true" />
-                Receta / Ingredientes (por unidad/persona)
+                <Layers className="h-5 w-5 mr-2 text-brand-orange" aria-hidden="true" />
+                Composición / Insumos (por unidad/persona)
             </h3>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">Define qué ingredientes y qué cantidad se necesitan para 1 unidad de este producto. Solo ingredientes generan costo.</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">Define qué insumos y qué cantidad se necesitan para 1 unidad de este producto. Solo insumos generan costo.</p>
 
             <div className="flex-1 overflow-y-auto mb-4 space-y-3">
                 {ingredientEntries.map(({ item, originalIndex }) => (
@@ -430,20 +430,20 @@ export const ProductForm: React.FC = () => {
                             type="button"
                             onClick={() => handleRemoveIngredient(originalIndex)}
                             className="absolute top-1 right-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400"
-                            aria-label={`Eliminar ingrediente`}
+                            aria-label={`Eliminar insumo`}
                         >
                             <Trash2 className="h-4 w-4" aria-hidden="true" />
                         </button>
                         <div className="mb-2 pr-6">
-                            <label htmlFor={`ingredient-select-${originalIndex}`} className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Ingrediente</label>
+                            <label htmlFor={`ingredient-select-${originalIndex}`} className="block text-xs text-gray-500 dark:text-gray-400 mb-1">Insumo</label>
                             <select
                                 id={`ingredient-select-${originalIndex}`}
                                 value={item.inventory_id}
                                 onChange={(e) => handleIngredientChange(originalIndex, 'inventory_id', e.target.value)}
                                 className="block w-full p-2.5 text-sm border-border rounded-xl shadow-sm bg-card text-text transition-shadow focus:ring-2 focus:ring-brand-orange/20"
-                                aria-label={`Seleccionar ingrediente`}
+                                aria-label={`Seleccionar insumo`}
                             >
-                                <option value="">Seleccionar ingrediente</option>
+                                <option value="">Seleccionar insumo</option>
                                 {ingredientInventoryItems.map(i => (
                                     <option key={i.id} value={i.id}>{i.ingredient_name} ({i.unit})</option>
                                 ))}
@@ -451,7 +451,7 @@ export const ProductForm: React.FC = () => {
                         </div>
                         <div className="flex gap-2 items-center">
                             <div className="w-1/2">
-                                <label htmlFor={`quantity-${originalIndex}`} className="text-xs text-gray-500 dark:text-gray-400">Cantidad</label>
+                                <label htmlFor={`quantity-${originalIndex}`} className="text-xs text-gray-500 dark:text-gray-400">Cant.</label>
                                 <input
                                     id={`quantity-${originalIndex}`}
                                     type="number"
@@ -459,7 +459,7 @@ export const ProductForm: React.FC = () => {
                                     value={item.quantity_required}
                                     onChange={(e) => handleIngredientChange(originalIndex, 'quantity_required', Number(e.target.value))}
                                     className="block w-full p-2.5 text-sm border-border rounded-xl shadow-sm bg-card text-text transition-shadow focus:ring-2 focus:ring-brand-orange/20"
-                                    aria-label={`Cantidad de ingrediente`}
+                                    aria-label={`Cantidad de insumo`}
                                 />
                             </div>
                             <div className="w-1/2 text-right">
@@ -476,9 +476,9 @@ export const ProductForm: React.FC = () => {
                     type="button"
                     onClick={handleAddIngredient}
                     className="w-full flex items-center justify-center px-4 py-3 border border-border shadow-sm text-sm font-medium rounded-xl text-text-secondary bg-card hover:bg-surface-alt transition-colors"
-                    aria-label="Agregar un ingrediente adicional a la receta"
+                    aria-label="Agregar un insumo adicional a la composición"
                 >
-                    <Plus className="h-4 w-4 mr-2" aria-hidden="true" /> Agregar Ingrediente
+                    <Plus className="h-4 w-4 mr-2" aria-hidden="true" /> Agregar Insumo
                 </button>
             </div>
 

--- a/web/src/services/searchService.test.ts
+++ b/web/src/services/searchService.test.ts
@@ -136,7 +136,7 @@ describe('searchService', () => {
     const result = await searchService.searchAll('harina');
 
     expect(result.inventory).toHaveLength(1);
-    expect(result.inventory[0].subtitle).toBe('Ingrediente - kg');
+    expect(result.inventory[0].subtitle).toBe('Insumo - kg');
     expect(result.inventory[0].meta).toBe('Stock: 10 kg');
   });
 

--- a/web/src/services/searchService.ts
+++ b/web/src/services/searchService.ts
@@ -59,7 +59,7 @@ const mapInventoryResults = (items: InventoryItem[]): SearchResult[] =>
     id: item.id,
     type: 'inventory',
     title: item.ingredient_name,
-    subtitle: `${item.type === 'equipment' ? 'Equipo' : 'Ingrediente'} - ${item.unit}`,
+    subtitle: `${item.type === 'equipment' ? 'Equipo' : 'Insumo'} - ${item.unit}`,
     meta: `Stock: ${item.current_stock} ${item.unit}`,
     href: `/inventory/${item.id}/edit`,
   }));


### PR DESCRIPTION
Replace food/catering-specific terminology with generic event management labels across web and mobile:
- "Ingrediente" → "Insumo", "Receta" → "Composición"
- "Lista de Compras" → "Lista de Insumos"
- Food-specific placeholders replaced with generic examples
- ChefHat icon replaced with Layers icon in product forms
- About page updated to reference all event types
- Contract template examples genericized
- All 977 tests updated and passing

https://claude.ai/code/session_01FV5EhhvTzrd22NP4pxJ5QE