### PR TITLE
feat: add HTML visual designs for marketing campaign

### DIFF
--- a/marketing/campaigns/tu-evento-sin-limites/designs/01-lanzamiento.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/01-lanzamiento.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Post Lanzamiento — Tu Evento, Sin Límites</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700&display=swap');
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background: #333;
+    font-family: 'Montserrat', sans-serif;
+  }
+
+  .post {
+    width: 1080px;
+    height: 1080px;
+    background: #1B2A4A;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Geometric background lines */
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background:
+      linear-gradient(135deg, transparent 40%, rgba(201,169,110,0.06) 40%, rgba(201,169,110,0.06) 40.5%, transparent 40.5%),
+      linear-gradient(135deg, transparent 60%, rgba(201,169,110,0.06) 60%, rgba(201,169,110,0.06) 60.5%, transparent 60.5%),
+      linear-gradient(45deg, transparent 45%, rgba(201,169,110,0.04) 45%, rgba(201,169,110,0.04) 45.5%, transparent 45.5%),
+      linear-gradient(45deg, transparent 55%, rgba(201,169,110,0.04) 55%, rgba(201,169,110,0.04) 55.5%, transparent 55.5%);
+    pointer-events: none;
+  }
+
+  /* Corner sparkles */
+  .sparkle {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background: radial-gradient(circle, rgba(201,169,110,0.6) 0%, transparent 70%);
+  }
+  .sparkle.tl { top: 40px; left: 40px; width: 30px; height: 30px; }
+  .sparkle.tr { top: 40px; right: 40px; width: 25px; height: 25px; }
+  .sparkle.bl { bottom: 40px; left: 40px; width: 25px; height: 25px; }
+  .sparkle.br { bottom: 40px; right: 40px; width: 30px; height: 30px; }
+  .sparkle.m1 { top: 120px; right: 100px; width: 15px; height: 15px; }
+  .sparkle.m2 { bottom: 150px; left: 80px; width: 18px; height: 18px; }
+
+  /* Decorative border */
+  .border-frame {
+    position: absolute;
+    top: 20px; left: 20px; right: 20px; bottom: 20px;
+    border: 1px solid rgba(201,169,110,0.15);
+    pointer-events: none;
+  }
+
+  .content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 60px;
+    width: 100%;
+  }
+
+  .logo {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 42px;
+    color: #C9A96E;
+    letter-spacing: 8px;
+    margin-bottom: 12px;
+  }
+
+  .logo-sub {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 13px;
+    color: rgba(201,169,110,0.7);
+    letter-spacing: 12px;
+    text-transform: uppercase;
+    margin-bottom: 60px;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 64px;
+    color: #C9A96E;
+    line-height: 1.15;
+    margin-bottom: 24px;
+    letter-spacing: 3px;
+  }
+
+  .subtitle {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 300;
+    font-size: 28px;
+    color: #FAF6F0;
+    margin-bottom: 50px;
+    letter-spacing: 1px;
+  }
+
+  .divider {
+    width: 200px;
+    height: 1px;
+    background: linear-gradient(to right, transparent, #C9A96E, transparent);
+    margin-bottom: 50px;
+  }
+
+  .promo-box {
+    background: rgba(201,169,110,0.1);
+    border: 1px solid rgba(201,169,110,0.3);
+    padding: 28px 50px;
+    border-radius: 4px;
+    margin-bottom: 30px;
+  }
+
+  .promo-label {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 14px;
+    color: #C9A96E;
+    letter-spacing: 4px;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+  }
+
+  .promo-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 22px;
+    color: #FAF6F0;
+    line-height: 1.5;
+  }
+
+  .promo-text span {
+    color: #C9A96E;
+    font-weight: 700;
+  }
+
+  .url {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 18px;
+    color: rgba(250,246,240,0.6);
+    letter-spacing: 2px;
+    margin-top: 10px;
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="border-frame"></div>
+    <div class="sparkle tl"></div>
+    <div class="sparkle tr"></div>
+    <div class="sparkle bl"></div>
+    <div class="sparkle br"></div>
+    <div class="sparkle m1"></div>
+    <div class="sparkle m2"></div>
+
+    <div class="content">
+      <div class="logo">SOLENNIX</div>
+      <div class="logo-sub">Cada Detalle Importa</div>
+
+      <div class="title">TU EVENTO,<br>SIN LÍMITES</div>
+
+      <div class="subtitle">Organiza como Pro. Empieza gratis.</div>
+
+      <div class="divider"></div>
+
+      <div class="promo-box">
+        <div class="promo-label">🔥 Promo de Lanzamiento</div>
+        <div class="promo-text">
+          <span>20 CUENTAS PRO GRATIS</span><br>
+          Primeros en registrarse ganan
+        </div>
+      </div>
+
+      <div class="url">solennix.com</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/02-promo-primeros-20.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/02-promo-primeros-20.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Post Promo Primeros 20 — Solennix</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700;800&display=swap');
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background: #333;
+  }
+
+  .post {
+    width: 1080px;
+    height: 1080px;
+    background: linear-gradient(160deg, #1B2A4A 0%, #2A3A5A 100%);
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Subtle geometric pattern */
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background:
+      radial-gradient(circle at 20% 20%, rgba(201,169,110,0.08) 0%, transparent 40%),
+      radial-gradient(circle at 80% 80%, rgba(201,169,110,0.06) 0%, transparent 40%);
+    pointer-events: none;
+  }
+
+  .border-frame {
+    position: absolute;
+    top: 24px; left: 24px; right: 24px; bottom: 24px;
+    border: 1px solid rgba(201,169,110,0.12);
+  }
+
+  .content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 60px;
+    width: 100%;
+  }
+
+  .fire-icon {
+    font-size: 72px;
+    margin-bottom: 30px;
+    filter: drop-shadow(0 0 20px rgba(201,169,110,0.4));
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 52px;
+    color: #C9A96E;
+    line-height: 1.2;
+    margin-bottom: 12px;
+    letter-spacing: 2px;
+  }
+
+  .title-accent {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 58px;
+    color: #C9A96E;
+    margin-bottom: 50px;
+    letter-spacing: 3px;
+    text-shadow: 0 0 40px rgba(201,169,110,0.3);
+  }
+
+  .cards {
+    display: flex;
+    gap: 30px;
+    margin-bottom: 50px;
+  }
+
+  .card {
+    width: 380px;
+    background: rgba(201,169,110,0.08);
+    border: 1.5px solid rgba(201,169,110,0.35);
+    border-radius: 12px;
+    padding: 40px 30px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: linear-gradient(to right, transparent, #C9A96E, transparent);
+  }
+
+  .card-medal {
+    font-size: 48px;
+    margin-bottom: 16px;
+  }
+
+  .card-range {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 32px;
+    color: #C9A96E;
+    margin-bottom: 8px;
+  }
+
+  .card-duration {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 46px;
+    color: #FAF6F0;
+    line-height: 1.1;
+    margin-bottom: 6px;
+  }
+
+  .card-plan {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 22px;
+    color: #C9A96E;
+    letter-spacing: 3px;
+    margin-bottom: 16px;
+  }
+
+  .card-value {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 16px;
+    color: rgba(250,246,240,0.5);
+  }
+
+  .cta-bar {
+    background: rgba(201,169,110,0.15);
+    border: 1px solid rgba(201,169,110,0.3);
+    padding: 20px 50px;
+    border-radius: 50px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .cta-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 22px;
+    color: #FAF6F0;
+  }
+
+  .cta-arrow {
+    font-size: 24px;
+    color: #C9A96E;
+  }
+
+  .cta-url {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 22px;
+    color: #C9A96E;
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="border-frame"></div>
+
+    <div class="content">
+      <div class="fire-icon">🔥</div>
+
+      <div class="title">LOS PRIMEROS 20 GANAN</div>
+      <div class="title-accent">PRO GRATIS</div>
+
+      <div class="cards">
+        <div class="card">
+          <div class="card-medal">🥇</div>
+          <div class="card-range">Lugares 1 — 10</div>
+          <div class="card-duration">6 MESES</div>
+          <div class="card-plan">PRO</div>
+          <div class="card-value">Valor: $894 MXN</div>
+        </div>
+
+        <div class="card">
+          <div class="card-medal">🥈</div>
+          <div class="card-range">Lugares 11 — 20</div>
+          <div class="card-duration">3 MESES</div>
+          <div class="card-plan">PRO</div>
+          <div class="card-value">Valor: $447 MXN</div>
+        </div>
+      </div>
+
+      <div class="cta-bar">
+        <span class="cta-text">Regístrate ya</span>
+        <span class="cta-arrow">→</span>
+        <span class="cta-url">solennix.com</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide1.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide1.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Carrusel Free vs Pro — Slide 1 (Cover)</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .post {
+    width: 1080px; height: 1080px;
+    background: #1B2A4A;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+  }
+
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: radial-gradient(ellipse at center, rgba(201,169,110,0.08) 0%, transparent 60%);
+  }
+
+  .border-frame {
+    position: absolute;
+    top: 24px; left: 24px; right: 24px; bottom: 24px;
+    border: 1px solid rgba(201,169,110,0.12);
+  }
+
+  .content {
+    position: relative; z-index: 2;
+    display: flex; flex-direction: column;
+    align-items: center; text-align: center;
+  }
+
+  .vs-badge {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 300;
+    font-size: 24px;
+    color: rgba(250,246,240,0.5);
+    letter-spacing: 6px;
+    text-transform: uppercase;
+    margin-bottom: 30px;
+  }
+
+  .title-free {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 110px;
+    color: #FAF6F0;
+    letter-spacing: 8px;
+    line-height: 1;
+  }
+
+  .title-vs {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 300;
+    font-size: 36px;
+    color: rgba(201,169,110,0.6);
+    margin: 15px 0;
+    letter-spacing: 10px;
+  }
+
+  .title-pro {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 110px;
+    color: #C9A96E;
+    letter-spacing: 8px;
+    line-height: 1;
+    text-shadow: 0 0 40px rgba(201,169,110,0.3);
+  }
+
+  .question {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 28px;
+    color: #FAF6F0;
+    margin-top: 50px;
+  }
+
+  .swipe {
+    position: absolute;
+    bottom: 60px;
+    right: 60px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 18px;
+    color: #C9A96E;
+    letter-spacing: 2px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .swipe-arrow {
+    font-size: 24px;
+    animation: slideRight 1.5s infinite;
+  }
+
+  @keyframes slideRight {
+    0%, 100% { transform: translateX(0); }
+    50% { transform: translateX(10px); }
+  }
+
+  .logo-small {
+    position: absolute;
+    top: 50px;
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 20px;
+    color: rgba(201,169,110,0.5);
+    letter-spacing: 6px;
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="border-frame"></div>
+    <div class="logo-small">SOLENNIX</div>
+
+    <div class="content">
+      <div class="title-free">FREE</div>
+      <div class="title-vs">vs</div>
+      <div class="title-pro">PRO</div>
+      <div class="question">¿Cuál es para ti?</div>
+    </div>
+
+    <div class="swipe">Desliza <span class="swipe-arrow">→</span></div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide2.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide2.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Carrusel Free vs Pro — Slide 2 (Plan Free)</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700;800&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .post {
+    width: 1080px; height: 1080px;
+    background: #FAF6F0;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    padding: 70px;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 50px;
+  }
+
+  .header-title {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 48px;
+    color: #1B2A4A;
+    letter-spacing: 3px;
+  }
+
+  .badge {
+    background: #C9A96E;
+    color: #1B2A4A;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 18px;
+    padding: 8px 24px;
+    border-radius: 50px;
+    letter-spacing: 2px;
+  }
+
+  .features {
+    width: 100%;
+    max-width: 700px;
+  }
+
+  .feature {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 18px 0;
+    border-bottom: 1px solid rgba(27,42,74,0.08);
+  }
+
+  .feature:last-child { border-bottom: none; }
+
+  .check {
+    width: 36px;
+    height: 36px;
+    background: rgba(201,169,110,0.15);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+    color: #C9A96E;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .feature-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+    font-size: 26px;
+    color: #1B2A4A;
+  }
+
+  .feature-text span {
+    font-weight: 700;
+    color: #C9A96E;
+  }
+
+  .footer-note {
+    margin-top: 40px;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 18px;
+    color: rgba(27,42,74,0.5);
+    text-align: center;
+  }
+
+  .logo-small {
+    position: absolute;
+    bottom: 40px;
+    right: 50px;
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 16px;
+    color: rgba(27,42,74,0.25);
+    letter-spacing: 4px;
+  }
+
+  /* Gold accent line at top */
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 4px;
+    background: linear-gradient(to right, transparent, #C9A96E, transparent);
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="header">
+      <div class="header-title">PLAN GRATUITO</div>
+      <div class="badge">GRATIS</div>
+    </div>
+
+    <div class="features">
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text"><span>3</span> eventos al mes</div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text"><span>50</span> clientes registrados</div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text"><span>20</span> productos en catálogo</div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Cotizaciones y contratos en <span>PDF</span></div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Listas de compras automáticas</div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Calendario de eventos</div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Dashboard con <span>KPIs</span></div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">App móvil <span>iOS + Android</span></div>
+      </div>
+    </div>
+
+    <div class="footer-note">Sin tarjeta de crédito · Sin límite de tiempo · Para siempre</div>
+    <div class="logo-small">SOLENNIX</div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide3.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide3.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Carrusel Free vs Pro — Slide 3 (Plan Pro)</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700;800&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .post {
+    width: 1080px; height: 1080px;
+    background: #1B2A4A;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    padding: 70px;
+  }
+
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: radial-gradient(ellipse at 50% 30%, rgba(201,169,110,0.1) 0%, transparent 50%);
+  }
+
+  .post::after {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 4px;
+    background: linear-gradient(to right, transparent, #C9A96E, transparent);
+  }
+
+  .header {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 50px;
+  }
+
+  .header-title {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 48px;
+    color: #C9A96E;
+    letter-spacing: 3px;
+    text-shadow: 0 0 30px rgba(201,169,110,0.3);
+  }
+
+  .badge {
+    background: #C9A96E;
+    color: #1B2A4A;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 16px;
+    padding: 8px 20px;
+    border-radius: 50px;
+    letter-spacing: 1px;
+  }
+
+  .features {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    max-width: 700px;
+  }
+
+  .feature {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+    padding: 18px 0;
+    border-bottom: 1px solid rgba(201,169,110,0.1);
+  }
+  .feature:last-child { border-bottom: none; }
+
+  .check {
+    width: 36px; height: 36px;
+    background: rgba(201,169,110,0.2);
+    border: 1px solid rgba(201,169,110,0.4);
+    border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px; color: #C9A96E; font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .feature-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+    font-size: 26px;
+    color: #FAF6F0;
+  }
+  .feature-text span {
+    font-weight: 700;
+    color: #C9A96E;
+  }
+
+  .promo-badge {
+    position: relative;
+    z-index: 2;
+    margin-top: 40px;
+    background: rgba(201,169,110,0.12);
+    border: 2px solid #C9A96E;
+    border-radius: 8px;
+    padding: 16px 36px;
+    text-align: center;
+  }
+
+  .promo-badge-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 20px;
+    color: #C9A96E;
+    letter-spacing: 2px;
+  }
+
+  .logo-small {
+    position: absolute;
+    bottom: 40px;
+    right: 50px;
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 16px;
+    color: rgba(201,169,110,0.3);
+    letter-spacing: 4px;
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="header">
+      <div class="header-title">PLAN PRO</div>
+      <div class="badge">$149/mes MXN</div>
+    </div>
+
+    <div class="features">
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Todo lo del plan gratuito</div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Eventos <span>ILIMITADOS</span></div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Clientes <span>ILIMITADOS</span></div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Catálogo <span>ILIMITADO</span></div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Analítica <span>avanzada</span></div>
+      </div>
+      <div class="feature">
+        <div class="check">✓</div>
+        <div class="feature-text">Soporte <span>prioritario</span></div>
+      </div>
+    </div>
+
+    <div class="promo-badge">
+      <div class="promo-badge-text">🔥 GANA HASTA 6 MESES GRATIS</div>
+    </div>
+
+    <div class="logo-small">SOLENNIX</div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide5.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/03-free-vs-pro-slide5.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Carrusel Free vs Pro — Slide 5 (CTA)</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700;800&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .post {
+    width: 1080px; height: 1080px;
+    background: #1B2A4A;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+  }
+
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: radial-gradient(ellipse at center, rgba(201,169,110,0.1) 0%, transparent 50%);
+  }
+
+  .content {
+    position: relative; z-index: 2;
+    display: flex; flex-direction: column;
+    align-items: center; text-align: center;
+    padding: 80px;
+  }
+
+  .tagline {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 48px;
+    color: #C9A96E;
+    line-height: 1.3;
+    margin-bottom: 40px;
+    letter-spacing: 2px;
+  }
+
+  .promo-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 26px;
+    color: #FAF6F0;
+    margin-bottom: 50px;
+    line-height: 1.5;
+  }
+  .promo-text span { color: #C9A96E; font-weight: 700; }
+
+  .url {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 52px;
+    color: #FAF6F0;
+    letter-spacing: 3px;
+    margin-bottom: 50px;
+  }
+
+  .logo {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 28px;
+    color: #C9A96E;
+    letter-spacing: 8px;
+  }
+
+  .logo-sub {
+    font-family: 'Montserrat', sans-serif;
+    font-size: 12px;
+    color: rgba(201,169,110,0.5);
+    letter-spacing: 8px;
+    text-transform: uppercase;
+    margin-top: 8px;
+  }
+
+  .divider {
+    width: 100px;
+    height: 1px;
+    background: linear-gradient(to right, transparent, #C9A96E, transparent);
+    margin: 30px 0;
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="content">
+      <div class="tagline">Empieza gratis.<br>Crece cuando<br>estés listo.</div>
+
+      <div class="promo-text">Los primeros <span>20</span> obtienen Pro <span>GRATIS</span></div>
+
+      <div class="url">solennix.com</div>
+
+      <div class="divider"></div>
+
+      <div class="logo">SOLENNIX</div>
+      <div class="logo-sub">Cada Detalle Importa</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/04-story-quedan-lugares.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/04-story-quedan-lugares.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Story — Quedan X Lugares</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700;800&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .story {
+    width: 1080px; height: 1920px;
+    background: #1B2A4A;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+  }
+
+  /* Radial glow behind number */
+  .story::before {
+    content: '';
+    position: absolute;
+    top: 35%; left: 50%;
+    transform: translate(-50%, -50%);
+    width: 500px; height: 500px;
+    background: radial-gradient(circle, rgba(201,169,110,0.15) 0%, transparent 60%);
+  }
+
+  .logo {
+    position: absolute;
+    top: 80px;
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 24px;
+    color: #C9A96E;
+    letter-spacing: 8px;
+  }
+
+  .content {
+    position: relative; z-index: 2;
+    display: flex; flex-direction: column;
+    align-items: center; text-align: center;
+    margin-top: -100px;
+  }
+
+  .big-number {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 280px;
+    color: #C9A96E;
+    line-height: 1;
+    text-shadow:
+      0 0 60px rgba(201,169,110,0.4),
+      0 0 120px rgba(201,169,110,0.2);
+  }
+
+  .label {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 40px;
+    color: #FAF6F0;
+    letter-spacing: 8px;
+    text-transform: uppercase;
+    margin-top: 10px;
+    margin-bottom: 80px;
+  }
+
+  /* Progress bar */
+  .progress-container {
+    width: 600px;
+    margin-bottom: 20px;
+  }
+
+  .progress-bar {
+    width: 100%;
+    height: 16px;
+    background: rgba(250,246,240,0.1);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .progress-fill {
+    /* Change width to match: (20 - remaining) / 20 * 100% */
+    /* Example: 13 of 20 taken = 65% */
+    width: 65%;
+    height: 100%;
+    background: linear-gradient(to right, #C9A96E, #d4b87e);
+    border-radius: 8px;
+    transition: width 0.5s;
+  }
+
+  .progress-label {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 20px;
+    color: rgba(250,246,240,0.5);
+    margin-top: 12px;
+    text-align: center;
+  }
+
+  .progress-label span {
+    color: #C9A96E;
+    font-weight: 700;
+  }
+
+  .prizes {
+    margin-top: 60px;
+    text-align: center;
+  }
+
+  .prize-line {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 500;
+    font-size: 22px;
+    color: rgba(250,246,240,0.7);
+    margin-bottom: 8px;
+  }
+  .prize-line span {
+    color: #C9A96E;
+    font-weight: 700;
+  }
+
+  .cta {
+    position: absolute;
+    bottom: 120px;
+    display: flex; flex-direction: column;
+    align-items: center; gap: 10px;
+  }
+
+  .cta-arrow {
+    font-size: 32px;
+    color: #C9A96E;
+    animation: bounce 1.5s infinite;
+  }
+
+  @keyframes bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
+  }
+
+  .cta-text {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 22px;
+    color: #C9A96E;
+    letter-spacing: 4px;
+  }
+</style>
+</head>
+<body>
+  <div class="story">
+    <div class="logo">SOLENNIX</div>
+
+    <div class="content">
+      <!-- CAMBIAR ESTE NÚMERO según lugares restantes -->
+      <div class="big-number">7</div>
+      <div class="label">Lugares Restantes</div>
+
+      <div class="progress-container">
+        <div class="progress-bar">
+          <!-- Cambiar width: 65% = 13 de 20 ocupados. Fórmula: ((20 - restantes) / 20) * 100 -->
+          <div class="progress-fill" style="width: 65%;"></div>
+        </div>
+        <div class="progress-label"><span>13</span> de 20 lugares ocupados</div>
+      </div>
+
+      <div class="prizes">
+        <div class="prize-line">🥇 Primeros 10 → <span>6 meses Pro GRATIS</span></div>
+        <div class="prize-line">🥈 Del 11 al 20 → <span>3 meses Pro GRATIS</span></div>
+      </div>
+    </div>
+
+    <div class="cta">
+      <div class="cta-arrow">↑</div>
+      <div class="cta-text">LINK EN BIO</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/05-story-testimonio.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/05-story-testimonio.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Story — Testimonio</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;500;600;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400;1,700&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .story {
+    width: 1080px; height: 1920px;
+    background: #FAF6F0;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+  }
+
+  /* Subtle paper texture */
+  .story::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background:
+      radial-gradient(circle at 30% 20%, rgba(201,169,110,0.05) 0%, transparent 40%),
+      radial-gradient(circle at 70% 80%, rgba(27,42,74,0.03) 0%, transparent 40%);
+  }
+
+  .content {
+    position: relative; z-index: 2;
+    display: flex; flex-direction: column;
+    align-items: center; text-align: center;
+    padding: 80px 100px;
+    width: 100%;
+  }
+
+  .quote-mark {
+    font-family: 'Playfair Display', serif;
+    font-size: 200px;
+    color: #C9A96E;
+    line-height: 0.6;
+    margin-bottom: 40px;
+    opacity: 0.6;
+  }
+
+  .quote-text {
+    font-family: 'Playfair Display', serif;
+    font-style: italic;
+    font-weight: 400;
+    font-size: 42px;
+    color: #1B2A4A;
+    line-height: 1.5;
+    margin-bottom: 50px;
+    max-width: 800px;
+  }
+
+  .divider {
+    width: 80px;
+    height: 2px;
+    background: #C9A96E;
+    margin-bottom: 40px;
+  }
+
+  .author {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 24px;
+    color: #C9A96E;
+    margin-bottom: 6px;
+    letter-spacing: 2px;
+  }
+
+  .author-title {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 20px;
+    color: rgba(27,42,74,0.5);
+    margin-bottom: 4px;
+  }
+
+  .author-location {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 18px;
+    color: rgba(27,42,74,0.4);
+  }
+
+  /* Stats */
+  .stats {
+    display: flex;
+    gap: 50px;
+    margin-top: 80px;
+    margin-bottom: 20px;
+  }
+
+  .stat {
+    text-align: center;
+  }
+
+  .stat-number {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 36px;
+    color: #C9A96E;
+    margin-bottom: 4px;
+  }
+
+  .stat-label {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    color: rgba(27,42,74,0.4);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+  }
+
+  /* Bottom CTA bar */
+  .cta-bar {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    background: #1B2A4A;
+    padding: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+  }
+
+  .cta-label {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 26px;
+    color: #FAF6F0;
+    letter-spacing: 2px;
+  }
+
+  .cta-url {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 700;
+    font-size: 26px;
+    color: #C9A96E;
+  }
+
+  .cta-badge {
+    background: #C9A96E;
+    color: #1B2A4A;
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 16px;
+    padding: 6px 18px;
+    border-radius: 50px;
+    margin-left: 10px;
+  }
+</style>
+</head>
+<body>
+  <div class="story">
+    <div class="content">
+      <div class="quote-mark">"</div>
+
+      <div class="quote-text">
+        Antes me tardaba 2 horas haciendo una sola cotización. Con Solennix la hago en 5 minutos desde mi celular.
+      </div>
+
+      <div class="divider"></div>
+
+      <div class="author">— María G.</div>
+      <div class="author-title">Wedding Planner 💍</div>
+      <div class="author-location">Ciudad de México</div>
+
+      <div class="stats">
+        <div class="stat">
+          <div class="stat-number">+500</div>
+          <div class="stat-label">Organizadores</div>
+        </div>
+        <div class="stat">
+          <div class="stat-number">+12,000</div>
+          <div class="stat-label">Eventos</div>
+        </div>
+        <div class="stat">
+          <div class="stat-number">98%</div>
+          <div class="stat-label">Satisfacción</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="cta-bar">
+      <span class="cta-label">GRATIS →</span>
+      <span class="cta-url">solennix.com</span>
+      <span class="cta-badge">GRATIS</span>
+    </div>
+  </div>
+</body>
+</html>

--- a/marketing/campaigns/tu-evento-sin-limites/designs/06-lugares-agotados.html
+++ b/marketing/campaigns/tu-evento-sin-limites/designs/06-lugares-agotados.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<title>Post — ¡Lugares Agotados!</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700;900&family=Montserrat:wght@300;400;600;700;800&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { display: flex; justify-content: center; align-items: center; min-height: 100vh; background: #333; }
+
+  .post {
+    width: 1080px; height: 1080px;
+    background: #1B2A4A;
+    position: relative; overflow: hidden;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+  }
+
+  /* Confetti particles */
+  .confetti {
+    position: absolute;
+    width: 12px;
+    border-radius: 2px;
+    opacity: 0.6;
+    background: #C9A96E;
+  }
+  .c1 { height: 30px; top: 30px; left: 15%; transform: rotate(25deg); opacity: 0.5; }
+  .c2 { height: 20px; top: 60px; left: 30%; transform: rotate(-15deg); opacity: 0.4; width: 8px; }
+  .c3 { height: 35px; top: 20px; left: 50%; transform: rotate(45deg); opacity: 0.6; }
+  .c4 { height: 25px; top: 50px; left: 70%; transform: rotate(-30deg); opacity: 0.3; width: 10px; }
+  .c5 { height: 28px; top: 40px; left: 85%; transform: rotate(60deg); opacity: 0.5; }
+  .c6 { height: 22px; top: 80px; left: 22%; transform: rotate(-45deg); opacity: 0.35; width: 9px; }
+  .c7 { height: 18px; top: 70px; left: 60%; transform: rotate(10deg); opacity: 0.45; }
+  .c8 { height: 32px; top: 15px; left: 40%; transform: rotate(-55deg); opacity: 0.4; width: 10px; }
+  .c9 { height: 15px; top: 90px; left: 78%; transform: rotate(35deg); opacity: 0.5; width: 8px; }
+  .c10 { height: 24px; top: 45px; left: 8%; transform: rotate(-20deg); opacity: 0.4; }
+  .c11 { height: 20px; top: 55px; left: 92%; transform: rotate(50deg); opacity: 0.35; width: 9px; }
+  .c12 { height: 26px; top: 100px; left: 45%; transform: rotate(-40deg); opacity: 0.3; }
+
+  /* Radial glow */
+  .post::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: radial-gradient(ellipse at 50% 40%, rgba(201,169,110,0.12) 0%, transparent 50%);
+  }
+
+  .border-frame {
+    position: absolute;
+    top: 24px; left: 24px; right: 24px; bottom: 24px;
+    border: 1px solid rgba(201,169,110,0.12);
+  }
+
+  .content {
+    position: relative; z-index: 2;
+    display: flex; flex-direction: column;
+    align-items: center; text-align: center;
+    padding: 60px;
+  }
+
+  .emoji-header {
+    font-size: 80px;
+    margin-bottom: 30px;
+  }
+
+  .title {
+    font-family: 'Cinzel', serif;
+    font-weight: 900;
+    font-size: 52px;
+    color: #C9A96E;
+    line-height: 1.2;
+    margin-bottom: 20px;
+    letter-spacing: 2px;
+    text-shadow: 0 0 40px rgba(201,169,110,0.3);
+  }
+
+  .subtitle {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 28px;
+    color: #FAF6F0;
+    margin-bottom: 50px;
+    line-height: 1.4;
+  }
+
+  .subtitle span {
+    color: #C9A96E;
+    font-weight: 700;
+  }
+
+  .coupon-box {
+    background: rgba(201,169,110,0.1);
+    border: 2px solid #C9A96E;
+    border-radius: 12px;
+    padding: 30px 60px;
+    margin-bottom: 20px;
+    text-align: center;
+  }
+
+  .coupon-label {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 16px;
+    color: rgba(250,246,240,0.6);
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+  }
+
+  .coupon-code {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 800;
+    font-size: 48px;
+    color: #C9A96E;
+    letter-spacing: 6px;
+    margin-bottom: 10px;
+  }
+
+  .coupon-detail {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 20px;
+    color: #FAF6F0;
+  }
+
+  .coupon-validity {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    color: rgba(250,246,240,0.4);
+    margin-top: 6px;
+  }
+
+  .footer {
+    margin-top: 30px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .footer-url {
+    font-family: 'Montserrat', sans-serif;
+    font-weight: 600;
+    font-size: 22px;
+    color: rgba(250,246,240,0.6);
+    letter-spacing: 2px;
+  }
+
+  .footer-logo {
+    font-family: 'Cinzel', serif;
+    font-weight: 700;
+    font-size: 18px;
+    color: rgba(201,169,110,0.4);
+    letter-spacing: 6px;
+    margin-top: 10px;
+  }
+</style>
+</head>
+<body>
+  <div class="post">
+    <div class="border-frame"></div>
+
+    <!-- Confetti particles -->
+    <div class="confetti c1"></div>
+    <div class="confetti c2"></div>
+    <div class="confetti c3"></div>
+    <div class="confetti c4"></div>
+    <div class="confetti c5"></div>
+    <div class="confetti c6"></div>
+    <div class="confetti c7"></div>
+    <div class="confetti c8"></div>
+    <div class="confetti c9"></div>
+    <div class="confetti c10"></div>
+    <div class="confetti c11"></div>
+    <div class="confetti c12"></div>
+
+    <div class="content">
+      <div class="emoji-header">🎉</div>
+
+      <div class="title">¡SE AGOTARON LOS<br>20 LUGARES!</div>
+
+      <div class="subtitle">
+        Pero Solennix sigue siendo <span>GRATIS</span>
+      </div>
+
+      <div class="coupon-box">
+        <div class="coupon-label">Código de descuento</div>
+        <div class="coupon-code">TUEVENTO20</div>
+        <div class="coupon-detail">20% OFF tu primer mes de Pro</div>
+        <div class="coupon-validity">Válido por 7 días</div>
+      </div>
+
+      <div class="footer">
+        <div class="footer-url">solennix.com</div>
+        <div class="footer-logo">SOLENNIX</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
9 ready-to-export HTML designs with exact brand colors (Navy/Gold/Cream):
- 01: Launch post (1080x1080)
- 02: Promo "First 20 win Pro" (1080x1080)
- 03: Free vs Pro carousel (4 slides, 1080x1080 each)
- 04: Story countdown "X spots left" (1080x1920)
- 05: Story testimonial (1080x1920)
- 06: "Sold out" celebration post (1080x1080)

Open in browser and screenshot to export as PNG for social media.

https://claude.ai/code/session_01RWR2mteRs6oRKVg7Smaxp4