### PR TITLE
fix(mobile): prevent NaN in numeric form fields when cleared

### DIFF
--- a/mobile/src/screens/catalog/InventoryFormScreen.tsx
+++ b/mobile/src/screens/catalog/InventoryFormScreen.tsx
@@ -238,8 +238,8 @@ export default function InventoryFormScreen({ navigation, route }: Props) {
               <FormInput
                 label="Stock Actual"
                 placeholder="0"
-                value={value?.toString() || "0"}
-                onChangeText={onChange}
+                value={value != null && !isNaN(Number(value)) ? String(value) : "0"}
+                onChangeText={(v) => onChange(parseFloat(v) || 0)}
                 onBlur={onBlur}
                 error={errors.current_stock?.message}
                 keyboardType="decimal-pad"
@@ -254,8 +254,8 @@ export default function InventoryFormScreen({ navigation, route }: Props) {
               <FormInput
                 label="Stock Mínimo (Alerta)"
                 placeholder="0"
-                value={value?.toString() || "0"}
-                onChangeText={onChange}
+                value={value != null && !isNaN(Number(value)) ? String(value) : "0"}
+                onChangeText={(v) => onChange(parseFloat(v) || 0)}
                 onBlur={onBlur}
                 error={errors.minimum_stock?.message}
                 keyboardType="decimal-pad"

--- a/mobile/src/screens/catalog/ProductFormScreen.tsx
+++ b/mobile/src/screens/catalog/ProductFormScreen.tsx
@@ -347,8 +347,8 @@ export default function ProductFormScreen({ navigation, route }: Props) {
               <FormInput
                 label="Precio Base"
                 placeholder="0.00"
-                value={value?.toString() || ""}
-                onChangeText={onChange}
+                value={value != null && !isNaN(Number(value)) ? String(value) : "0"}
+                onChangeText={(v) => onChange(parseFloat(v) || 0)}
                 onBlur={onBlur}
                 error={errors.base_price?.message}
                 keyboardType="decimal-pad"


### PR DESCRIPTION
Numeric fields in InventoryFormScreen (current_stock, minimum_stock) and ProductFormScreen (base_price) passed raw strings to React Hook Form via onChangeText={onChange}. When cleared, the empty string caused NaN when displayed with .toString(). Now all numeric Controller fields convert input to number with parseFloat(v) || 0 and guard the display value against NaN.

https://claude.ai/code/session_01UK18qKNyrQHEfRouHUZN5X