### PR TITLE
Improve Stripe checkout error handling with customer ID retry

### DIFF
--- a/backend/internal/handlers/subscription_handler.go
+++ b/backend/internal/handlers/subscription_handler.go
@@ -101,9 +101,22 @@ func (h *SubscriptionHandler) CreateCheckoutSession(w http.ResponseWriter, r *ht
 
 	s, err := session.New(params)
 	if err != nil {
-		slog.Error("Failed to create checkout session", "error", err)
-		writeError(w, http.StatusInternalServerError, "Failed to create checkout session")
-		return
+		slog.Error("Failed to create checkout session", "error", err, "user_id", userID)
+
+		// If we used a stored customer ID and it failed, retry with just the email.
+		// This handles stale/invalid customer IDs (e.g., test-mode IDs used in live mode).
+		if user.StripeCustomerID != nil && *user.StripeCustomerID != "" {
+			slog.Warn("Retrying checkout session without stored Stripe customer ID", "user_id", userID, "stripe_customer_id", *user.StripeCustomerID)
+			params.Customer = nil
+			params.CustomerEmail = stripe.String(user.Email)
+			s, err = session.New(params)
+		}
+
+		if err != nil {
+			slog.Error("Failed to create checkout session after retry", "error", err, "user_id", userID)
+			writeError(w, http.StatusInternalServerError, "Failed to create checkout session: "+err.Error())
+			return
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{

--- a/web/src/pages/Pricing.tsx
+++ b/web/src/pages/Pricing.tsx
@@ -19,7 +19,8 @@ export const Pricing: React.FC = () => {
       }
     } catch (err: unknown) {
       logError('Failed to create checkout session', err);
-      setError('Hubo un error al iniciar el proceso de pago. Por favor intenta nuevamente.');
+      const detail = err instanceof Error ? err.message : '';
+      setError('Hubo un error al iniciar el proceso de pago. Por favor intenta nuevamente.' + (detail ? ` (${detail})` : ''));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
Enhanced error handling for Stripe checkout session creation by implementing a retry mechanism when using stale or invalid stored customer IDs, and improved error messaging to users.

## Key Changes
- **Backend (subscription_handler.go)**:
  - Added retry logic when checkout session creation fails with a stored Stripe customer ID
  - If initial session creation fails and a customer ID is present, the handler now retries with just the customer email instead
  - This handles cases where stored customer IDs are invalid (e.g., test-mode IDs used in live mode)
  - Enhanced logging with user_id context for better debugging
  - Improved error messages to include error details

- **Frontend (Pricing.tsx)**:
  - Updated error handling to extract and display error details from the server response
  - Error messages now include the specific error reason when available, providing better user feedback

## Implementation Details
The retry mechanism gracefully degrades from using a stored customer ID to using just the customer email, which is more resilient to Stripe account mode mismatches and stale customer references. This reduces checkout failures without requiring user intervention or account cleanup.

https://claude.ai/code/session_01VVTttxzyU8tTYTt83kPAj6