### PR TITLE
fix(mobile): drawer Settings link now always opens Settings screen

### DIFF
--- a/mobile/src/components/navigation/CustomDrawerContent.tsx
+++ b/mobile/src/components/navigation/CustomDrawerContent.tsx
@@ -176,7 +176,10 @@ export default function CustomDrawerContent(props: DrawerContentComponentProps) 
         <DrawerItem
           label="Configuración"
           icon={<Settings size={iconSize} color={activeRoute === "SettingsStack" ? palette.primary : palette.textSecondary} />}
-          onPress={() => navigateToScreen("SettingsStack")}
+          onPress={() => {
+            navigation.navigate("SettingsStack", { screen: "Settings" });
+            navigation.closeDrawer();
+          }}
           isActive={activeRoute === "SettingsStack"}
           palette={palette}
         />


### PR DESCRIPTION
When navigating to SettingsStack from the drawer, explicitly target the "Settings" screen so the stack resets instead of showing the last visited screen (e.g. Pricing).

https://claude.ai/code/session_01JBzRqt5DKhHvUshqf9WECB