### PR TITLE
refactor: apply Copilot PR review suggestions

### DIFF
--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -520,48 +520,48 @@ func (r *EventRepo) GetEquipmentSuggestionsFromProducts(ctx context.Context, use
 	defer rows.Close()
 
 	// Aggregate by inventory ID: sum the required equipment across products.
-	type row struct {
-		id              uuid.UUID
-		name            string
-		stock           float64
-		unit            string
-		typ             string
-		quantityReq     float64
-		capacity        *float64
-		productQty      float64
+	type equipRow struct {
+		id          uuid.UUID
+		name        string
+		stock       float64
+		unit        string
+		typ         string
+		quantityReq float64
+		capacity    *float64
+		productQty  float64
 	}
 
 	totals := make(map[uuid.UUID]*models.EquipmentSuggestion)
 	var order []uuid.UUID
 
 	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.id, &r.name, &r.stock, &r.unit, &r.typ,
-			&r.quantityReq, &r.capacity, &r.productQty); err != nil {
+		var eq equipRow
+		if err := rows.Scan(&eq.id, &eq.name, &eq.stock, &eq.unit, &eq.typ,
+			&eq.quantityReq, &eq.capacity, &eq.productQty); err != nil {
 			return nil, err
 		}
 
 		var needed int
-		if r.capacity != nil && *r.capacity > 0 {
+		if eq.capacity != nil && *eq.capacity > 0 {
 			// Capacity-based: how many pieces of equipment handle this product qty
-			needed = int(math.Ceil(r.productQty / *r.capacity))
+			needed = int(math.Ceil(eq.productQty / *eq.capacity))
 		} else {
 			// Fixed: quantity_required is the total needed regardless of event qty
-			needed = int(math.Ceil(r.quantityReq))
+			needed = int(math.Ceil(eq.quantityReq))
 		}
 
-		if s, ok := totals[r.id]; ok {
+		if s, ok := totals[eq.id]; ok {
 			s.SuggestedQty += needed
 		} else {
-			totals[r.id] = &models.EquipmentSuggestion{
-				ID:             r.id,
-				IngredientName: r.name,
-				CurrentStock:   r.stock,
-				Unit:           r.unit,
-				Type:           r.typ,
+			totals[eq.id] = &models.EquipmentSuggestion{
+				ID:             eq.id,
+				IngredientName: eq.name,
+				CurrentStock:   eq.stock,
+				Unit:           eq.unit,
+				Type:           eq.typ,
 				SuggestedQty:   needed,
 			}
-			order = append(order, r.id)
+			order = append(order, eq.id)
 		}
 	}
 	if err := rows.Err(); err != nil {

--- a/mobile/src/screens/events/EventFormScreen.tsx
+++ b/mobile/src/screens/events/EventFormScreen.tsx
@@ -37,7 +37,7 @@ import {
 } from "lucide-react-native";
 import { Image } from "expo-image";
 import { EventsStackParamList } from "../../types/navigation";
-import { Event, Client, Product, InventoryItem, EquipmentConflict } from "../../types/entities";
+import { Event, Client, Product, InventoryItem, EquipmentConflict, EquipmentSuggestion } from "../../types/entities";
 import { eventService } from "../../services/eventService";
 import { clientService } from "../../services/clientService";
 import { productService } from "../../services/productService";
@@ -118,7 +118,7 @@ export default function EventFormScreen({ navigation, route }: Props) {
   const [equipmentInventory, setEquipmentInventory] = useState<InventoryItem[]>([]);
   const [selectedEquipment, setSelectedEquipment] = useState<SelectedEquipmentItem[]>([]);
   const [equipmentConflicts, setEquipmentConflicts] = useState<EquipmentConflict[]>([]);
-  const [equipmentSuggestions, setEquipmentSuggestions] = useState<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]>([]);
+  const [equipmentSuggestions, setEquipmentSuggestions] = useState<EquipmentSuggestion[]>([]);
   const [showEquipmentPicker, setShowEquipmentPicker] = useState(false);
 
   const [showDatePicker, setShowDatePicker] = useState(false);

--- a/mobile/src/services/eventService.ts
+++ b/mobile/src/services/eventService.ts
@@ -1,5 +1,5 @@
 import { api } from '../lib/api';
-import { Event, EventInsert, EventUpdate, EventEquipment, EquipmentConflict, InventoryItem } from '../types/entities';
+import { Event, EventInsert, EventUpdate, EventEquipment, EquipmentConflict, EquipmentSuggestion, InventoryItem } from '../types/entities';
 
 // Helper for type safety on joined data
 type EventWithClient = Event & { clients?: { name: string } | null };
@@ -99,7 +99,7 @@ export const eventService = {
         return api.post<EquipmentConflict[]>('/events/equipment/conflicts', params);
     },
 
-    async getEquipmentSuggestions(products: { product_id: string; quantity: number }[]): Promise<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]> {
+    async getEquipmentSuggestions(products: { product_id: string; quantity: number }[]): Promise<EquipmentSuggestion[]> {
         return api.post('/events/equipment/suggestions', { products });
     },
 

--- a/mobile/src/types/entities.ts
+++ b/mobile/src/types/entities.ts
@@ -158,6 +158,16 @@ export interface EventEquipment {
 
 export type EventEquipmentInsert = Omit<EventEquipment, 'id' | 'created_at' | 'equipment_name' | 'unit' | 'current_stock'>
 
+// ===== Equipment Suggestion =====
+export interface EquipmentSuggestion {
+    id: string
+    ingredient_name: string
+    current_stock: number
+    unit: string
+    type: string
+    suggested_quantity: number
+}
+
 // ===== Equipment Conflict =====
 export interface EquipmentConflict {
     inventory_id: string

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -23,7 +23,7 @@ import { EventFinancials } from "./components/EventFinancials";
 import { EventEquipment } from "./components/EventEquipment";
 import { inventoryService } from "../../services/inventoryService";
 import { usePlanLimits } from "../../hooks/usePlanLimits";
-import { EquipmentConflict, InventoryItem } from "../../types/entities";
+import { EquipmentConflict, EquipmentSuggestion, InventoryItem } from "../../types/entities";
 import { UpgradeBanner } from "../../components/UpgradeBanner";
 
 // Local types to avoid Supabase dependency
@@ -117,7 +117,7 @@ export const EventForm: React.FC = () => {
     { inventory_id: string; quantity: number; notes: string }[]
   >([]);
   const [equipmentConflicts, setEquipmentConflicts] = useState<EquipmentConflict[]>([]);
-  const [equipmentSuggestions, setEquipmentSuggestions] = useState<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]>([]);
+  const [equipmentSuggestions, setEquipmentSuggestions] = useState<EquipmentSuggestion[]>([]);
 
   const methods = useForm<EventFormData>({
     resolver: zodResolver(eventSchema) as Resolver<EventFormData>,

--- a/web/src/pages/Events/components/EventEquipment.tsx
+++ b/web/src/pages/Events/components/EventEquipment.tsx
@@ -1,19 +1,10 @@
 import { Plus, Trash2, AlertTriangle, Lightbulb, Wrench } from 'lucide-react';
-import { EquipmentConflict, InventoryItem } from '../../../types/entities';
+import { EquipmentConflict, EquipmentSuggestion, InventoryItem } from '../../../types/entities';
 
 interface SelectedEquipment {
   inventory_id: string;
   quantity: number;
   notes: string;
-}
-
-interface EquipmentSuggestion {
-  id: string;
-  ingredient_name: string;
-  current_stock: number;
-  unit: string;
-  type: string;
-  suggested_quantity: number;
 }
 
 interface EventEquipmentProps {

--- a/web/src/services/eventService.test.ts
+++ b/web/src/services/eventService.test.ts
@@ -206,9 +206,10 @@ describe('eventService', () => {
     expect(api.post).toHaveBeenCalledWith('/events/equipment/conflicts', params);
   });
 
-  it('getEquipmentSuggestions calls api.post with product_ids', async () => {
+  it('getEquipmentSuggestions calls api.post with products', async () => {
     (api.post as any).mockResolvedValue([]);
-    await eventService.getEquipmentSuggestions(['p1', 'p2']);
-    expect(api.post).toHaveBeenCalledWith('/events/equipment/suggestions', { product_ids: ['p1', 'p2'] });
+    const products = [{ product_id: 'p1', quantity: 2 }, { product_id: 'p2', quantity: 5 }];
+    await eventService.getEquipmentSuggestions(products);
+    expect(api.post).toHaveBeenCalledWith('/events/equipment/suggestions', { products });
   });
 });

--- a/web/src/services/eventService.ts
+++ b/web/src/services/eventService.ts
@@ -1,5 +1,5 @@
 import { api } from '../lib/api';
-import { Event, EventInsert, EventUpdate, EventEquipment, EquipmentConflict, InventoryItem } from '../types/entities';
+import { Event, EventInsert, EventUpdate, EventEquipment, EquipmentConflict, EquipmentSuggestion, InventoryItem } from '../types/entities';
 
 // Helper for type safety on joined data
 type EventWithClient = Event & { clients?: { name: string } | null };
@@ -101,7 +101,7 @@ export const eventService = {
     return api.post<EquipmentConflict[]>('/events/equipment/conflicts', params);
   },
 
-  async getEquipmentSuggestions(products: { product_id: string; quantity: number }[]): Promise<{ id: string; ingredient_name: string; current_stock: number; unit: string; type: string; suggested_quantity: number }[]> {
+  async getEquipmentSuggestions(products: { product_id: string; quantity: number }[]): Promise<EquipmentSuggestion[]> {
     return api.post('/events/equipment/suggestions', { products });
   },
 

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -182,6 +182,16 @@ export interface EventEquipment {
 
 export type EventEquipmentInsert = Omit<EventEquipment, 'id' | 'created_at' | 'equipment_name' | 'unit' | 'current_stock'>
 
+// ===== Equipment Suggestion =====
+export interface EquipmentSuggestion {
+    id: string
+    ingredient_name: string
+    current_stock: number
+    unit: string
+    type: string
+    suggested_quantity: number
+}
+
 // ===== Equipment Conflict =====
 export interface EquipmentConflict {
     inventory_id: string


### PR DESCRIPTION
- Rename local `type row` to `equipRow` in event_repo.go to avoid shadowing the `r *EventRepo` method receiver
- Define EquipmentSuggestion interface once in web and mobile entities.ts, replacing 4+ duplicated inline type literals
- Fix outdated unit test: getEquipmentSuggestions now receives {product_id, quantity}[] and sends { products }, not product_ids[]

https://claude.ai/code/session_017djpyZ7MSiDvWvFj5rhwDW