### PR TITLE
fix: address Copilot review observations

### DIFF
--- a/backend/internal/database/migrations/020_add_discount_type_to_events.down.sql
+++ b/backend/internal/database/migrations/020_add_discount_type_to_events.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP COLUMN IF EXISTS discount_type;

--- a/backend/internal/database/migrations/020_add_discount_type_to_events.up.sql
+++ b/backend/internal/database/migrations/020_add_discount_type_to_events.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events ADD COLUMN IF NOT EXISTS discount_type VARCHAR(10) NOT NULL DEFAULT 'percent';

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -54,6 +54,7 @@ type Event struct {
 	NumPeople        int       `json:"num_people"`
 	Status           string    `json:"status"`
 	Discount         float64   `json:"discount"`
+	DiscountType     string    `json:"discount_type"` // 'percent' | 'fixed'
 	RequiresInvoice  bool      `json:"requires_invoice"`
 	TaxRate          float64   `json:"tax_rate"`
 	TaxAmount        float64   `json:"tax_amount"`

--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -23,7 +23,7 @@ const eventSelectFields = `e.id, e.user_id, e.client_id,
 	to_char(e.event_date, 'YYYY-MM-DD') as event_date,
 	to_char(e.start_time, 'HH24:MI:SS') as start_time,
 	to_char(e.end_time, 'HH24:MI:SS') as end_time,
-	e.service_type, e.num_people, e.status, e.discount, e.requires_invoice,
+	e.service_type, e.num_people, e.status, e.discount, e.discount_type, e.requires_invoice,
 	e.tax_rate, e.tax_amount, e.total_amount, e.location, e.city,
 	e.deposit_percent, e.cancellation_days, e.refund_percent,
 	e.notes, e.photos, e.created_at, e.updated_at`
@@ -32,7 +32,7 @@ func scanEvent(row pgx.Row) (*models.Event, error) {
 	e := &models.Event{}
 	err := row.Scan(
 		&e.ID, &e.UserID, &e.ClientID, &e.EventDate, &e.StartTime, &e.EndTime,
-		&e.ServiceType, &e.NumPeople, &e.Status, &e.Discount, &e.RequiresInvoice,
+		&e.ServiceType, &e.NumPeople, &e.Status, &e.Discount, &e.DiscountType, &e.RequiresInvoice,
 		&e.TaxRate, &e.TaxAmount, &e.TotalAmount, &e.Location, &e.City,
 		&e.DepositPercent, &e.CancellationDays, &e.RefundPercent,
 		&e.Notes, &e.Photos, &e.CreatedAt, &e.UpdatedAt,
@@ -46,7 +46,7 @@ func scanEventWithClient(row pgx.Row) (models.Event, error) {
 	var clientPhone *string
 	err := row.Scan(
 		&e.ID, &e.UserID, &e.ClientID, &e.EventDate, &e.StartTime, &e.EndTime,
-		&e.ServiceType, &e.NumPeople, &e.Status, &e.Discount, &e.RequiresInvoice,
+		&e.ServiceType, &e.NumPeople, &e.Status, &e.Discount, &e.DiscountType, &e.RequiresInvoice,
 		&e.TaxRate, &e.TaxAmount, &e.TotalAmount, &e.Location, &e.City,
 		&e.DepositPercent, &e.CancellationDays, &e.RefundPercent,
 		&e.Notes, &e.Photos, &e.CreatedAt, &e.UpdatedAt,
@@ -199,15 +199,18 @@ func (r *EventRepo) Create(ctx context.Context, e *models.Event) error {
 		endTime = e.EndTime
 	}
 
+	if e.DiscountType == "" {
+		e.DiscountType = "percent"
+	}
 	query := `INSERT INTO events (user_id, client_id, event_date, start_time, end_time,
-		service_type, num_people, status, discount, requires_invoice,
+		service_type, num_people, status, discount, discount_type, requires_invoice,
 		tax_rate, tax_amount, total_amount, location, city,
 		deposit_percent, cancellation_days, refund_percent, notes, photos)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)
 		RETURNING id, created_at, updated_at`
 	err := r.pool.QueryRow(ctx, query,
 		e.UserID, e.ClientID, e.EventDate, startTime, endTime,
-		e.ServiceType, e.NumPeople, e.Status, e.Discount, e.RequiresInvoice,
+		e.ServiceType, e.NumPeople, e.Status, e.Discount, e.DiscountType, e.RequiresInvoice,
 		e.TaxRate, e.TaxAmount, e.TotalAmount, e.Location, e.City,
 		e.DepositPercent, e.CancellationDays, e.RefundPercent, e.Notes, e.Photos,
 	).Scan(&e.ID, &e.CreatedAt, &e.UpdatedAt)
@@ -228,15 +231,18 @@ func (r *EventRepo) Update(ctx context.Context, e *models.Event) error {
 		endTime = e.EndTime
 	}
 
+	if e.DiscountType == "" {
+		e.DiscountType = "percent"
+	}
 	query := `UPDATE events SET client_id=$3, event_date=$4, start_time=$5, end_time=$6,
-		service_type=$7, num_people=$8, status=$9, discount=$10, requires_invoice=$11,
-		tax_rate=$12, tax_amount=$13, total_amount=$14, location=$15, city=$16,
-		deposit_percent=$17, cancellation_days=$18, refund_percent=$19, notes=$20, photos=$21, updated_at=NOW()
+		service_type=$7, num_people=$8, status=$9, discount=$10, discount_type=$11, requires_invoice=$12,
+		tax_rate=$13, tax_amount=$14, total_amount=$15, location=$16, city=$17,
+		deposit_percent=$18, cancellation_days=$19, refund_percent=$20, notes=$21, photos=$22, updated_at=NOW()
 		WHERE id=$1 AND user_id=$2
 		RETURNING created_at, updated_at`
 	return r.pool.QueryRow(ctx, query,
 		e.ID, e.UserID, e.ClientID, e.EventDate, startTime, endTime,
-		e.ServiceType, e.NumPeople, e.Status, e.Discount, e.RequiresInvoice,
+		e.ServiceType, e.NumPeople, e.Status, e.Discount, e.DiscountType, e.RequiresInvoice,
 		e.TaxRate, e.TaxAmount, e.TotalAmount, e.Location, e.City,
 		e.DepositPercent, e.CancellationDays, e.RefundPercent, e.Notes, e.Photos,
 	).Scan(&e.CreatedAt, &e.UpdatedAt)

--- a/mobile/src/screens/auth/LoginScreen.tsx
+++ b/mobile/src/screens/auth/LoginScreen.tsx
@@ -112,12 +112,12 @@ export default function LoginScreen({ navigation }: Props) {
       >
         {!isLandscapeTablet && (
           <>
-            <Text style={styles.title}>EventosApp</Text>
-            <Text style={styles.subtitle}>Inicia sesión en tu cuenta</Text>
+            <Text style={[styles.title, { color: palette.text }]}>EventosApp</Text>
+            <Text style={[styles.subtitle, { color: palette.textSecondary }]}>Inicia sesión en tu cuenta</Text>
           </>
         )}
         {isLandscapeTablet && (
-          <Text style={styles.formTitle}>Inicia sesión</Text>
+          <Text style={[styles.formTitle, { color: palette.textSecondary }]}>Inicia sesión</Text>
         )}
 
         {error && (

--- a/mobile/src/screens/auth/RegisterScreen.tsx
+++ b/mobile/src/screens/auth/RegisterScreen.tsx
@@ -117,12 +117,12 @@ export default function RegisterScreen({ navigation }: Props) {
       <View style={[styles.formCard, isTablet && styles.formCardTablet]}>
         {!isLandscapeTablet && (
           <>
-            <Text style={styles.title}>Crear Cuenta</Text>
-            <Text style={styles.subtitle}>Regístrate para empezar</Text>
+            <Text style={[styles.title, { color: palette.text }]}>Crear Cuenta</Text>
+            <Text style={[styles.subtitle, { color: palette.textSecondary }]}>Regístrate para empezar</Text>
           </>
         )}
         {isLandscapeTablet && (
-          <Text style={styles.formTitle}>Crear cuenta</Text>
+          <Text style={[styles.formTitle, { color: palette.textSecondary }]}>Crear cuenta</Text>
         )}
 
         {error && (

--- a/mobile/src/types/entities.ts
+++ b/mobile/src/types/entities.ts
@@ -63,6 +63,7 @@ export interface Event {
     num_people: number
     status: 'quoted' | 'confirmed' | 'completed' | 'cancelled'
     discount: number
+    discount_type: 'percent' | 'fixed'
     requires_invoice: boolean
     tax_rate: number
     tax_amount: number

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -192,7 +192,8 @@ export const EventForm: React.FC = () => {
         setIsLoading(true);
         const event = await eventService.getById(eventId);
         if (!event) throw new Error('Evento no encontrado');
-        
+
+        setDiscountType(event.discount_type || "percent");
         reset({
           client_id: event.client_id || "",
           event_date: event.event_date || "",
@@ -477,6 +478,7 @@ export const EventForm: React.FC = () => {
     try {
       const payload = {
         ...data,
+        discount_type: discountType,
         start_time: data.start_time?.trim() ? data.start_time : null,
         end_time: data.end_time?.trim() ? data.end_time : null,
         user_id: user.id,

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -72,6 +72,7 @@ export interface Event {
     num_people: number
     status: 'quoted' | 'confirmed' | 'completed' | 'cancelled'
     discount: number
+    discount_type: 'percent' | 'fixed'
     requires_invoice: boolean
     tax_rate: number
     tax_amount: number


### PR DESCRIPTION
Mobile auth screens:
- Apply palette.text / palette.textSecondary to title and subtitle Text elements in LoginScreen and RegisterScreen (were unstyled in dark mode)
- Replace hardcoded #666 in formTitle with palette.textSecondary override

EventForm / discount_type persistence:
- Add migration 020: discount_type VARCHAR(10) DEFAULT 'percent' to events
- Add DiscountType field to Go Event model
- Update event_repo SELECT fields, scanEvent, scanEventWithClient, INSERT and UPDATE queries to include discount_type
- Add discount_type to Event interface in web and mobile TypeScript types
- Set discountType state from event.discount_type when loading an existing event for editing, so reopening a fixed-discount event preserves the type
- Include discountType in the submit payload so it is saved on every save

https://claude.ai/code/session_01SnfXj95iLeJEYv5MzwGnwm