### PR TITLE
feat(android): Complete Android app with onboarding, business setting…

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,16 @@
                 <data android:host="reset-password" />
             </intent-filter>
 
+            <!-- Deep Links for App Search indexing and notifications -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="solennix" android:host="client" />
+                <data android:scheme="solennix" android:host="event" />
+                <data android:scheme="solennix" android:host="product" />
+            </intent-filter>
+
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/android/app/src/main/java/com/creapolis/solennix/MainActivity.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.creapolis.solennix
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -9,12 +10,24 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : FragmentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             SolennixTheme {
-                MainNavHost()
+                MainNavHost(deepLinkIntent = intent)
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        // Recomponer con el nuevo intent de deep link
+        setContent {
+            SolennixTheme {
+                MainNavHost(deepLinkIntent = intent)
             }
         }
     }

--- a/android/app/src/main/java/com/creapolis/solennix/MainNavHost.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/MainNavHost.kt
@@ -1,5 +1,6 @@
 package com.creapolis.solennix
 
+import android.content.Intent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
@@ -11,6 +12,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import com.creapolis.solennix.feature.dashboard.ui.OnboardingScreen
+import com.creapolis.solennix.feature.dashboard.ui.hasSeenOnboarding
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
@@ -22,14 +25,44 @@ import com.creapolis.solennix.ui.navigation.AuthNavHost
 import com.creapolis.solennix.ui.navigation.CompactBottomNavLayout
 import androidx.fragment.app.FragmentActivity
 
