### PR TITLE
fix(equipment): suggestions now return calculated quantity using capa…

### DIFF
--- a/backend/internal/handlers/crud_handler.go
+++ b/backend/internal/handlers/crud_handler.go
@@ -511,34 +511,41 @@ func (h *CRUDHandler) CheckEquipmentConflicts(w http.ResponseWriter, r *http.Req
 func (h *CRUDHandler) GetEquipmentSuggestions(w http.ResponseWriter, r *http.Request) {
 	userID := middleware.GetUserID(r.Context())
 	var req struct {
-		ProductIDs []string `json:"product_ids"`
+		Products []struct {
+			ProductID string  `json:"product_id"`
+			Quantity  float64 `json:"quantity"`
+		} `json:"products"`
 	}
 	if err := decodeJSON(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
 		return
 	}
-	if len(req.ProductIDs) == 0 {
-		writeJSON(w, http.StatusOK, []models.InventoryItem{})
+	if len(req.Products) == 0 {
+		writeJSON(w, http.StatusOK, []models.EquipmentSuggestion{})
 		return
 	}
 
-	var productUUIDs []uuid.UUID
-	for _, idStr := range req.ProductIDs {
-		id, err := uuid.Parse(idStr)
+	var productQtys []repository.ProductQuantity
+	for _, p := range req.Products {
+		id, err := uuid.Parse(p.ProductID)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "Invalid product ID: "+idStr)
+			writeError(w, http.StatusBadRequest, "Invalid product ID: "+p.ProductID)
 			return
 		}
-		productUUIDs = append(productUUIDs, id)
+		qty := p.Quantity
+		if qty <= 0 {
+			qty = 1
+		}
+		productQtys = append(productQtys, repository.ProductQuantity{ID: id, Quantity: qty})
 	}
 
-	suggestions, err := h.eventRepo.GetEquipmentSuggestionsFromProducts(r.Context(), userID, productUUIDs)
+	suggestions, err := h.eventRepo.GetEquipmentSuggestionsFromProducts(r.Context(), userID, productQtys)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "Failed to fetch equipment suggestions")
 		return
 	}
 	if suggestions == nil {
-		suggestions = []models.InventoryItem{}
+		suggestions = []models.EquipmentSuggestion{}
 	}
 	writeJSON(w, http.StatusOK, suggestions)
 }

--- a/backend/internal/handlers/crud_handler_error_test.go
+++ b/backend/internal/handlers/crud_handler_error_test.go
@@ -70,7 +70,7 @@ func TestCRUDHandlerErrorBranchesWithClosedPool(t *testing.T) {
 		{"DeletePaymentRepoError", withURLParam(withUser(httptest.NewRequest(http.MethodDelete, "/api/payments/"+id, nil)), "id", id), (*CRUDHandler).DeletePayment, http.StatusNotFound},
 		// --- NEW: closed-pool error tests for additional repo paths ---
 		{"CheckEquipmentConflictsRepoError", withUser(httptest.NewRequest(http.MethodPost, "/api/events/equipment/conflicts", strings.NewReader(`{"event_date":"2026-01-01","inventory_ids":["`+id+`"]}`))), (*CRUDHandler).CheckEquipmentConflicts, http.StatusInternalServerError},
-		{"GetEquipmentSuggestionsRepoError", withUser(httptest.NewRequest(http.MethodPost, "/api/events/equipment/suggestions", strings.NewReader(`{"product_ids":["`+id+`"]}`))), (*CRUDHandler).GetEquipmentSuggestions, http.StatusInternalServerError},
+		{"GetEquipmentSuggestionsRepoError", withUser(httptest.NewRequest(http.MethodPost, "/api/events/equipment/suggestions", strings.NewReader(`{"products":[{"product_id":"`+id+`","quantity":1}]}`))), (*CRUDHandler).GetEquipmentSuggestions, http.StatusInternalServerError},
 		{"GetBatchProductIngredientsRepoError", withUser(httptest.NewRequest(http.MethodPost, "/api/products/ingredients/batch", strings.NewReader(`{"product_ids":["`+id+`"]}`))), (*CRUDHandler).GetBatchProductIngredients, http.StatusNotFound},
 		{"GetClientRepoError", withURLParam(withUser(httptest.NewRequest(http.MethodGet, "/api/clients/"+id, nil)), "id", id), (*CRUDHandler).GetClient, http.StatusNotFound},
 		{"GetProductRepoError", withURLParam(withUser(httptest.NewRequest(http.MethodGet, "/api/products/"+id, nil)), "id", id), (*CRUDHandler).GetProduct, http.StatusNotFound},

--- a/backend/internal/handlers/crud_handler_test.go
+++ b/backend/internal/handlers/crud_handler_test.go
@@ -489,7 +489,7 @@ func TestGetEquipmentSuggestionsValidation(t *testing.T) {
 	})
 
 	t.Run("InvalidProductID", func(t *testing.T) {
-		req := httptest.NewRequest(http.MethodPost, "/api/events/equipment-suggestions", strings.NewReader(`{"product_ids":["bad-id"]}`))
+		req := httptest.NewRequest(http.MethodPost, "/api/events/equipment-suggestions", strings.NewReader(`{"products":[{"product_id":"bad-id","quantity":1}]}`))
 		req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, uuid.New()))
 		rr := httptest.NewRecorder()
 		h.GetEquipmentSuggestions(rr, req)

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -133,6 +133,18 @@ type EventEquipment struct {
 	CurrentStock  *float64 `json:"current_stock,omitempty"`
 }
 
