### PR TITLE
Update equipment suggestions to use EquipmentSuggestion type

### DIFF
--- a/web/src/pages/Events/components/EventEquipment.test.tsx
+++ b/web/src/pages/Events/components/EventEquipment.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { EventEquipment } from './EventEquipment';
-import { EquipmentConflict, InventoryItem } from '../../../types/entities';
+import { EquipmentConflict, EquipmentSuggestion, InventoryItem } from '../../../types/entities';
 
 // ===== Shared test data =====
 
@@ -40,11 +40,17 @@ const mockEquipmentInventory: InventoryItem[] = [
   },
 ];
 
+const mockSuggestions: EquipmentSuggestion[] = [
+  { id: 'eq-1', ingredient_name: 'Mantelería', current_stock: 20, unit: 'pzas', type: 'equipment', suggested_quantity: 5 },
+  { id: 'eq-2', ingredient_name: 'Sillas plegables', current_stock: 100, unit: 'pzas', type: 'equipment', suggested_quantity: 10 },
+  { id: 'eq-3', ingredient_name: 'Mesas redondas', current_stock: 15, unit: 'pzas', type: 'equipment', suggested_quantity: 2 },
+];
+
 const defaultProps = {
   equipmentInventory: mockEquipmentInventory,
   selectedEquipment: [] as { inventory_id: string; quantity: number; notes: string }[],
   conflicts: [] as EquipmentConflict[],
-  suggestions: [] as InventoryItem[],
+  suggestions: [] as EquipmentSuggestion[],
   onAddEquipment: vi.fn(),
   onRemoveEquipment: vi.fn(),
   onEquipmentChange: vi.fn(),
@@ -445,23 +451,23 @@ describe('EventEquipment', () => {
 
   it('renders suggestions when available', () => {
     renderComponent({
-      suggestions: [mockEquipmentInventory[0], mockEquipmentInventory[1]],
+      suggestions: [mockSuggestions[0], mockSuggestions[1]],
     });
 
     expect(screen.getByText('Equipo sugerido por tus productos')).toBeInTheDocument();
-    expect(screen.getByText('Mantelería')).toBeInTheDocument();
-    expect(screen.getByText('Sillas plegables')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Mantelería/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sillas plegables/i })).toBeInTheDocument();
   });
 
   it('calls onQuickAddSuggestion when clicking a suggestion', () => {
     const onQuickAddSuggestion = vi.fn();
     renderComponent({
-      suggestions: [mockEquipmentInventory[0]],
+      suggestions: [mockSuggestions[0]],
       onQuickAddSuggestion,
     });
 
-    fireEvent.click(screen.getByText('Mantelería'));
-    expect(onQuickAddSuggestion).toHaveBeenCalledWith('eq-1');
+    fireEvent.click(screen.getByRole('button', { name: /Mantelería/i }));
+    expect(onQuickAddSuggestion).toHaveBeenCalledWith('eq-1', 5);
   });
 
   it('does not show suggestions that are already selected', () => {
@@ -469,7 +475,7 @@ describe('EventEquipment', () => {
       selectedEquipment: [
         { inventory_id: 'eq-1', quantity: 5, notes: '' },
       ],
-      suggestions: [mockEquipmentInventory[0], mockEquipmentInventory[1]],
+      suggestions: [mockSuggestions[0], mockSuggestions[1]],
     });
 
     // Mantelería (eq-1) is already selected, should not appear as suggestion
@@ -496,7 +502,7 @@ describe('EventEquipment', () => {
       selectedEquipment: [
         { inventory_id: 'eq-1', quantity: 5, notes: '' },
       ],
-      suggestions: [mockEquipmentInventory[0]], // only eq-1, which is already selected
+      suggestions: [mockSuggestions[0]], // only eq-1, which is already selected
     });
 
     expect(screen.queryByText('Equipo sugerido por tus productos')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
Updated the EventEquipment component tests to use a new `EquipmentSuggestion` type instead of `InventoryItem` for equipment suggestions, and improved test assertions to use semantic queries.

## Key Changes
- Added import of `EquipmentSuggestion` type from entities
- Created `mockSuggestions` test data with proper `EquipmentSuggestion` structure including `suggested_quantity` field
- Updated `defaultProps.suggestions` type annotation from `InventoryItem[]` to `EquipmentSuggestion[]`
- Updated all suggestion-related test cases to use `mockSuggestions` instead of `mockEquipmentInventory`
- Improved test assertions by replacing text-based queries with semantic role-based queries (`getByRole('button')`)
- Updated `onQuickAddSuggestion` callback expectation to include the `suggested_quantity` parameter (5) in addition to the equipment ID

## Notable Details
- The `EquipmentSuggestion` type includes fields: `id`, `ingredient_name`, `current_stock`, `unit`, `type`, and `suggested_quantity`
- Test coverage remains the same, but now validates the correct data structure and callback parameters
- All suggestion-related tests (rendering, clicking, filtering already-selected items) have been updated consistently

https://claude.ai/code/session_01Xfxy65wqViKQM7M1FGKksE