+/**
+ * Extrae la ruta de navegacion inicial desde un deep link intent.
+ * Soporta: solennix://client/{id}, solennix://event/{id}, solennix://product/{id}
+ */
+private fun parseDeepLinkRoute(intent: Intent?): String? {
+    val uri = intent?.data ?: return null
+    if (uri.scheme != "solennix") return null
+
+    val host = uri.host ?: return null
+    val pathId = uri.pathSegments?.firstOrNull() ?: return null
+
+    return when (host) {
+        "client" -> "client_detail/$pathId"
+        "event" -> "event_detail/$pathId"
+        "product" -> "product_detail/$pathId"
+        else -> null
+    }
+}
+
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
-fun MainNavHost() {
+fun MainNavHost(deepLinkIntent: Intent? = null) {
+    val context = LocalContext.current
+    var showOnboarding by remember { mutableStateOf(!hasSeenOnboarding(context)) }
+
+    if (showOnboarding) {
+        OnboardingScreen(
+            onComplete = { showOnboarding = false }
+        )
+        return
+    }
+
     val authViewModel: AuthViewModel = hiltViewModel()
     val authState by authViewModel.authState.collectAsStateWithLifecycle()
-    val context = LocalContext.current
     val activity = context as? FragmentActivity
     val windowSizeClass = activity?.let { calculateWindowSizeClass(it) }
+
+    val deepLinkRoute = remember(deepLinkIntent) { parseDeepLinkRoute(deepLinkIntent) }
 
     LaunchedEffect(Unit) {
         authViewModel.authManager.restoreSession()
@@ -51,7 +84,7 @@ fun MainNavHost() {
             if (windowSizeClass != null && windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact) {
                 AdaptiveNavigationRailLayout()
             } else {
-                CompactBottomNavLayout()
+                CompactBottomNavLayout(initialDeepLinkRoute = deepLinkRoute)
             }
         }
     }

--- a/android/app/src/main/java/com/creapolis/solennix/sync/SyncWorker.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/sync/SyncWorker.kt
@@ -7,6 +7,9 @@ import com.creapolis.solennix.core.data.repository.ClientRepository
 import com.creapolis.solennix.core.data.repository.EventRepository
 import com.creapolis.solennix.core.data.repository.InventoryRepository
 import com.creapolis.solennix.core.data.repository.ProductRepository
+import com.creapolis.solennix.core.data.search.AppSearchIndexer
+import com.creapolis.solennix.core.network.EventDayNotificationManager
+import kotlinx.coroutines.flow.first
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
@@ -21,7 +24,9 @@ class SyncWorker @AssistedInject constructor(
     private val eventRepository: EventRepository,
     private val clientRepository: ClientRepository,
     private val productRepository: ProductRepository,
-    private val inventoryRepository: InventoryRepository
+    private val inventoryRepository: InventoryRepository,
+    private val eventDayNotificationManager: EventDayNotificationManager,
+    private val appSearchIndexer: AppSearchIndexer
 ) : CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
@@ -31,6 +36,12 @@ class SyncWorker @AssistedInject constructor(
             syncClients()
             syncProducts()
             syncInventory()
+
+            // Post-sync: verificar eventos de hoy y mostrar notificaciones persistentes
+            checkTodayEventsNotifications()
+
+            // Post-sync: indexar contenido para busqueda en el dispositivo
+            indexContentForSearch()
 
             Result.success()
         } catch (e: Exception) {
@@ -71,6 +82,37 @@ class SyncWorker @AssistedInject constructor(
             inventoryRepository.syncInventory()
         } catch (e: Exception) {
             // Log but don't fail the entire sync
+        }
+    }
+
+    /**
+     * Verifica eventos de hoy y muestra notificaciones persistentes para los confirmados.
+     */
+    private suspend fun checkTodayEventsNotifications() {
+        try {
+            val events = eventRepository.getEvents().first()
+            val clients = clientRepository.getClients().first()
+            val clientsMap = clients.associateBy { it.id }
+            eventDayNotificationManager.checkAndShowTodayEvents(events, clientsMap)
+        } catch (e: Exception) {
+            // No fallar el sync por errores de notificacion
+        }
+    }
+
+    /**
+     * Indexa clientes, eventos y productos para busqueda en el dispositivo.
+     */
+    private suspend fun indexContentForSearch() {
+        try {
+            val clients = clientRepository.getClients().first()
+            val events = eventRepository.getEvents().first()
+            val products = productRepository.getProducts().first()
+
+            appSearchIndexer.indexClients(clients)
+            appSearchIndexer.indexEvents(events)
+            appSearchIndexer.indexProducts(products)
+        } catch (e: Exception) {
+            // No fallar el sync por errores de indexacion
         }
     }
 

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
@@ -31,13 +31,24 @@ import com.creapolis.solennix.feature.settings.ui.ChangePasswordScreen
 import com.creapolis.solennix.feature.settings.ui.EditProfileScreen
 import com.creapolis.solennix.feature.settings.ui.PricingScreen
 import com.creapolis.solennix.feature.settings.ui.PrivacyScreen
+import com.creapolis.solennix.feature.settings.ui.BusinessSettingsScreen
+import com.creapolis.solennix.feature.settings.ui.ContractDefaultsScreen
 import com.creapolis.solennix.feature.settings.ui.SettingsScreen
 import com.creapolis.solennix.feature.settings.ui.TermsScreen
 
 @Composable
-fun CompactBottomNavLayout() {
+fun CompactBottomNavLayout(initialDeepLinkRoute: String? = null) {
     var selectedDestination by remember { mutableStateOf(TopLevelDestination.HOME) }
     val navController = rememberNavController()
+
+    // Navegar al deep link despues de que el NavHost se haya inicializado
+    LaunchedEffect(initialDeepLinkRoute) {
+        initialDeepLinkRoute?.let { route ->
+            navController.navigate(route) {
+                launchSingleTop = true
+            }
+        }
+    }
 
     Scaffold(
         bottomBar = {
@@ -168,7 +179,8 @@ fun CompactBottomNavLayout() {
                     viewModel = hiltViewModel(),
                     onEditProfile = { navController.navigate("edit_profile") },
                     onChangePassword = { navController.navigate("change_password") },
-                    onBusinessSettings = { /* TODO: Business Settings */ },
+                    onBusinessSettings = { navController.navigate("business_settings") },
+                    onContractDefaults = { navController.navigate("contract_defaults") },
                     onPricing = { navController.navigate("pricing") },
                     onAbout = { navController.navigate("about") },
                     onPrivacy = { navController.navigate("privacy") },
@@ -185,6 +197,18 @@ fun CompactBottomNavLayout() {
             }
             composable("change_password") {
                 ChangePasswordScreen(
+                    viewModel = hiltViewModel(),
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable("business_settings") {
+                BusinessSettingsScreen(
+                    viewModel = hiltViewModel(),
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable("contract_defaults") {
+                ContractDefaultsScreen(
                     viewModel = hiltViewModel(),
                     onNavigateBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/Route.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/Route.kt
@@ -13,6 +13,7 @@ sealed class Route {
     @Serializable data class ProductForm(val id: String? = null) : Route()
     @Serializable data class InventoryDetail(val id: String) : Route()
     @Serializable data class InventoryForm(val id: String? = null) : Route()
+    @Serializable data object Onboarding : Route()
     @Serializable data object EditProfile : Route()
     @Serializable data object ChangePassword : Route()
     @Serializable data object BusinessSettings : Route()

--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/search/AppSearchIndexer.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/search/AppSearchIndexer.kt
@@ -1,0 +1,148 @@
+package com.creapolis.solennix.core.data.search
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import com.creapolis.solennix.core.model.Client
+import com.creapolis.solennix.core.model.Event
+import com.creapolis.solennix.core.model.Product
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Indexa contenido de la app para que aparezca en la busqueda del dispositivo.
+ * Usa ShortcutManagerCompat con shortcuts dinamicos y de larga duracion
+ * para integrarse con Google Search en el dispositivo.
+ */
+@Singleton
+class AppSearchIndexer @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    companion object {
+        private const val MAX_SHORTCUTS = 15 // Android limita shortcuts dinamicos
+        private const val CATEGORY_CLIENT = "com.creapolis.solennix.category.CLIENT"
+        private const val CATEGORY_EVENT = "com.creapolis.solennix.category.EVENT"
+        private const val CATEGORY_PRODUCT = "com.creapolis.solennix.category.PRODUCT"
+    }
+
+    /**
+     * Indexa clientes como shortcuts dinamicos para busqueda.
+     * Incluye nombre, telefono y email como palabras clave.
+     */
+    fun indexClients(clients: List<Client>) {
+        val shortcuts = clients
+            .take(MAX_SHORTCUTS)
+            .map { client ->
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("solennix://client/${client.id}")).apply {
+                    setPackage(context.packageName)
+                }
+
+                ShortcutInfoCompat.Builder(context, "client_${client.id}")
+                    .setShortLabel(client.name)
+                    .setLongLabel("${client.name} - ${client.phone}")
+                    .setIcon(IconCompat.createWithResource(context, android.R.drawable.ic_menu_my_calendar))
+                    .setIntent(intent)
+                    .setLongLived(true)
+                    .setCategories(setOf(CATEGORY_CLIENT))
+                    .build()
+            }
+
+        // Eliminar shortcuts de clientes anteriores y agregar nuevos
+        removeShortcutsByCategory(CATEGORY_CLIENT)
+        shortcuts.forEach { shortcut ->
+            ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+        }
+    }
+
+    /**
+     * Indexa eventos como shortcuts dinamicos para busqueda.
+     * Incluye tipo de evento, cliente, fecha y ubicacion.
+     */
+    fun indexEvents(events: List<Event>) {
+        val shortcuts = events
+            .take(MAX_SHORTCUTS)
+            .map { event ->
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("solennix://event/${event.id}")).apply {
+                    setPackage(context.packageName)
+                }
+
+                val locationText = event.location ?: event.city ?: ""
+                val longLabel = buildString {
+                    append(event.serviceType)
+                    append(" - ${event.eventDate}")
+                    if (locationText.isNotBlank()) append(" · $locationText")
+                }
+
+                ShortcutInfoCompat.Builder(context, "event_${event.id}")
+                    .setShortLabel(event.serviceType)
+                    .setLongLabel(longLabel.take(80)) // Android limita a ~80 chars
+                    .setIcon(IconCompat.createWithResource(context, android.R.drawable.ic_menu_my_calendar))
+                    .setIntent(intent)
+                    .setLongLived(true)
+                    .setCategories(setOf(CATEGORY_EVENT))
+                    .build()
+            }
+
+        removeShortcutsByCategory(CATEGORY_EVENT)
+        shortcuts.forEach { shortcut ->
+            ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+        }
+    }
+
+    /**
+     * Indexa productos como shortcuts dinamicos para busqueda.
+     * Incluye nombre, categoria y precio.
+     */
+    fun indexProducts(products: List<Product>) {
+        val shortcuts = products
+            .filter { it.isActive }
+            .take(MAX_SHORTCUTS)
+            .map { product ->
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("solennix://product/${product.id}")).apply {
+                    setPackage(context.packageName)
+                }
+
+                val longLabel = "${product.name} - ${product.category} · $${product.basePrice}"
+
+                ShortcutInfoCompat.Builder(context, "product_${product.id}")
+                    .setShortLabel(product.name)
+                    .setLongLabel(longLabel.take(80))
+                    .setIcon(IconCompat.createWithResource(context, android.R.drawable.ic_menu_my_calendar))
+                    .setIntent(intent)
+                    .setLongLived(true)
+                    .setCategories(setOf(CATEGORY_PRODUCT))
+                    .build()
+            }
+
+        removeShortcutsByCategory(CATEGORY_PRODUCT)
+        shortcuts.forEach { shortcut ->
+            ShortcutManagerCompat.pushDynamicShortcut(context, shortcut)
+        }
+    }
+
+    /**
+     * Elimina todos los items indexados.
+     */
+    fun removeAll() {
+        ShortcutManagerCompat.removeAllDynamicShortcuts(context)
+    }
+
+    /**
+     * Elimina shortcuts de una categoria especifica.
+     */
+    private fun removeShortcutsByCategory(category: String) {
+        val allShortcuts = ShortcutManagerCompat.getDynamicShortcuts(context)
+        val toRemove = allShortcuts
+            .filter { it.categories?.contains(category) == true }
+            .map { it.id }
+
+        if (toRemove.isNotEmpty()) {
+            ShortcutManagerCompat.removeDynamicShortcuts(context, toRemove)
+        }
+    }
+}

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/EventDayNotificationManager.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/EventDayNotificationManager.kt
@@ -1,0 +1,180 @@
+package com.creapolis.solennix.core.network
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.creapolis.solennix.core.model.Client
+import com.creapolis.solennix.core.model.Event
+import com.creapolis.solennix.core.model.EventStatus
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Gestiona notificaciones persistentes para eventos del dia.
+ * Equivalente Android de iOS Live Activities.
+ */
+@Singleton
+class EventDayNotificationManager @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+
+    companion object {
+        private const val CHANNEL_ID = "event_day"
+        private const val CHANNEL_NAME = "Eventos del Dia"
+        private const val CHANNEL_DESCRIPTION = "Notificaciones persistentes para eventos programados hoy"
+        private const val NOTIFICATION_TAG = "event_day_notification"
+        private const val SOLENNIX_GOLD_ARGB = 0xFFC4A265.toInt()
+    }
+
+    private val notificationManager =
+        context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    init {
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = CHANNEL_DESCRIPTION
+                setShowBadge(true)
+            }
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Muestra una notificacion persistente para un evento del dia.
+     */
+    fun showEventNotification(event: Event, client: Client) {
+        val notificationId = event.id.hashCode()
+
+        // Intent para abrir el detalle del evento
+        val viewIntent = Intent(Intent.ACTION_VIEW, Uri.parse("solennix://event/${event.id}")).apply {
+            setPackage(context.packageName)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val viewPendingIntent = PendingIntent.getActivity(
+            context,
+            notificationId,
+            viewIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        // Intent para marcar como finalizado
+        val finishIntent = Intent(Intent.ACTION_VIEW, Uri.parse("solennix://event/${event.id}/complete")).apply {
+            setPackage(context.packageName)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val finishPendingIntent = PendingIntent.getActivity(
+            context,
+            notificationId + 1,
+            finishIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val startTimeText = event.startTime?.let { "Hoy a las $it" } ?: "Hoy"
+        val locationText = event.location ?: event.city ?: ""
+        val guestText = "${event.numPeople} invitados"
+
+        val contentParts = listOfNotNull(
+            startTimeText,
+            locationText.takeIf { it.isNotBlank() },
+            guestText
+        )
+        val contentText = contentParts.joinToString(" \u00b7 ")
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_menu_my_calendar)
+            .setContentTitle("${client.name} - ${event.serviceType}")
+            .setContentText(contentText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(contentText))
+            .setOngoing(true)
+            .setAutoCancel(false)
+            .setColor(SOLENNIX_GOLD_ARGB)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setContentIntent(viewPendingIntent)
+            .addAction(
+                android.R.drawable.ic_menu_view,
+                "Ver Evento",
+                viewPendingIntent
+            )
+            .addAction(
+                android.R.drawable.ic_menu_close_clear_cancel,
+                "Finalizar",
+                finishPendingIntent
+            )
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_TAG, notificationId, notification)
+    }
+
+    /**
+     * Actualiza el texto de una notificacion existente para un evento.
+     */
+    fun updateEventNotification(eventId: String, status: String) {
+        val notificationId = eventId.hashCode()
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_menu_my_calendar)
+            .setContentTitle("Evento en curso")
+            .setContentText("Estado: $status")
+            .setOngoing(true)
+            .setAutoCancel(false)
+            .setColor(SOLENNIX_GOLD_ARGB)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .build()
+
+        notificationManager.notify(NOTIFICATION_TAG, notificationId, notification)
+    }
+
+    /**
+     * Cancela la notificacion persistente de un evento.
+     */
+    fun dismissEventNotification(eventId: String) {
+        val notificationId = eventId.hashCode()
+        notificationManager.cancel(NOTIFICATION_TAG, notificationId)
+    }
+
+    /**
+     * Verifica los eventos de hoy y muestra notificaciones persistentes
+     * para los que estan confirmados.
+     */
+    fun checkAndShowTodayEvents(events: List<Event>, clients: Map<String, Client>) {
+        val today = LocalDate.now().toString() // formato yyyy-MM-dd
+
+        val todayConfirmedEvents = events.filter { event ->
+            event.eventDate == today && event.status == EventStatus.CONFIRMED
+        }
+
+        // Cancelar notificaciones de eventos que ya no son de hoy o confirmados
+        val todayEventIds = todayConfirmedEvents.map { it.id }.toSet()
+        events.filter { it.id !in todayEventIds }.forEach { event ->
+            dismissEventNotification(event.id)
+        }
+
+        // Mostrar notificaciones para eventos confirmados de hoy
+        todayConfirmedEvents.forEach { event ->
+            val client = clients[event.clientId]
+            if (client != null) {
+                showEventNotification(event, client)
+            }
+        }
+    }
+}

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/OnboardingPageContent.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/OnboardingPageContent.kt
@@ -1,0 +1,133 @@
+package com.creapolis.solennix.feature.dashboard.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.creapolis.solennix.core.designsystem.theme.SolennixGradient
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.designsystem.theme.Spacing
+
+/**
+ * Reusable page content composable for the onboarding HorizontalPager.
+ *
+ * Displays an icon inside a gradient circle, a title, an optional description,
+ * and an optional list of feature bullet items with checkmark icons.
+ */
+@Composable
+fun OnboardingPageContent(
+    icon: ImageVector,
+    title: String,
+    description: String? = null,
+    features: List<String>? = null,
+    modifier: Modifier = Modifier,
+    extraContent: @Composable ColumnScope.() -> Unit = {}
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Icon with gradient background circle
+        Box(
+            modifier = Modifier
+                .size(120.dp)
+                .clip(CircleShape)
+                .background(SolennixGradient.premiumBrush),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(56.dp),
+                tint = androidx.compose.ui.graphics.Color.White
+            )
+        }
+
+        Spacer(modifier = Modifier.height(Spacing.xxl))
+
+        // Title
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = SolennixTheme.colors.primaryText,
+            textAlign = TextAlign.Center
+        )
+
+        // Description
+        if (description != null) {
+            Spacer(modifier = Modifier.height(Spacing.md))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyLarge,
+                color = SolennixTheme.colors.secondaryText,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        // Feature list
+        if (!features.isNullOrEmpty()) {
+            Spacer(modifier = Modifier.height(Spacing.xl))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(Spacing.sm)
+            ) {
+                features.forEach { feature ->
+                    OnboardingFeatureItem(text = feature)
+                }
+            }
+        }
+
+        // Extra composable content slot (e.g. for the CTA button on the last page)
+        extraContent()
+    }
+}
+
+@Composable
+private fun OnboardingFeatureItem(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .clip(CircleShape)
+                .background(SolennixTheme.colors.primary.copy(alpha = 0.15f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = SolennixTheme.colors.primary
+            )
+        }
+        Spacer(modifier = Modifier.width(Spacing.md))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyLarge,
+            color = SolennixTheme.colors.primaryText
+        )
+    }
+}

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/OnboardingScreen.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/OnboardingScreen.kt
@@ -1,0 +1,186 @@
+package com.creapolis.solennix.feature.dashboard.ui
+
+import android.content.Context
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.creapolis.solennix.core.designsystem.component.PremiumButton
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.designsystem.theme.Spacing
+import kotlinx.coroutines.launch
+
+private const val ONBOARDING_PREFS = "solennix_onboarding"
+private const val KEY_HAS_SEEN_ONBOARDING = "has_seen_onboarding"
+private const val PAGE_COUNT = 4
+
+/**
+ * Full-screen first-launch onboarding experience with a 4-page HorizontalPager.
+ *
+ * Pages:
+ * 1. Welcome
+ * 2. Core features
+ * 3. Android-specific features
+ * 4. Get started CTA
+ *
+ * @param onComplete Called after the user finishes or skips onboarding.
+ *                   The SharedPreferences flag is set before invoking this callback.
+ */
+@Composable
+fun OnboardingScreen(
+    onComplete: () -> Unit
+) {
+    val context = LocalContext.current
+    val pagerState = rememberPagerState(pageCount = { PAGE_COUNT })
+    val coroutineScope = rememberCoroutineScope()
+
+    val completeOnboarding = {
+        context.getSharedPreferences(ONBOARDING_PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_HAS_SEEN_ONBOARDING, true)
+            .apply()
+        onComplete()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SolennixTheme.colors.background)
+    ) {
+        // Pager
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 140.dp) // Room for navigation controls
+        ) { page ->
+            when (page) {
+                0 -> OnboardingPageContent(
+                    icon = Icons.Default.AutoAwesome,
+                    title = "Bienvenido a Solennix",
+                    description = "La herramienta definitiva para organizar tus eventos de manera profesional"
+                )
+                1 -> OnboardingPageContent(
+                    icon = Icons.Default.Layers,
+                    title = "Todo en un Solo Lugar",
+                    features = listOf(
+                        "Gestiona clientes y contactos",
+                        "Crea cotizaciones y contratos",
+                        "Controla tu inventario",
+                        "Programa eventos en calendario"
+                    )
+                )
+                2 -> OnboardingPageContent(
+                    icon = Icons.Default.PhoneAndroid,
+                    title = "Diseñado para Android",
+                    features = listOf(
+                        "Widgets en tu pantalla de inicio",
+                        "Modo oscuro automatico",
+                        "Funciona sin conexion",
+                        "Notificaciones inteligentes",
+                        "Soporte para tablets y plegables"
+                    )
+                )
+                3 -> OnboardingPageContent(
+                    icon = Icons.Default.RocketLaunch,
+                    title = "Comienza Ahora",
+                    description = "Crea tu cuenta o inicia sesion para empezar"
+                ) {
+                    Spacer(modifier = Modifier.height(Spacing.xxl))
+                    PremiumButton(
+                        text = "Comenzar",
+                        onClick = { completeOnboarding() },
+                        modifier = Modifier.padding(horizontal = Spacing.md)
+                    )
+                }
+            }
+        }
+
+        // Skip button (top-right) - hidden on last page
+        if (pagerState.currentPage < PAGE_COUNT - 1) {
+            TextButton(
+                onClick = { completeOnboarding() },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .statusBarsPadding()
+                    .padding(end = Spacing.sm, top = Spacing.sm)
+            ) {
+                Text(
+                    text = "Omitir",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = SolennixTheme.colors.secondaryText
+                )
+            }
+        }
+
+        // Bottom navigation: page indicators + "Siguiente" button
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .padding(bottom = Spacing.xxl, start = Spacing.xl, end = Spacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // Page indicators (dots)
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                repeat(PAGE_COUNT) { index ->
+                    val isActive = pagerState.currentPage == index
+                    val color by animateColorAsState(
+                        targetValue = if (isActive)
+                            SolennixTheme.colors.primary
+                        else
+                            SolennixTheme.colors.divider,
+                        label = "dotColor_$index"
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(if (isActive) 10.dp else 8.dp)
+                            .clip(CircleShape)
+                            .background(color)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(Spacing.xl))
+
+            // "Siguiente" button (hidden on last page where PremiumButton is shown inline)
+            if (pagerState.currentPage < PAGE_COUNT - 1) {
+                PremiumButton(
+                    text = "Siguiente",
+                    onClick = {
+                        coroutineScope.launch {
+                            pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Checks whether the user has already completed the first-launch onboarding.
+ */
+fun hasSeenOnboarding(context: Context): Boolean {
+    return context.getSharedPreferences(ONBOARDING_PREFS, Context.MODE_PRIVATE)
+        .getBoolean(KEY_HAS_SEEN_ONBOARDING, false)
+}

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventDetailViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventDetailViewModel.kt
@@ -13,7 +13,9 @@ import com.creapolis.solennix.core.model.EventPhoto
 import com.creapolis.solennix.core.model.EventProduct
 import com.creapolis.solennix.core.model.Payment
 import com.creapolis.solennix.core.model.User
+import com.creapolis.solennix.core.model.EventStatus
 import com.creapolis.solennix.core.network.AuthManager
+import com.creapolis.solennix.core.network.EventDayNotificationManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -44,6 +46,7 @@ class EventDetailViewModel @Inject constructor(
     private val clientRepository: ClientRepository,
     private val paymentRepository: PaymentRepository,
     private val authManager: AuthManager,
+    private val eventDayNotificationManager: EventDayNotificationManager,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -130,6 +133,9 @@ class EventDetailViewModel @Inject constructor(
                     _client.value = clientRepository.getClient(clientId)
                 }
 
+                // Auto-mostrar notificacion persistente si el evento es hoy y confirmado
+                checkAndShowEventDayNotification(event, _client.value)
+
                 _isLoading.value = false
             } catch (e: Exception) {
                 _errorMessage.value = e.message
@@ -195,6 +201,33 @@ class EventDetailViewModel @Inject constructor(
             } catch (e: Exception) {
                 _errorMessage.value = "Error deleting photo: ${e.message}"
             }
+        }
+    }
+
+    /**
+     * Muestra la notificacion persistente del evento del dia.
+     */
+    fun startEventDayNotification() {
+        val event = _event.value ?: return
+        val client = _client.value ?: return
+        eventDayNotificationManager.showEventNotification(event, client)
+    }
+
+    /**
+     * Cancela la notificacion persistente del evento del dia.
+     */
+    fun stopEventDayNotification() {
+        eventDayNotificationManager.dismissEventNotification(eventId)
+    }
+
+    /**
+     * Verifica si el evento es hoy y esta confirmado para mostrar notificacion automaticamente.
+     */
+    private fun checkAndShowEventDayNotification(event: Event?, client: Client?) {
+        if (event == null || client == null) return
+        val today = java.time.LocalDate.now().toString()
+        if (event.eventDate == today && event.status == EventStatus.CONFIRMED) {
+            eventDayNotificationManager.showEventNotification(event, client)
         }
     }
 }

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/BusinessSettingsScreen.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/BusinessSettingsScreen.kt
@@ -1,0 +1,323 @@
+package com.creapolis.solennix.feature.settings.ui
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.creapolis.solennix.core.designsystem.component.PremiumButton
+import com.creapolis.solennix.core.designsystem.component.SolennixTextField
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.feature.settings.viewmodel.BusinessSettingsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BusinessSettingsScreen(
+    viewModel: BusinessSettingsViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    val context = LocalContext.current
+
+    LaunchedEffect(viewModel.saveSuccess) {
+        if (viewModel.saveSuccess) {
+            onNavigateBack()
+        }
+    }
+
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        uri?.let {
+            val inputStream = context.contentResolver.openInputStream(it)
+            val bytes = inputStream?.readBytes()
+            inputStream?.close()
+            if (bytes != null) {
+                viewModel.uploadLogo(bytes)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Ajustes del Negocio") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (viewModel.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = SolennixTheme.colors.primary)
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(scrollState)
+                    .padding(16.dp)
+            ) {
+                // Logo Section
+                Text(
+                    text = "Logo",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        // Logo preview
+                        if (viewModel.logoUrl != null) {
+                            AsyncImage(
+                                model = ImageRequest.Builder(context)
+                                    .data(viewModel.logoUrl)
+                                    .crossfade(true)
+                                    .build(),
+                                contentDescription = "Logo del negocio",
+                                modifier = Modifier
+                                    .size(100.dp)
+                                    .clip(RoundedCornerShape(12.dp)),
+                                contentScale = ContentScale.Fit
+                            )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .size(100.dp)
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .background(SolennixTheme.colors.surfaceGrouped),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    Icons.Default.Business,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(32.dp),
+                                    tint = SolennixTheme.colors.secondaryText
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        // Upload button
+                        OutlinedButton(
+                            onClick = { imagePickerLauncher.launch("image/*") },
+                            enabled = !viewModel.isUploadingLogo
+                        ) {
+                            if (viewModel.isUploadingLogo) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    strokeWidth = 2.dp,
+                                    color = SolennixTheme.colors.primary
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text("Subiendo...")
+                            } else {
+                                Icon(
+                                    Icons.Default.PhotoCamera,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    if (viewModel.logoUrl != null) "Cambiar Logo"
+                                    else "Subir Logo"
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Tu logo aparecera en los contratos y cotizaciones que generes.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Business Name Section
+                Text(
+                    text = "Nombre del Negocio",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        SolennixTextField(
+                            value = viewModel.businessName,
+                            onValueChange = { viewModel.businessName = it },
+                            label = "Nombre del negocio",
+                            leadingIcon = Icons.Default.Business
+                        )
+
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Mostrar en PDFs",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Switch(
+                                checked = viewModel.showBusinessNameInPdf,
+                                onCheckedChange = { viewModel.showBusinessNameInPdf = it },
+                                colors = SwitchDefaults.colors(
+                                    checkedTrackColor = SolennixTheme.colors.primary
+                                )
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Si activas esta opcion, tu nombre comercial aparecera en los documentos en lugar de tu nombre personal.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Brand Color Section
+                Text(
+                    text = "Identidad Visual",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "Color de marca",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = SolennixTheme.colors.primaryText,
+                            modifier = Modifier.padding(bottom = 12.dp)
+                        )
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            val presetColors = listOf(
+                                "#007AFF", "#FF3B30", "#34C759", "#FF9500",
+                                "#AF52DE", "#5856D6", "#FF2D55", "#00C7BE"
+                            )
+                            presetColors.forEach { color ->
+                                val isSelected = viewModel.brandColor.equals(color, ignoreCase = true)
+                                Surface(
+                                    onClick = { viewModel.brandColor = color },
+                                    modifier = Modifier.size(36.dp),
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = parseHexColor(color),
+                                    border = if (isSelected) {
+                                        androidx.compose.foundation.BorderStroke(
+                                            2.dp,
+                                            SolennixTheme.colors.primaryText
+                                        )
+                                    } else null
+                                ) {}
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Este color se usara como acento en los documentos PDF que generes.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                if (viewModel.errorMessage != null) {
+                    Text(
+                        text = viewModel.errorMessage!!,
+                        color = SolennixTheme.colors.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+                }
+
+                PremiumButton(
+                    text = "Guardar",
+                    onClick = { viewModel.saveBusinessSettings() },
+                    isLoading = viewModel.isSaving,
+                    enabled = !viewModel.isSaving
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+private fun parseHexColor(hex: String): androidx.compose.ui.graphics.Color {
+    val sanitized = hex.removePrefix("#")
+    return try {
+        androidx.compose.ui.graphics.Color(android.graphics.Color.parseColor("#$sanitized"))
+    } catch (e: Exception) {
+        androidx.compose.ui.graphics.Color(0xFF007AFF)
+    }
+}

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/ContractDefaultsScreen.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/ContractDefaultsScreen.kt
@@ -1,0 +1,368 @@
+package com.creapolis.solennix.feature.settings.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.creapolis.solennix.core.designsystem.component.PremiumButton
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.feature.settings.viewmodel.ContractDefaultsViewModel
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContractDefaultsScreen(
+    viewModel: ContractDefaultsViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(viewModel.saveSuccess) {
+        if (viewModel.saveSuccess) {
+            onNavigateBack()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Valores del Contrato") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (viewModel.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = SolennixTheme.colors.primary)
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(scrollState)
+                    .padding(16.dp)
+            ) {
+                // Deposit Section
+                Text(
+                    text = "Anticipo",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Porcentaje de anticipo",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Text(
+                                text = "${viewModel.depositPercent.roundToInt()}%",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = SolennixTheme.colors.primary
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Slider(
+                            value = viewModel.depositPercent,
+                            onValueChange = { viewModel.depositPercent = it },
+                            valueRange = 0f..100f,
+                            steps = 19,
+                            colors = SliderDefaults.colors(
+                                thumbColor = SolennixTheme.colors.primary,
+                                activeTrackColor = SolennixTheme.colors.primary
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Porcentaje del total que solicitas como anticipo al confirmar un evento.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Cancellation Section
+                Text(
+                    text = "Cancelacion",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Dias de anticipacion",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Text(
+                                text = "${viewModel.cancellationDays.roundToInt()} dias",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = SolennixTheme.colors.primary
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Slider(
+                            value = viewModel.cancellationDays,
+                            onValueChange = { viewModel.cancellationDays = it },
+                            valueRange = 1f..30f,
+                            steps = 28,
+                            colors = SliderDefaults.colors(
+                                thumbColor = SolennixTheme.colors.primary,
+                                activeTrackColor = SolennixTheme.colors.primary
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Numero minimo de dias antes del evento para permitir cancelacion con reembolso.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Refund Section
+                Text(
+                    text = "Reembolso",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Porcentaje de reembolso",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Text(
+                                text = "${viewModel.refundPercent.roundToInt()}%",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = SolennixTheme.colors.primary
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Slider(
+                            value = viewModel.refundPercent,
+                            onValueChange = { viewModel.refundPercent = it },
+                            valueRange = 0f..100f,
+                            steps = 19,
+                            colors = SliderDefaults.colors(
+                                thumbColor = SolennixTheme.colors.primary,
+                                activeTrackColor = SolennixTheme.colors.primary
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Porcentaje del anticipo que devuelves en caso de cancelacion dentro del plazo permitido.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Contract Template Section
+                Text(
+                    text = "Plantilla del Contrato",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        OutlinedTextField(
+                            value = viewModel.contractTemplate,
+                            onValueChange = { viewModel.contractTemplate = it },
+                            label = { Text("Texto adicional del contrato") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(min = 150.dp),
+                            maxLines = 10,
+                            colors = OutlinedTextFieldDefaults.colors(
+                                focusedBorderColor = SolennixTheme.colors.primary,
+                                cursorColor = SolennixTheme.colors.primary
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "Puedes personalizar el texto adicional que aparecera en tus contratos. Usa {{nombre_cliente}}, {{fecha_evento}}, {{total}} para variables.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Preview Section
+                Text(
+                    text = "Vista Previa",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.medium,
+                    color = SolennixTheme.colors.card,
+                    tonalElevation = 1.dp
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(
+                            text = "Vista previa de terminos",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = SolennixTheme.colors.primaryText,
+                            modifier = Modifier.padding(bottom = 12.dp)
+                        )
+
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(8.dp),
+                            color = SolennixTheme.colors.surfaceGrouped
+                        ) {
+                            Column(modifier = Modifier.padding(12.dp)) {
+                                PreviewRow(
+                                    label = "Anticipo requerido",
+                                    value = "${viewModel.depositPercent.roundToInt()}% del total"
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                PreviewRow(
+                                    label = "Cancelacion sin penalizacion",
+                                    value = "${viewModel.cancellationDays.roundToInt()} dias antes"
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                PreviewRow(
+                                    label = "Reembolso por cancelacion",
+                                    value = "${viewModel.refundPercent.roundToInt()}% del anticipo"
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                if (viewModel.errorMessage != null) {
+                    Text(
+                        text = viewModel.errorMessage!!,
+                        color = SolennixTheme.colors.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+                }
+
+                PremiumButton(
+                    text = "Guardar",
+                    onClick = { viewModel.saveContractDefaults() },
+                    isLoading = viewModel.isSaving,
+                    enabled = !viewModel.isSaving
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = SolennixTheme.colors.secondaryText
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = SolennixTheme.colors.primaryText
+        )
+    }
+}

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/SettingsScreen.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/SettingsScreen.kt
@@ -24,6 +24,7 @@ fun SettingsScreen(
     onEditProfile: () -> Unit,
     onChangePassword: () -> Unit,
     onBusinessSettings: () -> Unit,
+    onContractDefaults: () -> Unit,
     onPricing: () -> Unit,
     onAbout: () -> Unit,
     onPrivacy: () -> Unit,
@@ -72,6 +73,7 @@ fun SettingsScreen(
                 SettingsItem(icon = Icons.Default.Person, label = "Editar Perfil", onClick = onEditProfile)
                 SettingsItem(icon = Icons.Default.Lock, label = "Cambiar Contraseña", onClick = onChangePassword)
                 SettingsItem(icon = Icons.Default.Business, label = "Ajustes del Negocio", onClick = onBusinessSettings)
+                SettingsItem(icon = Icons.Default.Receipt, label = "Valores del Contrato", onClick = onContractDefaults)
             }
 
             SettingsSection(title = "Suscripción") {

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/viewmodel/BusinessSettingsViewModel.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/viewmodel/BusinessSettingsViewModel.kt
@@ -1,0 +1,102 @@
+package com.creapolis.solennix.feature.settings.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.model.User
+import com.creapolis.solennix.core.network.ApiService
+import com.creapolis.solennix.core.network.AuthManager
+import com.creapolis.solennix.core.network.Endpoints
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BusinessSettingsViewModel @Inject constructor(
+    private val authManager: AuthManager,
+    private val apiService: ApiService
+) : ViewModel() {
+
+    var businessName by mutableStateOf("")
+    var showBusinessNameInPdf by mutableStateOf(false)
+    var logoUrl by mutableStateOf<String?>(null)
+    var brandColor by mutableStateOf("#007AFF")
+
+    var isLoading by mutableStateOf(true)
+    var isSaving by mutableStateOf(false)
+    var isUploadingLogo by mutableStateOf(false)
+    var errorMessage by mutableStateOf<String?>(null)
+    var saveSuccess by mutableStateOf(false)
+
+    init {
+        loadUser()
+    }
+
+    fun loadUser() {
+        viewModelScope.launch {
+            isLoading = true
+            errorMessage = null
+            try {
+                val user = authManager.currentUser.value
+                if (user != null) {
+                    businessName = user.businessName ?: ""
+                    showBusinessNameInPdf = user.showBusinessNameInPdf ?: true
+                    logoUrl = user.logoUrl
+                    brandColor = user.brandColor ?: "#007AFF"
+                }
+            } catch (e: Exception) {
+                errorMessage = "Error al cargar los datos: ${e.message}"
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    fun saveBusinessSettings() {
+        viewModelScope.launch {
+            isSaving = true
+            errorMessage = null
+            try {
+                val payload = mapOf(
+                    "business_name" to businessName.trim(),
+                    "show_business_name_in_pdf" to showBusinessNameInPdf,
+                    "brand_color" to brandColor
+                )
+                val updatedUser: User = apiService.put(Endpoints.UPDATE_PROFILE, payload)
+                authManager.storeUser(updatedUser)
+                saveSuccess = true
+            } catch (e: Exception) {
+                errorMessage = "Error al guardar: ${e.message}"
+            } finally {
+                isSaving = false
+            }
+        }
+    }
+
+    fun uploadLogo(bytes: ByteArray) {
+        viewModelScope.launch {
+            isUploadingLogo = true
+            errorMessage = null
+            try {
+                val uploadedUrl: String = apiService.upload(
+                    Endpoints.UPLOAD_IMAGE,
+                    bytes,
+                    "logo.jpg",
+                    "image/jpeg"
+                )
+
+                // Update profile with new logo URL
+                val payload = mapOf("logo_url" to uploadedUrl)
+                val updatedUser: User = apiService.put(Endpoints.UPDATE_PROFILE, payload)
+                authManager.storeUser(updatedUser)
+                logoUrl = uploadedUrl
+            } catch (e: Exception) {
+                errorMessage = "Error al subir el logo: ${e.message}"
+            } finally {
+                isUploadingLogo = false
+            }
+        }
+    }
+}

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/viewmodel/ContractDefaultsViewModel.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/viewmodel/ContractDefaultsViewModel.kt
@@ -1,0 +1,77 @@
+package com.creapolis.solennix.feature.settings.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.model.User
+import com.creapolis.solennix.core.network.ApiService
+import com.creapolis.solennix.core.network.AuthManager
+import com.creapolis.solennix.core.network.Endpoints
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ContractDefaultsViewModel @Inject constructor(
+    private val authManager: AuthManager,
+    private val apiService: ApiService
+) : ViewModel() {
+
+    var depositPercent by mutableStateOf(50f)
+    var cancellationDays by mutableStateOf(7f)
+    var refundPercent by mutableStateOf(50f)
+    var contractTemplate by mutableStateOf("")
+
+    var isLoading by mutableStateOf(true)
+    var isSaving by mutableStateOf(false)
+    var saveSuccess by mutableStateOf(false)
+    var errorMessage by mutableStateOf<String?>(null)
+
+    init {
+        loadContractDefaults()
+    }
+
+    fun loadContractDefaults() {
+        viewModelScope.launch {
+            isLoading = true
+            errorMessage = null
+            try {
+                val user = authManager.currentUser.value
+                if (user != null) {
+                    depositPercent = user.defaultDepositPercent?.toFloat() ?: 50f
+                    cancellationDays = user.defaultCancellationDays?.toFloat() ?: 7f
+                    refundPercent = user.defaultRefundPercent?.toFloat() ?: 50f
+                    contractTemplate = user.contractTemplate ?: ""
+                }
+            } catch (e: Exception) {
+                errorMessage = "Error al cargar los datos: ${e.message}"
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    fun saveContractDefaults() {
+        viewModelScope.launch {
+            isSaving = true
+            errorMessage = null
+            try {
+                val payload = mapOf(
+                    "default_deposit_percent" to depositPercent.toDouble(),
+                    "default_cancellation_days" to cancellationDays.toDouble(),
+                    "default_refund_percent" to refundPercent.toDouble(),
+                    "contract_template" to contractTemplate.trim()
+                )
+                val updatedUser: User = apiService.put(Endpoints.UPDATE_PROFILE, payload)
+                authManager.storeUser(updatedUser)
+                saveSuccess = true
+            } catch (e: Exception) {
+                errorMessage = "Error al guardar: ${e.message}"
+            } finally {
+                isSaving = false
+            }
+        }
+    }
+}


### PR DESCRIPTION
…s, contract defaults, event notifications, and app search

- Add 4-page first-launch onboarding flow with HorizontalPager, premium gradient design, and SharedPreferences gate
- Add BusinessSettingsScreen with logo upload, business name, PDF toggle, and brand color picker
- Add ContractDefaultsScreen with deposit/cancellation/refund sliders, contract template editor, and terms preview
- Add EventDayNotificationManager for persistent event day notifications (Android equivalent of iOS Live Activities)
- Wire event day notifications into EventDetailViewModel and SyncWorker for automatic today's-event tracking
- Add AppSearchIndexer using ShortcutManagerCompat for on-device content indexing of clients, events, and products
- Update Route.kt, MainNavHost, and SettingsScreen with new navigation routes
- Update AndroidManifest with deep link intent filters for solennix:// scheme

https://claude.ai/code/session_01MF2ur7DmFx4LKY2Ye7xu7N