+// EquipmentSuggestion is returned by the suggestions endpoint.
+// SuggestedQty is already calculated: ceil(product_qty / capacity) if capacity is set,
+// or quantity_required otherwise, summed across all products in the event.
+type EquipmentSuggestion struct {
+	ID             uuid.UUID `json:"id"`
+	IngredientName string    `json:"ingredient_name"`
+	CurrentStock   float64   `json:"current_stock"`
+	Unit           string    `json:"unit"`
+	Type           string    `json:"type"`
+	SuggestedQty   int       `json:"suggested_quantity"`
+}
+
 type EquipmentConflict struct {
 	InventoryID   uuid.UUID `json:"inventory_id"`
 	EquipmentName string    `json:"equipment_name"`

--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -475,35 +476,103 @@ func (r *EventRepo) CheckEquipmentConflicts(ctx context.Context, userID uuid.UUI
 	return conflicts, nil
 }
 
-func (r *EventRepo) GetEquipmentSuggestionsFromProducts(ctx context.Context, userID uuid.UUID, productIDs []uuid.UUID) ([]models.InventoryItem, error) {
-	if len(productIDs) == 0 {
+// ProductQuantity pairs a product ID with the number of units in the event.
+type ProductQuantity struct {
+	ID       uuid.UUID
+	Quantity float64
+}
+
+// GetEquipmentSuggestionsFromProducts returns suggested equipment for an event,
+// with quantities calculated from each product's recipe:
+//   - If capacity is set: ceil(product_event_qty / capacity)
+//   - Otherwise: quantity_required (fixed, not scaled by event qty)
+//
+// Results are summed across all products that share the same equipment piece.
+func (r *EventRepo) GetEquipmentSuggestionsFromProducts(ctx context.Context, userID uuid.UUID, products []ProductQuantity) ([]models.EquipmentSuggestion, error) {
+	if len(products) == 0 {
 		return nil, nil
 	}
 
-	query := `SELECT DISTINCT i.id, i.user_id, i.ingredient_name, i.current_stock, i.minimum_stock,
-		i.unit, i.unit_cost, i.type, i.last_updated
-		FROM product_ingredients pi
+	productIDs := make([]uuid.UUID, len(products))
+	quantities := make([]float64, len(products))
+	for i, p := range products {
+		productIDs[i] = p.ID
+		quantities[i] = p.Quantity
+	}
+
+	// Join unnested product arrays with product_ingredients to get one row per
+	// (product, equipment) pair, then aggregate in Go.
+	query := `
+		SELECT i.id, i.ingredient_name, i.current_stock, i.unit, i.type,
+		       pi.quantity_required, pi.capacity, p.quantity AS product_quantity
+		FROM (
+			SELECT unnest($1::uuid[]) AS product_id,
+			       unnest($2::float8[]) AS quantity
+		) AS p
+		JOIN product_ingredients pi ON pi.product_id = p.product_id
 		JOIN inventory i ON pi.inventory_id = i.id
-		WHERE pi.product_id = ANY($1) AND i.type = 'equipment' AND i.user_id = $2`
-	rows, err := r.pool.Query(ctx, query, productIDs, userID)
+		WHERE i.type = 'equipment' AND i.user_id = $3`
+
+	rows, err := r.pool.Query(ctx, query, productIDs, quantities, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var items []models.InventoryItem
+	// Aggregate by inventory ID: sum the required equipment across products.
+	type row struct {
+		id              uuid.UUID
+		name            string
+		stock           float64
+		unit            string
+		typ             string
+		quantityReq     float64
+		capacity        *float64
+		productQty      float64
+	}
+
+	totals := make(map[uuid.UUID]*models.EquipmentSuggestion)
+	var order []uuid.UUID
+
 	for rows.Next() {
-		var item models.InventoryItem
-		if err := rows.Scan(&item.ID, &item.UserID, &item.IngredientName, &item.CurrentStock,
-			&item.MinimumStock, &item.Unit, &item.UnitCost, &item.Type, &item.LastUpdated); err != nil {
+		var r row
+		if err := rows.Scan(&r.id, &r.name, &r.stock, &r.unit, &r.typ,
+			&r.quantityReq, &r.capacity, &r.productQty); err != nil {
 			return nil, err
 		}
-		items = append(items, item)
+
+		var needed int
+		if r.capacity != nil && *r.capacity > 0 {
+			// Capacity-based: how many pieces of equipment handle this product qty
+			needed = int(math.Ceil(r.productQty / *r.capacity))
+		} else {
+			// Fixed: quantity_required is the total needed regardless of event qty
+			needed = int(math.Ceil(r.quantityReq))
+		}
+
+		if s, ok := totals[r.id]; ok {
+			s.SuggestedQty += needed
+		} else {
+			totals[r.id] = &models.EquipmentSuggestion{
+				ID:             r.id,
+				IngredientName: r.name,
+				CurrentStock:   r.stock,
+				Unit:           r.unit,
+				Type:           r.typ,
+				SuggestedQty:   needed,
+			}
+			order = append(order, r.id)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating equipment suggestions: %w", err)
 	}
-	return items, nil
+
+	result := make([]models.EquipmentSuggestion, 0, len(order))
+	for _, id := range order {
+		result = append(result, *totals[id])
+	}
+	return result, nil
 }
 
 // Search performs a full-text search on events for the given user

--- a/backend/internal/repository/repository_error_test.go
+++ b/backend/internal/repository/repository_error_test.go
@@ -142,7 +142,7 @@ func TestRepositoryMethodsWithClosedPool(t *testing.T) {
 	if _, err := NewEventRepo(pool).CheckEquipmentConflicts(ctx, userID, "2026-01-01", nil, nil, []uuid.UUID{id}, nil); err == nil {
 		t.Fatalf("EventRepo.CheckEquipmentConflicts() expected error with closed pool")
 	}
-	if _, err := NewEventRepo(pool).GetEquipmentSuggestionsFromProducts(ctx, userID, []uuid.UUID{id}); err == nil {
+	if _, err := NewEventRepo(pool).GetEquipmentSuggestionsFromProducts(ctx, userID, []ProductQuantity{{ID: id, Quantity: 1}}); err == nil {
 		t.Fatalf("EventRepo.GetEquipmentSuggestionsFromProducts() expected error with closed pool")
 	}
 	if _, err := NewEventRepo(pool).Search(ctx, userID, "test"); err == nil {
@@ -240,7 +240,7 @@ func TestRepositoryEdgeCases(t *testing.T) {
 	}
 
 	// EventRepo.GetEquipmentSuggestionsFromProducts with empty productIDs returns early without hitting the pool
-	suggestions, err := NewEventRepo(nil).GetEquipmentSuggestionsFromProducts(ctx, userID, []uuid.UUID{})
+	suggestions, err := NewEventRepo(nil).GetEquipmentSuggestionsFromProducts(ctx, userID, []ProductQuantity{})
 	if err != nil {
 		t.Fatalf("EventRepo.GetEquipmentSuggestionsFromProducts(empty) expected no error, got: %v", err)
 	}

--- a/mobile/src/screens/events/EventFormScreen.tsx
+++ b/mobile/src/screens/events/EventFormScreen.tsx
@@ -118,7 +118,7 @@ export default function EventFormScreen({ navigation, route }: Props) {
   const [equipmentInventory, setEquipmentInventory] = useState<InventoryItem[]>([]);
   const [selectedEquipment, setSelectedEquipment] = useState<SelectedEquipmentItem[]>([]);
   const [equipmentConflicts, setEquipmentConflicts] = useState<EquipmentConflict[]>([]);
-  const [equipmentSuggestions, setEquipmentSuggestions] = useState<InventoryItem[]>([]);
+  const [equipmentSuggestions, setEquipmentSuggestions] = useState<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]>([]);
   const [showEquipmentPicker, setShowEquipmentPicker] = useState(false);
 
   const [showDatePicker, setShowDatePicker] = useState(false);
@@ -350,14 +350,16 @@ export default function EventFormScreen({ navigation, route }: Props) {
 
   // Auto-suggest equipment when products change
   useEffect(() => {
-    const productIds = selectedProducts.map(p => p.product_id).filter(Boolean);
-    if (productIds.length === 0) {
+    const products = selectedProducts
+      .filter(p => p.product_id)
+      .map(p => ({ product_id: p.product_id, quantity: p.quantity }));
+    if (products.length === 0) {
       setEquipmentSuggestions([]);
       return;
     }
     const fetchSuggestions = async () => {
       try {
-        const suggestions = await eventService.getEquipmentSuggestions(productIds);
+        const suggestions = await eventService.getEquipmentSuggestions(products);
         setEquipmentSuggestions(suggestions || []);
       } catch {
         // Silently ignore
@@ -395,6 +397,12 @@ export default function EventFormScreen({ navigation, route }: Props) {
       setSelectedEquipment(prev => [...prev, { inventory_id: item.id, quantity: 1, notes: '' }]);
     }
     setShowEquipmentPicker(false);
+  };
+
+  const handleQuickAddSuggestion = (suggestion: { id: string; suggested_quantity: number }) => {
+    if (!selectedEquipment.some(eq => eq.inventory_id === suggestion.id)) {
+      setSelectedEquipment(prev => [...prev, { inventory_id: suggestion.id, quantity: suggestion.suggested_quantity, notes: '' }]);
+    }
   };
 
   const handleRemoveEquipment = (index: number) => {
@@ -843,10 +851,10 @@ export default function EventFormScreen({ navigation, route }: Props) {
                       <TouchableOpacity
                         key={s.id}
                         style={{ flexDirection: 'row', alignItems: 'center', backgroundColor: palette.info || '#DBEAFE', paddingHorizontal: spacing.sm, paddingVertical: spacing.xs, borderRadius: 8 }}
-                        onPress={() => handleAddEquipmentItem(s)}
+                        onPress={() => handleQuickAddSuggestion(s)}
                       >
                         <Plus color={palette.info || '#3B82F6'} size={14} />
-                        <Text style={{ ...typography.caption, color: palette.info || '#2563EB', marginLeft: 4 }}>{s.ingredient_name}</Text>
+                        <Text style={{ ...typography.caption, color: palette.info || '#2563EB', marginLeft: 4 }}>{s.ingredient_name} ×{s.suggested_quantity}</Text>
                       </TouchableOpacity>
                     ))}
                 </View>

--- a/mobile/src/services/eventService.ts
+++ b/mobile/src/services/eventService.ts
@@ -99,8 +99,8 @@ export const eventService = {
         return api.post<EquipmentConflict[]>('/events/equipment/conflicts', params);
     },
 
-    async getEquipmentSuggestions(productIds: string[]): Promise<InventoryItem[]> {
-        return api.post<InventoryItem[]>('/events/equipment/suggestions', { product_ids: productIds });
+    async getEquipmentSuggestions(products: { product_id: string; quantity: number }[]): Promise<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]> {
+        return api.post('/events/equipment/suggestions', { products });
     },
 
     async addProducts(

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -117,7 +117,7 @@ export const EventForm: React.FC = () => {
     { inventory_id: string; quantity: number; notes: string }[]
   >([]);
   const [equipmentConflicts, setEquipmentConflicts] = useState<EquipmentConflict[]>([]);
-  const [equipmentSuggestions, setEquipmentSuggestions] = useState<InventoryItem[]>([]);
+  const [equipmentSuggestions, setEquipmentSuggestions] = useState<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]>([]);
 
   const methods = useForm<EventFormData>({
     resolver: zodResolver(eventSchema) as Resolver<EventFormData>,
@@ -404,24 +404,24 @@ export const EventForm: React.FC = () => {
     });
   };
 
-  const handleQuickAddSuggestion = (inventoryId: string) => {
+  const handleQuickAddSuggestion = (inventoryId: string, suggestedQty: number) => {
     if (!selectedEquipment.some(eq => eq.inventory_id === inventoryId)) {
-      setSelectedEquipment(prev => [...prev, { inventory_id: inventoryId, quantity: 1, notes: '' }]);
+      setSelectedEquipment(prev => [...prev, { inventory_id: inventoryId, quantity: suggestedQty, notes: '' }]);
     }
   };
 
   // Auto-suggest equipment when products change
   useEffect(() => {
-    const productIds = selectedProducts
-      .map(p => p.product_id)
-      .filter(Boolean);
-    if (productIds.length === 0) {
+    const products = selectedProducts
+      .filter(p => p.product_id)
+      .map(p => ({ product_id: p.product_id, quantity: p.quantity }));
+    if (products.length === 0) {
       setEquipmentSuggestions([]);
       return;
     }
     const fetchSuggestions = async () => {
       try {
-        const suggestions = await eventService.getEquipmentSuggestions(productIds);
+        const suggestions = await eventService.getEquipmentSuggestions(products);
         setEquipmentSuggestions(suggestions || []);
       } catch {
         // Silently ignore suggestion errors

--- a/web/src/pages/Events/components/EventEquipment.tsx
+++ b/web/src/pages/Events/components/EventEquipment.tsx
@@ -7,15 +7,24 @@ interface SelectedEquipment {
   notes: string;
 }
 
+interface EquipmentSuggestion {
+  id: string;
+  ingredient_name: string;
+  current_stock: number;
+  unit: string;
+  type: string;
+  suggested_quantity: number;
+}
+
 interface EventEquipmentProps {
   equipmentInventory: InventoryItem[];
   selectedEquipment: SelectedEquipment[];
   conflicts: EquipmentConflict[];
-  suggestions: InventoryItem[];
+  suggestions: EquipmentSuggestion[];
   onAddEquipment: () => void;
   onRemoveEquipment: (index: number) => void;
   onEquipmentChange: (index: number, field: keyof SelectedEquipment, value: string | number) => void;
-  onQuickAddSuggestion: (inventoryId: string) => void;
+  onQuickAddSuggestion: (inventoryId: string, suggestedQty: number) => void;
 }
 
 export const EventEquipment: React.FC<EventEquipmentProps> = ({
@@ -82,11 +91,11 @@ export const EventEquipment: React.FC<EventEquipmentProps> = ({
               <button
                 key={s.id}
                 type="button"
-                onClick={() => onQuickAddSuggestion(s.id)}
+                onClick={() => onQuickAddSuggestion(s.id, s.suggested_quantity)}
                 className="inline-flex items-center gap-1 px-3 py-1.5 text-sm bg-primary/10 text-primary rounded-lg hover:bg-primary/20 transition-colors"
               >
                 <Plus className="h-3 w-3" />
-                {s.ingredient_name}
+                {s.ingredient_name} ×{s.suggested_quantity}
               </button>
             ))}
           </div>

--- a/web/src/services/eventService.ts
+++ b/web/src/services/eventService.ts
@@ -101,8 +101,8 @@ export const eventService = {
     return api.post<EquipmentConflict[]>('/events/equipment/conflicts', params);
   },
 
-  async getEquipmentSuggestions(productIds: string[]): Promise<InventoryItem[]> {
-    return api.post<InventoryItem[]>('/events/equipment/suggestions', { product_ids: productIds });
+  async getEquipmentSuggestions(products: { product_id: string; quantity: number }[]): Promise<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]> {
+    return api.post('/events/equipment/suggestions', { products });
   },
 
   // Compatibility methods for legacy calls (if any individual update is used)


### PR DESCRIPTION
…city formula

The suggestions endpoint previously returned only InventoryItem (no quantity), causing Quick Add to always add equipment with quantity=1.

Changes:
- Backend: new EquipmentSuggestion model with suggested_quantity field
- Backend: suggestions endpoint now accepts {products: [{product_id, quantity}]} instead of {product_ids: []}; calculates ceil(event_qty / capacity) for capacity-based equipment, or quantity_required (fixed) otherwise; sums across products sharing the same equipment
- Web: eventService, EventForm, EventEquipment updated to pass product quantities and use suggested_quantity on Quick Add (shows "×N" on button)
- Mobile: same fixes to eventService and EventFormScreen

Fixes: 50 churros + fryer(capacity=50) now correctly suggests 1 fryer. Suggestion button shows equipment name and quantity before adding.

https://claude.ai/code/session_017djpyZ7MSiDvWvFj5rhwDW