### PR TITLE
fix(auth): add direct password change from settings (web + mobile)

### DIFF
--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -361,6 +361,68 @@ func (h *AuthHandler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// ChangePassword handles POST /api/auth/change-password (authenticated)
+func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+
+	var req struct {
+		CurrentPassword string `json:"current_password"`
+		NewPassword     string `json:"new_password"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if req.CurrentPassword == "" || req.NewPassword == "" {
+		writeError(w, http.StatusBadRequest, "Current password and new password are required")
+		return
+	}
+
+	if len(req.NewPassword) < 6 {
+		writeError(w, http.StatusBadRequest, "New password must be at least 6 characters")
+		return
+	}
+
+	if len(req.NewPassword) > 128 {
+		writeError(w, http.StatusBadRequest, "New password must not exceed 128 characters")
+		return
+	}
+
+	// Get user to verify current password
+	user, err := h.userRepo.GetByID(r.Context(), userID)
+	if err != nil || user == nil {
+		writeError(w, http.StatusNotFound, "User not found")
+		return
+	}
+
+	// Verify current password
+	if !h.authService.CheckPassword(req.CurrentPassword, user.PasswordHash) {
+		writeError(w, http.StatusUnauthorized, "Current password is incorrect")
+		return
+	}
+
+	// Hash new password
+	hash, err := h.authService.HashPassword(req.NewPassword)
+	if err != nil {
+		slog.Error("Failed to hash password", "error", err)
+		writeError(w, http.StatusInternalServerError, "Internal server error")
+		return
+	}
+
+	// Update password
+	if err := h.userRepo.UpdatePassword(r.Context(), userID, hash); err != nil {
+		slog.Error("Failed to update password", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to update password")
+		return
+	}
+
+	slog.Info("Password changed successfully", "user_id", userID)
+	writeJSON(w, http.StatusOK, map[string]string{
+		"message": "Password changed successfully",
+	})
+}
+
 // UpdateProfile handles PUT /api/users/me
 func (h *AuthHandler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 	userID := middleware.GetUserID(r.Context())

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -48,6 +48,7 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 			r.Group(func(r chi.Router) {
 				r.Use(mw.Auth(authService))
 				r.Get("/me", authHandler.Me)
+				r.Post("/change-password", authHandler.ChangePassword)
 			})
 		})
 

--- a/mobile/src/navigation/SettingsStack.tsx
+++ b/mobile/src/navigation/SettingsStack.tsx
@@ -3,6 +3,7 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { SettingsStackParamList } from "../types/navigation";
 import SettingsScreen from "../screens/profile/SettingsScreen";
 import EditProfileScreen from "../screens/profile/EditProfileScreen";
+import ChangePasswordScreen from "../screens/profile/ChangePasswordScreen";
 import BusinessSettingsScreen from "../screens/profile/BusinessSettingsScreen";
 import ContractDefaultsScreen from "../screens/profile/ContractDefaultsScreen";
 import PricingScreen from "../screens/profile/PricingScreen";
@@ -32,6 +33,11 @@ export default function SettingsStack() {
         name="EditProfile"
         component={EditProfileScreen}
         options={{ title: "Editar Perfil" }}
+      />
+      <Stack.Screen
+        name="ChangePassword"
+        component={ChangePasswordScreen}
+        options={{ title: "Cambiar Contraseña" }}
       />
       <Stack.Screen
         name="BusinessSettings"

--- a/mobile/src/screens/profile/ChangePasswordScreen.tsx
+++ b/mobile/src/screens/profile/ChangePasswordScreen.tsx
@@ -1,0 +1,159 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { Save } from "lucide-react-native";
+import { SettingsStackParamList } from "../../types/navigation";
+import { useToast } from "../../hooks/useToast";
+import { api } from "../../lib/api";
+import { FormInput } from "../../components/shared";
+import { useTheme } from "../../hooks/useTheme";
+import { colors } from "../../theme/colors";
+import { spacing } from "../../theme/spacing";
+import { typography } from "../../theme/typography";
+
+type Props = NativeStackScreenProps<SettingsStackParamList, "ChangePassword">;
+
+export default function ChangePasswordScreen({ navigation }: Props) {
+  const addToast = useToast((s) => s.addToast);
+  const { isDark } = useTheme();
+  const palette = isDark ? colors.dark : colors.light;
+  const styles = getStyles(palette);
+  const [submitting, setSubmitting] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const handleSubmit = async () => {
+    if (!currentPassword || !newPassword) {
+      addToast("Completa todos los campos", "error");
+      return;
+    }
+    if (newPassword.length < 6) {
+      addToast("La nueva contraseña debe tener al menos 6 caracteres", "error");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      addToast("Las contraseñas no coinciden", "error");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await api.post("/auth/change-password", {
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      addToast("Contraseña actualizada correctamente", "success");
+      navigation.goBack();
+    } catch (error: any) {
+      const msg = error?.message?.includes("incorrect")
+        ? "La contraseña actual es incorrecta"
+        : "Error al cambiar la contraseña";
+      addToast(msg, "error");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={[]}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={{ flex: 1 }}
+      >
+        <ScrollView contentContainerStyle={styles.content}>
+          <Text style={styles.description}>
+            Ingresa tu contraseña actual y elige una nueva contraseña.
+          </Text>
+
+          <View style={styles.form}>
+            <FormInput
+              label="Contraseña actual"
+              value={currentPassword}
+              onChangeText={setCurrentPassword}
+              secureTextEntry
+              placeholder="Ingresa tu contraseña actual"
+            />
+            <FormInput
+              label="Nueva contraseña"
+              value={newPassword}
+              onChangeText={setNewPassword}
+              secureTextEntry
+              placeholder="Mínimo 6 caracteres"
+            />
+            <FormInput
+              label="Confirmar nueva contraseña"
+              value={confirmPassword}
+              onChangeText={setConfirmPassword}
+              secureTextEntry
+              placeholder="Repite la nueva contraseña"
+            />
+          </View>
+
+          <TouchableOpacity
+            style={[styles.button, submitting && styles.buttonDisabled]}
+            onPress={handleSubmit}
+            disabled={submitting}
+            activeOpacity={0.8}
+          >
+            {submitting ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <>
+                <Save color="#fff" size={18} />
+                <Text style={styles.buttonText}>Guardar</Text>
+              </>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const getStyles = (palette: typeof colors.light) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: palette.surfaceGrouped,
+    },
+    content: {
+      padding: spacing.lg,
+    },
+    description: {
+      ...typography.body,
+      color: palette.textSecondary,
+      marginBottom: spacing.lg,
+    },
+    form: {
+      gap: spacing.md,
+      marginBottom: spacing.xl,
+    },
+    button: {
+      backgroundColor: palette.primary,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: spacing.xs,
+      paddingVertical: spacing.md,
+      borderRadius: spacing.borderRadius.md,
+    },
+    buttonDisabled: {
+      opacity: 0.6,
+    },
+    buttonText: {
+      ...typography.body,
+      color: "#fff",
+      fontWeight: "600",
+    },
+  });

--- a/mobile/src/screens/profile/SettingsScreen.tsx
+++ b/mobile/src/screens/profile/SettingsScreen.tsx
@@ -100,7 +100,6 @@ export default function SettingsScreen() {
   const [showLogout, setShowLogout] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [restoring, setRestoring] = useState(false);
-  const [sendingPasswordReset, setSendingPasswordReset] = useState(false);
   const {
     eventsThisMonth,
     limit: eventLimit,
@@ -111,17 +110,8 @@ export default function SettingsScreen() {
 
   const planIsPro = user?.plan === "pro" || user?.plan === "premium";
 
-  const handleChangePassword = async () => {
-    if (!user?.email) return;
-    setSendingPasswordReset(true);
-    try {
-      await api.post("/auth/forgot-password", { email: user.email });
-      addToast("Revisa tu correo para cambiar la contraseña", "success");
-    } catch {
-      addToast("Error al enviar el correo", "error");
-    } finally {
-      setSendingPasswordReset(false);
-    }
+  const handleChangePassword = () => {
+    navigation.navigate("ChangePassword" as any);
   };
 
   const handleRestore = async () => {
@@ -188,17 +178,10 @@ export default function SettingsScreen() {
             trailing={chevron}
           />
           <SettingsRow
-            icon={
-              sendingPasswordReset ? (
-                <ActivityIndicator color={palette.textTertiary} size={20} />
-              ) : (
-                <Lock color={palette.textTertiary} size={20} />
-              )
-            }
+            icon={<Lock color={palette.textTertiary} size={20} />}
             label="Cambiar Contraseña"
-            subtitle="Te enviaremos instrucciones por correo"
             onPress={handleChangePassword}
-            disabled={sendingPasswordReset}
+            trailing={chevron}
           />
           <SettingsRow
             icon={<CreditCard color={palette.textTertiary} size={20} />}

--- a/mobile/src/types/navigation.ts
+++ b/mobile/src/types/navigation.ts
@@ -59,6 +59,7 @@ export type InventoryStackParamList = {
 export type SettingsStackParamList = {
     Settings: undefined;
     EditProfile: undefined;
+    ChangePassword: undefined;
     BusinessSettings: undefined;
     ContractDefaults: undefined;
     Pricing: undefined;

--- a/web/src/pages/Settings.tsx
+++ b/web/src/pages/Settings.tsx
@@ -78,6 +78,10 @@ export const Settings: React.FC = () => {
   const initialTab = searchParams.get("tab") === "subscription" ? "subscription" : "profile";
   const [activeTab, setActiveTab] = useState<"profile" | "business" | "subscription" | "contracts">(initialTab);
   const [isSendingPasswordReset, setIsSendingPasswordReset] = useState(false);
+  const [showPasswordForm, setShowPasswordForm] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
 
   useEffect(() => {
     if (profile) {
@@ -171,13 +175,34 @@ export const Settings: React.FC = () => {
   };
 
   const handleChangePassword = async () => {
-    if (!profile?.email) return;
+    if (!currentPassword || !newPassword) {
+      addToast("Completa todos los campos", "error");
+      return;
+    }
+    if (newPassword.length < 6) {
+      addToast("La nueva contraseña debe tener al menos 6 caracteres", "error");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      addToast("Las contraseñas no coinciden", "error");
+      return;
+    }
     setIsSendingPasswordReset(true);
     try {
-      await api.post("/auth/forgot-password", { email: profile.email });
-      addToast("Revisa tu correo para cambiar la contraseña", "success");
-    } catch {
-      addToast("Error al enviar el correo de recuperación", "error");
+      await api.post("/auth/change-password", {
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      addToast("Contraseña actualizada correctamente", "success");
+      setShowPasswordForm(false);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+    } catch (error: any) {
+      const msg = error?.message?.includes("incorrect")
+        ? "La contraseña actual es incorrecta"
+        : "Error al cambiar la contraseña";
+      addToast(msg, "error");
     } finally {
       setIsSendingPasswordReset(false);
     }
@@ -265,14 +290,62 @@ export const Settings: React.FC = () => {
                 </div>
               </div>
 
-              <div className="pt-6 border-t border-border flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                <button
-                  onClick={handleChangePassword}
-                  disabled={isSendingPasswordReset}
-                  className="flex items-center gap-2 text-primary font-bold hover:gap-3 transition-all disabled:opacity-50"
-                >
-                  {isSendingPasswordReset ? "Enviando..." : "Cambiar contraseña"} <ExternalLink className="h-4 w-4" />
-                </button>
+              <div className="pt-6 border-t border-border space-y-4">
+                {!showPasswordForm ? (
+                  <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                    <button
+                      onClick={() => setShowPasswordForm(true)}
+                      className="flex items-center gap-2 text-primary font-bold hover:gap-3 transition-all"
+                    >
+                      Cambiar contraseña <Shield className="h-4 w-4" />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="space-y-4 max-w-md">
+                    <h4 className="font-bold text-text">Cambiar contraseña</h4>
+                    <input
+                      type="password"
+                      placeholder="Contraseña actual"
+                      value={currentPassword}
+                      onChange={(e) => setCurrentPassword(e.target.value)}
+                      className="w-full bg-surface border border-border rounded-xl px-4 py-3 focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+                    />
+                    <input
+                      type="password"
+                      placeholder="Nueva contraseña (mín. 6 caracteres)"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                      className="w-full bg-surface border border-border rounded-xl px-4 py-3 focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+                    />
+                    <input
+                      type="password"
+                      placeholder="Confirmar nueva contraseña"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      className="w-full bg-surface border border-border rounded-xl px-4 py-3 focus:ring-2 focus:ring-primary/20 focus:border-primary outline-none"
+                    />
+                    <div className="flex gap-3">
+                      <button
+                        onClick={handleChangePassword}
+                        disabled={isSendingPasswordReset}
+                        className="bg-primary text-white font-medium px-4 py-2 rounded-md hover:bg-primary-dark transition-colors shadow-sm disabled:opacity-50"
+                      >
+                        {isSendingPasswordReset ? "Guardando..." : "Guardar"}
+                      </button>
+                      <button
+                        onClick={() => {
+                          setShowPasswordForm(false);
+                          setCurrentPassword("");
+                          setNewPassword("");
+                          setConfirmPassword("");
+                        }}
+                        className="bg-surface-alt text-text font-bold px-4 py-2 rounded-xl border border-border hover:bg-border transition-all"
+                      >
+                        Cancelar
+                      </button>
+                    </div>
+                  </div>
+                )}
                 <div className="flex items-center justify-between sm:justify-end gap-4">
                   <div>
                     <p className="font-bold text-text text-sm">Modo Oscuro</p>


### PR DESCRIPTION
Replace the forgot-password email flow in Settings with a direct password change form (current password + new password). This fixes the non-functional password change button that relied on Resend email delivery which requires domain verification.

- Add POST /api/auth/change-password backend endpoint (authenticated)
- Web: inline password change form in Settings profile tab
- Mobile: new ChangePasswordScreen with navigation from Settings

https://claude.ai/code/session_017iSLfqw4RbKQhpNjSsF6Z7