### PR TITLE
feat(ios,android): sync product info to match web completeness

### DIFF
--- a/PRD/11_CURRENT_STATUS.md
+++ b/PRD/11_CURRENT_STATUS.md
@@ -217,9 +217,9 @@
 - ✅ Cotizacion rapida (QuickQuoteView)
 
 ### Productos
-- ✅ Lista de productos (ProductListView)
-- ✅ Detalle de producto (ProductDetailView)
-- ✅ Formulario de producto (ProductFormView)
+- ✅ Lista de productos (ProductListView) — con busqueda, filtros por categoria, ordenamiento
+- ✅ Detalle de producto (ProductDetailView) — KPI cards (precio, costo/unidad, margen, eventos), alerta inteligente, tablas de composicion con costos, demanda por fecha con urgencia y revenue
+- ✅ Formulario de producto (ProductFormView) — con gestion estructurada de ingredientes/equipo/insumos con costos estimados
 
 ### Inventario
 - ✅ Lista de inventario (InventoryListView)
@@ -338,9 +338,9 @@
 - ✅ Cotizacion rapida (QuickQuoteScreen, QuickQuoteViewModel, QuickQuotePdfGenerator)
 
 ### Productos
-- ✅ Lista de productos (ProductListScreen)
-- ✅ Detalle de producto (ProductDetailScreen)
-- ✅ Formulario de producto (ProductFormScreen)
+- ✅ Lista de productos (ProductListScreen) — con busqueda, filtros por categoria, ordenamiento (nombre/precio/categoria)
+- ✅ Detalle de producto (ProductDetailScreen) — KPI cards (precio, costo/unidad, margen, eventos), alerta inteligente, tablas de composicion con costos, demanda por fecha con urgencia y revenue
+- ✅ Formulario de producto (ProductFormScreen) — con gestion estructurada de ingredientes/equipo/insumos con picker de inventario y costos estimados
 
 ### Inventario
 - ✅ Lista de inventario (InventoryListScreen)
@@ -442,9 +442,16 @@
 | Feature | iOS | Android | Web | Backend | Notas |
 |---------|-----|---------|-----|---------|-------|
 | Lista de productos | ✅ | ✅ | ✅ | ✅ | |
+| Ordenamiento de lista | ✅ | ✅ | ✅ | ✅ | Nombre, Precio, Categoria |
 | Detalle de producto | ✅ | ✅ | ✅ | ✅ | |
+| KPI cards (precio, costo, margen, eventos) | ✅ | ✅ | ✅ | ✅ | |
+| Tablas de composicion (insumos, equipo, suministros) | ✅ | ✅ | ✅ | ✅ | Con costos estimados |
+| Alerta inteligente de demanda | ✅ | ✅ | ✅ | ✅ | Demanda 7 dias + revenue estimado |
+| Demanda por fecha con urgencia | ✅ | ✅ | ✅ | ✅ | Badges Hoy/Manana, revenue por evento |
 | Formulario de producto | ✅ | ✅ | ✅ | ✅ | |
+| Gestion de ingredientes/equipo/insumos en form | ✅ | ✅ | ✅ | ✅ | Con picker de inventario y costos |
 | Ingredientes | ✅ | ✅ | ✅ | ✅ | |
+| Exportar CSV | ⬜ | ⬜ | ✅ | ➖ | Solo web |
 
 ### Inventario
 

--- a/PRD/11_CURRENT_STATUS.md
+++ b/PRD/11_CURRENT_STATUS.md
@@ -222,8 +222,8 @@
 - ✅ Formulario de producto (ProductFormView) — con gestion estructurada de ingredientes/equipo/insumos con costos estimados
 
 ### Inventario
-- ✅ Lista de inventario (InventoryListView)
-- ✅ Detalle de inventario (InventoryDetailView)
+- ✅ Lista de inventario (InventoryListView) — con busqueda, filtro stock bajo, ordenamiento
+- ✅ Detalle de inventario (InventoryDetailView) — KPI cards (costo, valor en stock), pronostico de demanda, alerta inteligente 7 dias, barras de salud de stock, ajuste rapido
 - ✅ Formulario de inventario (InventoryFormView)
 
 ### Calendario
@@ -343,8 +343,8 @@
 - ✅ Formulario de producto (ProductFormScreen) — con gestion estructurada de ingredientes/equipo/insumos con picker de inventario y costos estimados
 
 ### Inventario
-- ✅ Lista de inventario (InventoryListScreen)
-- ✅ Detalle de inventario (InventoryDetailScreen)
+- ✅ Lista de inventario (InventoryListScreen) — con busqueda, filtro stock bajo, ordenamiento (nombre/stock/minimo/costo)
+- ✅ Detalle de inventario (InventoryDetailScreen) — KPI cards (stock, minimo, costo, valor), pronostico de demanda, alerta inteligente 7 dias, barras de salud, ajuste rapido de stock
 - ✅ Formulario de inventario (InventoryFormScreen)
 
 ### Calendario
@@ -458,8 +458,15 @@
 | Feature | iOS | Android | Web | Backend | Notas |
 |---------|-----|---------|-----|---------|-------|
 | Lista de inventario | ✅ | ✅ | ✅ | ✅ | |
+| Ordenamiento de lista | ✅ | ✅ | ✅ | ✅ | Nombre, Stock, Minimo, Costo |
 | Detalle de inventario | ✅ | ✅ | ✅ | ✅ | |
+| KPI cards (stock, minimo, costo, valor) | ✅ | ✅ | ✅ | ✅ | |
+| Pronostico de demanda desde eventos | ✅ | ✅ | ✅ | ✅ | Calcula demanda por ingredientes de productos |
+| Alerta inteligente de stock 7 dias | ✅ | ✅ | ✅ | ✅ | Critico/advertencia/OK |
+| Barras de salud de stock | ✅ | ✅ | ✅ | ✅ | Stock actual vs minimo vs demanda |
+| Ajuste rapido de stock | ✅ | ✅ | ✅ | ✅ | Con botones -10/-1/+1/+10 |
 | Formulario de inventario | ✅ | ✅ | ✅ | ✅ | |
+| Exportar CSV | ⬜ | ⬜ | ✅ | ➖ | Solo web |
 
 ### Calendario
 

--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/ProductRepository.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/ProductRepository.kt
@@ -4,6 +4,7 @@ import com.creapolis.solennix.core.database.dao.ProductDao
 import com.creapolis.solennix.core.database.entity.asEntity
 import com.creapolis.solennix.core.database.entity.asExternalModel
 import com.creapolis.solennix.core.model.Product
+import com.creapolis.solennix.core.model.ProductIngredient
 import com.creapolis.solennix.core.network.ApiService
 import com.creapolis.solennix.core.network.Endpoints
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +19,8 @@ interface ProductRepository {
     suspend fun createProduct(product: Product): Product
     suspend fun updateProduct(product: Product): Product
     suspend fun deleteProduct(id: String)
+    suspend fun getProductIngredients(productId: String): List<ProductIngredient>
+    suspend fun updateProductIngredients(productId: String, ingredients: List<ProductIngredient>): List<ProductIngredient>
 }
 
 @Singleton
@@ -53,4 +56,13 @@ class OfflineFirstProductRepository @Inject constructor(
         apiService.delete(Endpoints.product(id))
         productDao.deleteProductById(id)
     }
+
+    override suspend fun getProductIngredients(productId: String): List<ProductIngredient> =
+        apiService.get(Endpoints.productIngredients(productId))
+
+    override suspend fun updateProductIngredients(
+        productId: String,
+        ingredients: List<ProductIngredient>
+    ): List<ProductIngredient> =
+        apiService.put(Endpoints.productIngredients(productId), ingredients)
 }

--- a/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/ui/InventoryDetailScreen.kt
+++ b/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/ui/InventoryDetailScreen.kt
@@ -1,20 +1,34 @@
 package com.creapolis.solennix.feature.inventory.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.extensions.asMXN
 import com.creapolis.solennix.feature.inventory.viewmodel.InventoryDetailViewModel
+import com.creapolis.solennix.feature.inventory.viewmodel.InventoryDemandEntry
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -25,11 +39,15 @@ fun InventoryDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var showAdjustSheet by remember { mutableStateOf(false) }
+    var adjustmentValue by remember { mutableStateOf("") }
 
     LaunchedEffect(viewModel.deleteSuccess) {
-        if (viewModel.deleteSuccess) {
-            onNavigateBack()
-        }
+        if (viewModel.deleteSuccess) onNavigateBack()
+    }
+
+    LaunchedEffect(viewModel.adjustmentSuccess) {
+        if (viewModel.adjustmentSuccess) showAdjustSheet = false
     }
 
     if (showDeleteDialog) {
@@ -39,20 +57,33 @@ fun InventoryDetailScreen(
             text = { Text("¿Estás seguro de que deseas eliminar este item del inventario? Esta acción no se puede deshacer.") },
             confirmButton = {
                 TextButton(
-                    onClick = {
-                        showDeleteDialog = false
-                        viewModel.deleteItem()
-                    },
+                    onClick = { showDeleteDialog = false; viewModel.deleteItem() },
                     colors = ButtonDefaults.textButtonColors(contentColor = SolennixTheme.colors.error)
-                ) {
-                    Text("Eliminar")
-                }
+                ) { Text("Eliminar") }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteDialog = false }) {
-                    Text("Cancelar")
-                }
+                TextButton(onClick = { showDeleteDialog = false }) { Text("Cancelar") }
             }
+        )
+    }
+
+    if (showAdjustSheet) {
+        StockAdjustmentSheet(
+            itemName = uiState.item?.ingredientName ?: "",
+            currentStock = uiState.item?.currentStock ?: 0.0,
+            unit = uiState.item?.unit ?: "",
+            adjustmentValue = adjustmentValue,
+            onValueChange = { adjustmentValue = it },
+            onQuickAdjust = { delta ->
+                val current = adjustmentValue.toDoubleOrNull() ?: (uiState.item?.currentStock ?: 0.0)
+                adjustmentValue = (current + delta).coerceAtLeast(0.0).let {
+                    if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it)
+                }
+            },
+            onSave = {
+                adjustmentValue.toDoubleOrNull()?.let { viewModel.adjustStock(it) }
+            },
+            onDismiss = { showAdjustSheet = false }
         )
     }
 
@@ -67,87 +98,516 @@ fun InventoryDetailScreen(
                 },
                 actions = {
                     uiState.item?.let { item ->
+                        IconButton(onClick = {
+                            adjustmentValue = item.currentStock.let {
+                                if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it)
+                            }
+                            showAdjustSheet = true
+                        }) {
+                            Icon(Icons.Default.Tune, contentDescription = "Ajustar stock")
+                        }
                         IconButton(onClick = { onEditClick(item.id) }) {
                             Icon(Icons.Default.Edit, contentDescription = "Edit")
                         }
                         IconButton(onClick = { showDeleteDialog = true }) {
-                            Icon(Icons.Default.Delete, contentDescription = "Delete")
+                            Icon(Icons.Default.Delete, contentDescription = "Delete", tint = SolennixTheme.colors.error)
                         }
                     }
                 }
             )
         }
     ) { padding ->
+        val colors = SolennixTheme.colors
+
         if (uiState.isLoading) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
         } else if (uiState.errorMessage != null) {
             Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
-                Text(uiState.errorMessage.orEmpty(), color = SolennixTheme.colors.error)
+                Text(uiState.errorMessage.orEmpty(), color = colors.error)
             }
         } else if (uiState.item != null) {
             val item = uiState.item ?: return@Scaffold
-            val scrollState = rememberScrollState()
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
-                    .verticalScroll(scrollState)
-                    .padding(24.dp)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Text(
-                    text = item.ingredientName,
-                    style = MaterialTheme.typography.headlineMedium,
-                    color = SolennixTheme.colors.primaryText
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                
-                Surface(
-                    color = SolennixTheme.colors.surfaceAlt,
-                    shape = MaterialTheme.shapes.small
-                ) {
+                // Header
+                Text(item.ingredientName, style = MaterialTheme.typography.headlineMedium, color = colors.primaryText)
+                val typeBadgeColor = when (item.type.name) {
+                    "EQUIPMENT" -> Color(0xFF9C27B0)
+                    "SUPPLY" -> Color(0xFFFF9800)
+                    else -> colors.primary
+                }
+                val typeLabel = when (item.type.name) {
+                    "EQUIPMENT" -> "Activo / Equipo"
+                    "SUPPLY" -> "Insumo por Evento"
+                    else -> "Insumo Consumible"
+                }
+                Surface(shape = RoundedCornerShape(16.dp), color = typeBadgeColor.copy(alpha = 0.1f)) {
                     Text(
-                        text = item.type.name.uppercase(),
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = SolennixTheme.colors.secondaryText
+                        typeLabel,
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = typeBadgeColor,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
                     )
                 }
-                
-                Spacer(modifier = Modifier.height(24.dp))
-                
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.weight(1f)) {
-                        Text("Stock Actual", style = MaterialTheme.typography.labelMedium, color = SolennixTheme.colors.secondaryText)
-                        val isLow = item.currentStock <= item.minimumStock
-                        Text(
-                            text = "${item.currentStock} ${item.unit}",
-                            style = MaterialTheme.typography.titleLarge,
-                            color = if (isLow) SolennixTheme.colors.error else SolennixTheme.colors.success,
-                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
-                        )
-                    }
-                    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.weight(1f)) {
-                        Text("Stock Mínimo", style = MaterialTheme.typography.labelMedium, color = SolennixTheme.colors.secondaryText)
-                        Text(
-                            text = "${item.minimumStock} ${item.unit}",
-                            style = MaterialTheme.typography.titleLarge,
-                            color = SolennixTheme.colors.primaryText,
-                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
-                        )
-                    }
+
+                // KPI Cards
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    val stockColor = if (uiState.isLowStock) colors.error else Color(0xFF4CAF50)
+                    InventoryKpiCard(
+                        icon = Icons.Default.Inventory2,
+                        iconColor = stockColor,
+                        label = "Stock Actual",
+                        value = "${item.currentStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }}",
+                        subtitle = item.unit,
+                        valueColor = stockColor,
+                        extraLabel = if (uiState.isLowStock) "Bajo mínimo" else null,
+                        extraColor = colors.error,
+                        modifier = Modifier.weight(1f)
+                    )
+                    InventoryKpiCard(
+                        icon = Icons.Default.TrendingDown,
+                        iconColor = colors.secondaryText,
+                        label = "Stock Mínimo",
+                        value = "${item.minimumStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }}",
+                        subtitle = item.unit,
+                        modifier = Modifier.weight(1f)
+                    )
                 }
-                
-                if (item.unitCost != null) {
-                    Spacer(modifier = Modifier.height(24.dp))
-                    Text("Costo Unitario", style = MaterialTheme.typography.labelMedium, color = SolennixTheme.colors.secondaryText)
-                    Text("$${item.unitCost}", style = MaterialTheme.typography.bodyLarge, color = SolennixTheme.colors.primaryText)
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    InventoryKpiCard(
+                        icon = Icons.Default.AttachMoney,
+                        iconColor = colors.primary,
+                        label = "Costo Unitario",
+                        value = item.unitCost?.asMXN() ?: "—",
+                        subtitle = "por ${item.unit}",
+                        modifier = Modifier.weight(1f)
+                    )
+                    InventoryKpiCard(
+                        icon = Icons.Default.Assessment,
+                        iconColor = colors.primary,
+                        label = "Valor en Stock",
+                        value = if (item.unitCost != null) uiState.stockValue.asMXN() else "—",
+                        subtitle = "valor total",
+                        modifier = Modifier.weight(1f)
+                    )
                 }
 
-                Spacer(modifier = Modifier.height(24.dp))
-                Text("Última actualización: ${item.lastUpdated}", style = MaterialTheme.typography.bodySmall, color = SolennixTheme.colors.tertiaryText)
+                // Smart Alert
+                SmartStockAlert(
+                    demand7Days = uiState.demand7Days,
+                    stockAfter7Days = uiState.stockAfter7Days,
+                    isLowStock = uiState.isLowStock,
+                    currentStock = item.currentStock,
+                    minimumStock = item.minimumStock,
+                    unit = item.unit,
+                    hasDemand = uiState.demandEntries.isNotEmpty(),
+                    colors = colors
+                )
+
+                // Stock Health Bars
+                StockHealthBars(
+                    currentStock = item.currentStock,
+                    minimumStock = item.minimumStock,
+                    demand7Days = uiState.demand7Days,
+                    isLowStock = uiState.isLowStock,
+                    stockAfter7Days = uiState.stockAfter7Days,
+                    unit = item.unit,
+                    colors = colors
+                )
+
+                // Demand Forecast
+                DemandForecastCard(
+                    entries = uiState.demandEntries,
+                    currentStock = item.currentStock,
+                    unit = item.unit,
+                    colors = colors
+                )
+
+                // Adjust stock button
+                Button(
+                    onClick = {
+                        adjustmentValue = item.currentStock.let {
+                            if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it)
+                        }
+                        showAdjustSheet = true
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = colors.primary.copy(alpha = 0.1f),
+                        contentColor = colors.primary
+                    )
+                ) {
+                    Icon(Icons.Default.Tune, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Ajustar Stock", fontWeight = FontWeight.SemiBold)
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
             }
+        }
+    }
+}
+
+@Composable
+private fun InventoryKpiCard(
+    icon: ImageVector,
+    iconColor: Color,
+    label: String,
+    value: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    valueColor: Color = SolennixTheme.colors.primaryText,
+    extraLabel: String? = null,
+    extraColor: Color = SolennixTheme.colors.error
+) {
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(label, style = MaterialTheme.typography.labelSmall, color = SolennixTheme.colors.secondaryText)
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(value, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.Black, color = valueColor, maxLines = 1)
+            Text(subtitle, style = MaterialTheme.typography.labelSmall, color = SolennixTheme.colors.secondaryText)
+            if (extraLabel != null) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Warning, contentDescription = null, tint = extraColor, modifier = Modifier.size(12.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(extraLabel, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.SemiBold, color = extraColor)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SmartStockAlert(
+    demand7Days: Double,
+    stockAfter7Days: Double,
+    isLowStock: Boolean,
+    currentStock: Double,
+    minimumStock: Double,
+    unit: String,
+    hasDemand: Boolean,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    val isCritical = demand7Days > 0 && stockAfter7Days < 0
+    val isWarning = demand7Days > 0 && stockAfter7Days >= 0 && stockAfter7Days < minimumStock
+    val isLowOnly = isLowStock && demand7Days == 0.0
+
+    val (bgColor, borderColor, iconColor, icon) = when {
+        isCritical -> listOf(colors.error.copy(alpha = 0.08f), colors.error.copy(alpha = 0.2f), colors.error, Icons.Default.Warning)
+        isWarning -> listOf(Color(0xFFFFF3E0), Color(0xFFFFE0B2), Color(0xFFFF9800), Icons.Default.Warning)
+        isLowOnly -> listOf(colors.error.copy(alpha = 0.08f), colors.error.copy(alpha = 0.2f), colors.error, Icons.Default.Warning)
+        else -> listOf(Color(0xFFE8F5E9), Color(0xFFC8E6C9), Color(0xFF4CAF50), Icons.Default.CheckCircle)
+    }
+
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = bgColor as Color,
+        border = androidx.compose.foundation.BorderStroke(1.dp, borderColor as Color),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(modifier = Modifier.padding(16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Icon(icon as ImageVector, contentDescription = null, tint = iconColor as Color, modifier = Modifier.size(24.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = when {
+                        isCritical -> "¡Stock insuficiente para los próximos 7 días!"
+                        isWarning -> "Stock quedará bajo el mínimo tras eventos próximos"
+                        isLowOnly -> "Stock por debajo del mínimo recomendado"
+                        demand7Days > 0 -> "Stock suficiente para los próximos 7 días"
+                        hasDemand -> "Sin demanda en los próximos 7 días"
+                        else -> "Sin eventos próximos"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = iconColor
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = when {
+                        isCritical -> "Necesitas ${demand7Days.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit en los próximos 7 días. Tienes ${currentStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit. Faltan ${(-stockAfter7Days).let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit."
+                        isLowOnly -> "Tu stock actual (${currentStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit) está por debajo del mínimo recomendado (${minimumStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit)."
+                        else -> "Stock actual: ${currentStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.secondaryText
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StockHealthBars(
+    currentStock: Double,
+    minimumStock: Double,
+    demand7Days: Double,
+    isLowStock: Boolean,
+    stockAfter7Days: Double,
+    unit: String,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    val maxBar = maxOf(currentStock, minimumStock, demand7Days, 1.0)
+
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            // Stock Actual bar
+            HealthBar(
+                label = "Stock Actual",
+                value = "${currentStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit",
+                fraction = (currentStock / maxBar).toFloat().coerceIn(0f, 1f),
+                barColor = if (isLowStock) colors.error else colors.primary
+            )
+            // Mínimo bar
+            HealthBar(
+                label = "Mínimo Recomendado",
+                value = "${minimumStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit",
+                fraction = (minimumStock / maxBar).toFloat().coerceIn(0f, 1f),
+                barColor = Color(0xFFFF9800)
+            )
+            // Demand bar (only if demand exists)
+            if (demand7Days > 0) {
+                HealthBar(
+                    label = "Demanda próximos 7 días",
+                    value = "${demand7Days.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit",
+                    fraction = (demand7Days / maxBar).toFloat().coerceIn(0f, 1f),
+                    barColor = if (stockAfter7Days < 0) colors.error else Color(0xFFFF9800)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HealthBar(label: String, value: String, fraction: Float, barColor: Color) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(label, style = MaterialTheme.typography.labelSmall, color = SolennixTheme.colors.secondaryText)
+            Text(value, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = SolennixTheme.colors.primaryText)
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(SolennixTheme.colors.surfaceGrouped)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(fraction)
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(barColor)
+            )
+        }
+    }
+}
+
+@Composable
+private fun DemandForecastCard(
+    entries: List<InventoryDemandEntry>,
+    currentStock: Double,
+    unit: String,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.CalendarMonth, contentDescription = null, tint = colors.primary, modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Demanda por Fecha", style = MaterialTheme.typography.titleMedium, color = colors.primaryText)
+                }
+                Text("Eventos confirmados", style = MaterialTheme.typography.labelSmall, color = colors.secondaryText)
+            }
+
+            if (entries.isEmpty()) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(Icons.Default.CalendarMonth, contentDescription = null, modifier = Modifier.size(32.dp), tint = colors.tertiaryText)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text("Sin eventos confirmados que usen este ítem.", style = MaterialTheme.typography.bodySmall, color = colors.secondaryText)
+                }
+            } else {
+                val today = LocalDate.now()
+                val dateFormatter = DateTimeFormatter.ofPattern("d 'de' MMMM", Locale("es"))
+                var accumulated = currentStock
+
+                entries.forEach { entry ->
+                    accumulated -= entry.quantity
+                    val eventDate = try { LocalDate.parse(entry.eventDate) } catch (_: Exception) { null }
+                    val diffDays = eventDate?.let { ChronoUnit.DAYS.between(today, it).toInt() } ?: Int.MAX_VALUE
+                    val isUrgent = accumulated < 0
+                    val isWithinWeek = diffDays in 0..7
+
+                    val dotColor = when {
+                        isUrgent -> colors.error
+                        isWithinWeek -> Color(0xFFFF9800)
+                        else -> colors.primary.copy(alpha = 0.4f)
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(dotColor))
+                        Spacer(modifier = Modifier.width(10.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                Text(
+                                    eventDate?.format(dateFormatter) ?: entry.eventDate,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = FontWeight.Medium,
+                                    color = colors.primaryText
+                                )
+                                when (diffDays) {
+                                    0 -> BadgeLabel("Hoy", colors.primary)
+                                    1 -> BadgeLabel("Mañana", Color(0xFFFF9800))
+                                    in 2..7 -> Text("en $diffDays días", style = MaterialTheme.typography.labelSmall, color = colors.secondaryText)
+                                }
+                            }
+                        }
+                        Text(
+                            "${entry.quantity.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = if (isUrgent) colors.error else colors.primaryText
+                        )
+                    }
+                }
+
+                // Total
+                HorizontalDivider(color = colors.divider)
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text("Total demanda", style = MaterialTheme.typography.labelSmall, color = colors.secondaryText)
+                    val total = entries.sumOf { it.quantity }
+                    Text(
+                        "${total.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.primaryText
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BadgeLabel(text: String, color: Color) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = color,
+        modifier = Modifier
+            .background(color.copy(alpha = 0.1f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StockAdjustmentSheet(
+    itemName: String,
+    currentStock: Double,
+    unit: String,
+    adjustmentValue: String,
+    onValueChange: (String) -> Unit,
+    onQuickAdjust: (Double) -> Unit,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = SolennixTheme.colors.card
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text("Ajustar Stock", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+            Text(itemName, style = MaterialTheme.typography.titleSmall, color = SolennixTheme.colors.primaryText)
+            Text(
+                "Stock actual: ${currentStock.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} $unit",
+                style = MaterialTheme.typography.bodySmall,
+                color = SolennixTheme.colors.secondaryText
+            )
+
+            HorizontalDivider()
+
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text("Nuevo stock:", style = MaterialTheme.typography.bodyMedium)
+                OutlinedTextField(
+                    value = adjustmentValue,
+                    onValueChange = onValueChange,
+                    modifier = Modifier.width(100.dp),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                    shape = RoundedCornerShape(8.dp)
+                )
+                Text(unit, style = MaterialTheme.typography.bodySmall, color = SolennixTheme.colors.secondaryText)
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(-10.0, -1.0, 1.0, 10.0).forEach { delta ->
+                    OutlinedButton(
+                        onClick = { onQuickAdjust(delta) },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = if (delta > 0) Color(0xFF4CAF50) else SolennixTheme.colors.error
+                        )
+                    ) {
+                        Text(if (delta > 0) "+${delta.toInt()}" else "${delta.toInt()}")
+                    }
+                }
+            }
+
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onDismiss, modifier = Modifier.weight(1f)) { Text("Cancelar") }
+                Button(onClick = onSave, modifier = Modifier.weight(1f)) { Text("Guardar") }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
         }
     }
 }

--- a/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/ui/InventoryListScreen.kt
+++ b/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/ui/InventoryListScreen.kt
@@ -1,14 +1,19 @@
 package com.creapolis.solennix.feature.inventory.ui
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Kitchen
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.ShoppingBasket
+import androidx.compose.material.icons.filled.SortByAlpha
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.Build
 import androidx.compose.material3.*
@@ -24,6 +29,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.InventoryItem
 import com.creapolis.solennix.feature.inventory.viewmodel.InventoryListViewModel
+import com.creapolis.solennix.feature.inventory.viewmodel.InventorySortKey
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,6 +85,51 @@ fun InventoryListScreen(
                     shape = MaterialTheme.shapes.medium,
                     singleLine = true
                 )
+
+                // Sort options
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.SortByAlpha,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = SolennixTheme.colors.secondaryText
+                    )
+                    InventorySortKey.entries.forEach { key ->
+                        val label = when (key) {
+                            InventorySortKey.NAME -> "Nombre"
+                            InventorySortKey.CURRENT_STOCK -> "Stock"
+                            InventorySortKey.MINIMUM_STOCK -> "Mínimo"
+                            InventorySortKey.UNIT_COST -> "Costo"
+                        }
+                        val isSelected = uiState.sortKey == key
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = { viewModel.onSortChange(key) },
+                            label = { Text(label) },
+                            trailingIcon = if (isSelected) {
+                                {
+                                    Icon(
+                                        if (uiState.sortAscending) Icons.Default.ArrowUpward
+                                        else Icons.Default.ArrowDownward,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
+                            } else null,
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = SolennixTheme.colors.primaryLight,
+                                selectedLabelColor = SolennixTheme.colors.primary
+                            )
+                        )
+                    }
+                }
 
                 val hasItems = uiState.ingredientItems.isNotEmpty() ||
                     uiState.equipmentItems.isNotEmpty() ||

--- a/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/viewmodel/InventoryDetailViewModel.kt
+++ b/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/viewmodel/InventoryDetailViewModel.kt
@@ -6,22 +6,62 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.data.repository.EventRepository
 import com.creapolis.solennix.core.data.repository.InventoryRepository
+import com.creapolis.solennix.core.data.repository.ProductRepository
+import com.creapolis.solennix.core.model.EventStatus
 import com.creapolis.solennix.core.model.InventoryItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
+
+data class InventoryDemandEntry(
+    val eventId: String,
+    val eventDate: String,
+    val eventName: String,
+    val quantity: Double,
+    val unit: String
+)
 
 data class InventoryDetailUiState(
     val item: InventoryItem? = null,
+    val demandEntries: List<InventoryDemandEntry> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null
-)
+) {
+    val isLowStock: Boolean
+        get() = item?.let { it.currentStock <= it.minimumStock } ?: false
+
+    val stockValue: Double
+        get() = item?.let { (it.unitCost ?: 0.0) * it.currentStock } ?: 0.0
+
+    val totalDemand: Double
+        get() = demandEntries.sumOf { it.quantity }
+
+    val demand7Days: Double
+        get() {
+            val today = LocalDate.now()
+            val in7Days = today.plusDays(7)
+            return demandEntries.filter { entry ->
+                try {
+                    val date = LocalDate.parse(entry.eventDate)
+                    !date.isBefore(today) && !date.isAfter(in7Days)
+                } catch (_: Exception) { false }
+            }.sumOf { it.quantity }
+        }
+
+    val stockAfter7Days: Double
+        get() = (item?.currentStock ?: 0.0) - demand7Days
+}
 
 @HiltViewModel
 class InventoryDetailViewModel @Inject constructor(
     private val inventoryRepository: InventoryRepository,
+    private val eventRepository: EventRepository,
+    private val productRepository: ProductRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -37,13 +77,83 @@ class InventoryDetailViewModel @Inject constructor(
     var deleteSuccess by mutableStateOf(false)
         private set
 
+    var adjustmentSuccess by mutableStateOf(false)
+        private set
+
     private fun loadItem() {
         viewModelScope.launch {
             try {
                 val item = inventoryRepository.getInventoryItem(itemId)
                 _uiState.value = InventoryDetailUiState(item = item, isLoading = false)
+                loadDemandForecast()
             } catch (e: Exception) {
                 _uiState.value = InventoryDetailUiState(errorMessage = e.message, isLoading = false)
+            }
+        }
+    }
+
+    private fun loadDemandForecast() {
+        viewModelScope.launch {
+            try {
+                val today = LocalDate.now().toString()
+                val events = eventRepository.getEvents().first()
+                val upcomingEvents = events.filter {
+                    it.eventDate >= today && it.status == EventStatus.CONFIRMED
+                }
+
+                val demandEntries = mutableListOf<InventoryDemandEntry>()
+                val item = _uiState.value.item ?: return@launch
+
+                for (event in upcomingEvents) {
+                    val eventProducts = eventRepository.getEventProducts(event.id).first()
+                    var eventDemand = 0.0
+
+                    for (ep in eventProducts) {
+                        try {
+                            val ingredients = productRepository.getProductIngredients(ep.productId)
+                            val matching = ingredients.find { it.inventoryId == itemId }
+                            if (matching != null) {
+                                eventDemand += matching.quantityRequired * ep.quantity
+                            }
+                        } catch (_: Exception) {
+                            // Skip failed ingredient fetches
+                        }
+                    }
+
+                    if (eventDemand > 0) {
+                        demandEntries.add(
+                            InventoryDemandEntry(
+                                eventId = event.id,
+                                eventDate = event.eventDate.take(10),
+                                eventName = event.serviceType ?: "Evento",
+                                quantity = eventDemand,
+                                unit = item.unit
+                            )
+                        )
+                    }
+                }
+
+                _uiState.value = _uiState.value.copy(
+                    demandEntries = demandEntries.sortedBy { it.eventDate }
+                )
+            } catch (_: Exception) {
+                // Demand forecast is supplementary
+            }
+        }
+    }
+
+    fun adjustStock(newStock: Double) {
+        viewModelScope.launch {
+            try {
+                val current = _uiState.value.item ?: return@launch
+                val updated = current.copy(currentStock = newStock.coerceAtLeast(0.0))
+                inventoryRepository.updateInventoryItem(updated)
+                _uiState.value = _uiState.value.copy(item = updated)
+                adjustmentSuccess = true
+            } catch (e: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    errorMessage = "Error al ajustar stock: ${e.message}"
+                )
             }
         }
     }

--- a/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/viewmodel/InventoryListViewModel.kt
+++ b/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/viewmodel/InventoryListViewModel.kt
@@ -10,6 +10,10 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+enum class InventorySortKey {
+    NAME, CURRENT_STOCK, MINIMUM_STOCK, UNIT_COST
+}
+
 data class InventoryListUiState(
     val ingredientItems: List<InventoryItem> = emptyList(),
     val equipmentItems: List<InventoryItem> = emptyList(),
@@ -17,7 +21,9 @@ data class InventoryListUiState(
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val searchQuery: String = "",
-    val lowStockOnly: Boolean = false
+    val lowStockOnly: Boolean = false,
+    val sortKey: InventorySortKey = InventorySortKey.NAME,
+    val sortAscending: Boolean = true
 )
 
 @HiltViewModel
@@ -28,13 +34,15 @@ class InventoryListViewModel @Inject constructor(
     private val _searchQuery = MutableStateFlow("")
     private val _lowStockOnly = MutableStateFlow(false)
     private val _isRefreshing = MutableStateFlow(false)
+    private val _sortKey = MutableStateFlow(InventorySortKey.NAME)
+    private val _sortAscending = MutableStateFlow(true)
 
     val uiState: StateFlow<InventoryListUiState> = combine(
         inventoryRepository.getInventoryItems(),
         _searchQuery,
         _lowStockOnly,
-        _isRefreshing
-    ) { items, query, lowStock, refreshing ->
+        combine(_isRefreshing, _sortKey, _sortAscending) { r, k, a -> Triple(r, k, a) }
+    ) { items, query, lowStock, (refreshing, sortKey, sortAscending) ->
         var filtered = items
         if (query.isNotBlank()) {
             filtered = filtered.filter { it.ingredientName.contains(query, ignoreCase = true) }
@@ -42,13 +50,25 @@ class InventoryListViewModel @Inject constructor(
         if (lowStock) {
             filtered = filtered.filter { it.currentStock <= it.minimumStock }
         }
+        val sorted = when (sortKey) {
+            InventorySortKey.NAME -> if (sortAscending) filtered.sortedBy { it.ingredientName.lowercase() }
+                else filtered.sortedByDescending { it.ingredientName.lowercase() }
+            InventorySortKey.CURRENT_STOCK -> if (sortAscending) filtered.sortedBy { it.currentStock }
+                else filtered.sortedByDescending { it.currentStock }
+            InventorySortKey.MINIMUM_STOCK -> if (sortAscending) filtered.sortedBy { it.minimumStock }
+                else filtered.sortedByDescending { it.minimumStock }
+            InventorySortKey.UNIT_COST -> if (sortAscending) filtered.sortedBy { it.unitCost ?: 0.0 }
+                else filtered.sortedByDescending { it.unitCost ?: 0.0 }
+        }
         InventoryListUiState(
-            ingredientItems = filtered.filter { it.type == InventoryType.INGREDIENT },
-            equipmentItems = filtered.filter { it.type == InventoryType.EQUIPMENT },
-            supplyItems = filtered.filter { it.type == InventoryType.SUPPLY },
+            ingredientItems = sorted.filter { it.type == InventoryType.INGREDIENT },
+            equipmentItems = sorted.filter { it.type == InventoryType.EQUIPMENT },
+            supplyItems = sorted.filter { it.type == InventoryType.SUPPLY },
             isRefreshing = refreshing,
             searchQuery = query,
-            lowStockOnly = lowStock
+            lowStockOnly = lowStock,
+            sortKey = sortKey,
+            sortAscending = sortAscending
         )
     }.stateIn(
         scope = viewModelScope,
@@ -66,6 +86,15 @@ class InventoryListViewModel @Inject constructor(
 
     fun onLowStockToggle(enabled: Boolean) {
         _lowStockOnly.value = enabled
+    }
+
+    fun onSortChange(key: InventorySortKey) {
+        if (_sortKey.value == key) {
+            _sortAscending.value = !_sortAscending.value
+        } else {
+            _sortKey.value = key
+            _sortAscending.value = true
+        }
     }
 
     fun refresh() {

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/DemandForecastChart.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/DemandForecastChart.kt
@@ -1,15 +1,19 @@
 package com.creapolis.solennix.feature.products.ui
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -19,8 +23,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.extensions.asMXN
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Locale
 
 data class DemandDataPoint(
@@ -28,13 +34,17 @@ data class DemandDataPoint(
     val eventDate: String, // YYYY-MM-DD
     val clientName: String,
     val quantity: Int,
-    val numPeople: Int
-)
+    val numPeople: Int,
+    val unitPrice: Double = 0.0
+) {
+    val revenue: Double get() = quantity * unitPrice
+}
 
 @Composable
 fun DemandForecastChart(
     dataPoints: List<DemandDataPoint>,
     productName: String,
+    basePrice: Double = 0.0,
     modifier: Modifier = Modifier
 ) {
     val colors = SolennixTheme.colors
@@ -50,18 +60,29 @@ fun DemandForecastChart(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             // Header
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Default.BarChart,
-                    contentDescription = null,
-                    tint = colors.primary,
-                    modifier = Modifier.size(20.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.BarChart,
+                        contentDescription = null,
+                        tint = colors.primary,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Demanda por Fecha",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = colors.primaryText
+                    )
+                }
                 Text(
-                    text = "Demanda Proyectada",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = colors.primaryText
+                    text = "Eventos confirmados",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.secondaryText
                 )
             }
 
@@ -78,6 +99,9 @@ fun DemandForecastChart(
                 // Summary stats
                 val totalQuantity = dataPoints.sumOf { it.quantity }
                 val totalPeople = dataPoints.sumOf { it.numPeople }
+                val totalRevenue = dataPoints.sumOf { dp ->
+                    if (dp.unitPrice > 0) dp.revenue else dp.quantity * basePrice
+                }
 
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
@@ -95,9 +119,55 @@ fun DemandForecastChart(
 
                 HorizontalDivider(color = colors.divider)
 
-                // Event list (max 5)
+                // Event list with urgency badges
+                val today = LocalDate.now()
                 dataPoints.take(5).forEach { point ->
-                    DemandEventRow(point = point, colors = colors)
+                    DemandEventRow(
+                        point = point,
+                        basePrice = basePrice,
+                        today = today,
+                        colors = colors
+                    )
+                }
+
+                // Total row
+                if (totalQuantity > 0) {
+                    HorizontalDivider(color = colors.divider)
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column {
+                            Text(
+                                text = "TOTAL DEMANDA",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = colors.secondaryText
+                            )
+                            Text(
+                                text = "${dataPoints.size} evento${if (dataPoints.size != 1) "s" else ""}",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = colors.secondaryText
+                            )
+                        }
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text(
+                                text = "$totalQuantity unidades",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = colors.primaryText
+                            )
+                            if (totalRevenue > 0) {
+                                Text(
+                                    text = "${totalRevenue.asMXN()} est.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = colors.secondaryText
+                                )
+                            }
+                        }
+                    }
                 }
             } else {
                 DemandEmptyState(colors = colors)
@@ -143,7 +213,6 @@ private fun DemandBarChart(
             val x = startX + barSpacing + index * (barWidth + barSpacing)
             val y = topPadding + chartHeight - barHeight
 
-            // Bar
             drawRoundRect(
                 color = barColor,
                 topLeft = Offset(x, y),
@@ -151,7 +220,6 @@ private fun DemandBarChart(
                 cornerRadius = CornerRadius(4f, 4f)
             )
 
-            // Value label above bar
             val valueText = "${point.quantity}"
             val valueLayout = textMeasurer.measure(valueText, valueStyle)
             drawText(
@@ -162,7 +230,6 @@ private fun DemandBarChart(
                 )
             )
 
-            // Date label below bar
             val dateLabel = try {
                 LocalDate.parse(point.eventDate).format(dateFormatter)
             } catch (_: Exception) {
@@ -183,48 +250,133 @@ private fun DemandBarChart(
 @Composable
 private fun DemandEventRow(
     point: DemandDataPoint,
+    basePrice: Double,
+    today: LocalDate,
     colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
 ) {
     val dateFormatter = DateTimeFormatter.ofPattern("d 'de' MMMM", Locale("es"))
-    val formattedDate = try {
-        LocalDate.parse(point.eventDate).format(dateFormatter)
+    val eventDate = try {
+        LocalDate.parse(point.eventDate)
     } catch (_: Exception) {
-        point.eventDate
+        null
+    }
+    val formattedDate = eventDate?.format(dateFormatter) ?: point.eventDate
+    val diffDays = eventDate?.let { ChronoUnit.DAYS.between(today, it).toInt() } ?: Int.MAX_VALUE
+    val isUrgent = diffDays <= 3
+    val isThisWeek = diffDays in 4..7
+
+    val bgColor = when {
+        isUrgent -> colors.primary.copy(alpha = 0.08f)
+        isThisWeek -> Color(0xFFFFF3E0) // warning light
+        else -> colors.surfaceGrouped
+    }
+    val dotColor = when {
+        isUrgent -> colors.primary
+        isThisWeek -> Color(0xFFFF9800) // warning
+        else -> colors.primary.copy(alpha = 0.4f)
     }
 
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 4.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
+    val revenue = if (point.unitPrice > 0) point.revenue else point.quantity * basePrice
+
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = bgColor,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = point.clientName,
-                style = MaterialTheme.typography.bodyMedium,
-                color = colors.primaryText
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Urgency dot
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(dotColor)
             )
-            Text(
-                text = formattedDate,
-                style = MaterialTheme.typography.bodySmall,
-                color = colors.tertiaryText
-            )
-        }
-        Column(horizontalAlignment = Alignment.End) {
-            Text(
-                text = "${point.quantity} uds",
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = colors.primary
-            )
-            Text(
-                text = "${point.numPeople} personas",
-                style = MaterialTheme.typography.bodySmall,
-                color = colors.tertiaryText
-            )
+
+            Spacer(modifier = Modifier.width(10.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Text(
+                        text = formattedDate,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = colors.primaryText
+                    )
+                    // Urgency badge
+                    when (diffDays) {
+                        0 -> UrgencyBadge("Hoy", colors.primary)
+                        1 -> UrgencyBadge("Mañana", Color(0xFFFF9800))
+                        in 2..7 -> Text(
+                            text = "en $diffDays días",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = colors.secondaryText
+                        )
+                    }
+                }
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = point.clientName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.secondaryText
+                    )
+                    if (point.numPeople > 0) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                Icons.Default.People,
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp),
+                                tint = colors.tertiaryText
+                            )
+                            Spacer(modifier = Modifier.width(2.dp))
+                            Text(
+                                text = "${point.numPeople}",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = colors.tertiaryText
+                            )
+                        }
+                    }
+                }
+            }
+
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = "${point.quantity} uds",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.primaryText
+                )
+                if (revenue > 0) {
+                    Text(
+                        text = revenue.asMXN(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.secondaryText
+                    )
+                }
+            }
         }
     }
+}
+
+@Composable
+private fun UrgencyBadge(text: String, color: Color) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+        color = color,
+        modifier = Modifier
+            .background(color.copy(alpha = 0.1f), RoundedCornerShape(4.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    )
 }
 
 @Composable

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductDetailScreen.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductDetailScreen.kt
@@ -1,24 +1,32 @@
 package com.creapolis.solennix.feature.products.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
-import com.creapolis.solennix.core.network.UrlResolver
+import com.creapolis.solennix.core.model.InventoryType
+import com.creapolis.solennix.core.model.ProductIngredient
 import com.creapolis.solennix.core.model.extensions.asMXN
+import com.creapolis.solennix.core.network.UrlResolver
 import com.creapolis.solennix.feature.products.viewmodel.ProductDetailViewModel
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -97,12 +105,16 @@ fun ProductDetailScreen(
         } else if (uiState.product != null) {
             val product = uiState.product ?: return@Scaffold
             val scrollState = rememberScrollState()
+            val demandData by viewModel.demandData.collectAsStateWithLifecycle()
+            val colors = SolennixTheme.colors
+
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
                     .verticalScroll(scrollState)
             ) {
+                // Product image
                 if (product.imageUrl != null) {
                     AsyncImage(
                         model = UrlResolver.resolve(product.imageUrl),
@@ -122,52 +134,478 @@ fun ProductDetailScreen(
                         Text(
                             text = product.name.take(1).uppercase(),
                             style = MaterialTheme.typography.displayLarge,
-                            color = SolennixTheme.colors.primary
+                            color = colors.primary
                         )
                     }
                 }
 
-                Column(modifier = Modifier.padding(24.dp)) {
+                Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                    // Name + Category
                     Text(
                         text = product.name,
                         style = MaterialTheme.typography.headlineMedium,
-                        color = SolennixTheme.colors.primaryText
+                        color = colors.primaryText
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = product.category,
-                        style = MaterialTheme.typography.titleMedium,
-                        color = SolennixTheme.colors.secondaryText
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = product.basePrice.asMXN(),
-                        style = MaterialTheme.typography.headlineSmall,
-                        color = SolennixTheme.colors.primary,
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
-                    )
-                    
-                    if (product.recipe != null) {
-                        Spacer(modifier = Modifier.height(32.dp))
-                        Text(
-                            text = "Receta",
-                            style = MaterialTheme.typography.titleLarge,
-                            color = SolennixTheme.colors.primaryText
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = colors.primary.copy(alpha = 0.1f)
+                        ) {
+                            Text(
+                                text = product.category,
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = colors.primary,
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                            )
+                        }
+                        if (!product.isActive) {
+                            Surface(
+                                shape = RoundedCornerShape(16.dp),
+                                color = colors.error.copy(alpha = 0.1f)
+                            ) {
+                                Text(
+                                    text = "Inactivo",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = colors.error,
+                                    modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    // KPI Cards
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        KpiCard(
+                            icon = Icons.Default.AttachMoney,
+                            iconColor = colors.primary,
+                            label = "Precio Base",
+                            value = product.basePrice.asMXN(),
+                            subtitle = "por unidad",
+                            modifier = Modifier.weight(1f)
                         )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = product.recipe.toString(),
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = SolennixTheme.colors.secondaryText
+                        KpiCard(
+                            icon = Icons.Default.Layers,
+                            iconColor = colors.secondaryText,
+                            label = "Costo / Unidad",
+                            value = uiState.unitCost.asMXN(),
+                            subtitle = "en insumos",
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        val marginColor = when {
+                            uiState.margin >= 50 -> Color(0xFF4CAF50) // success
+                            uiState.margin >= 20 -> colors.primaryText
+                            else -> Color(0xFFFF9800) // warning
+                        }
+                        KpiCard(
+                            icon = Icons.Default.TrendingUp,
+                            iconColor = marginColor,
+                            label = "Margen Est.",
+                            value = "%.1f%%".format(uiState.margin),
+                            subtitle = "utilidad estimada",
+                            valueColor = marginColor,
+                            modifier = Modifier.weight(1f)
+                        )
+                        KpiCard(
+                            icon = Icons.Default.CalendarMonth,
+                            iconColor = colors.primary,
+                            label = "Próx. Eventos",
+                            value = "${demandData.size}",
+                            subtitle = "confirmados",
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+
+                    // Smart Alert
+                    SmartAlertSection(
+                        demandData = demandData,
+                        basePrice = product.basePrice,
+                        colors = colors
+                    )
+
+                    // General Info Card
+                    GeneralInfoCard(
+                        category = product.category,
+                        basePrice = product.basePrice,
+                        ingredientCount = uiState.ingredientItems.size,
+                        supplyCount = uiState.supplyItems.size,
+                        equipmentCount = uiState.equipmentItems.size,
+                        colors = colors
+                    )
+
+                    // Composition / Ingredients table
+                    if (uiState.ingredientItems.isNotEmpty()) {
+                        CompositionSection(
+                            title = "Composición / Insumos",
+                            icon = Icons.Default.Layers,
+                            iconColor = colors.primary,
+                            items = uiState.ingredientItems,
+                            showCost = true,
+                            totalLabel = "Costo Total por Unidad",
+                            totalValue = uiState.unitCost,
+                            colors = colors
+                        )
+                    }
+
+                    // Per-event supplies table
+                    if (uiState.supplyItems.isNotEmpty()) {
+                        CompositionSection(
+                            title = "Insumos por Evento",
+                            icon = Icons.Default.LocalGasStation,
+                            iconColor = Color(0xFFFF9800),
+                            items = uiState.supplyItems,
+                            showCost = true,
+                            badge = "Costo fijo por evento",
+                            badgeColor = Color(0xFFFF9800),
+                            totalLabel = "Costo por Evento",
+                            totalValue = uiState.perEventCost,
+                            totalValueColor = Color(0xFFFF9800),
+                            colors = colors
+                        )
+                    }
+
+                    // Equipment table
+                    if (uiState.equipmentItems.isNotEmpty()) {
+                        CompositionSection(
+                            title = "Equipo Necesario",
+                            icon = Icons.Default.Build,
+                            iconColor = Color(0xFF2196F3),
+                            items = uiState.equipmentItems,
+                            showCost = false,
+                            badge = "Sin costo - Reutilizable",
+                            badgeColor = Color(0xFF2196F3),
+                            colors = colors
                         )
                     }
 
                     // Demand Forecast Chart
-                    val demandData by viewModel.demandData.collectAsStateWithLifecycle()
-                    Spacer(modifier = Modifier.height(24.dp))
                     DemandForecastChart(
                         dataPoints = demandData,
-                        productName = product.name
+                        productName = product.name,
+                        basePrice = product.basePrice
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun KpiCard(
+    icon: ImageVector,
+    iconColor: Color,
+    label: String,
+    value: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    valueColor: Color = SolennixTheme.colors.primaryText
+) {
+    Card(
+        modifier = modifier,
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(16.dp))
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = SolennixTheme.colors.secondaryText
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = value,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Black,
+                color = valueColor
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = SolennixTheme.colors.secondaryText
+            )
+        }
+    }
+}
+
+@Composable
+private fun SmartAlertSection(
+    demandData: List<DemandDataPoint>,
+    basePrice: Double,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    val today = LocalDate.now()
+    val in7Days = today.plusDays(7)
+
+    val demand7Days = demandData.filter { dp ->
+        try {
+            val date = LocalDate.parse(dp.eventDate)
+            !date.isBefore(today) && !date.isAfter(in7Days)
+        } catch (_: Exception) { false }
+    }.sumOf { it.quantity }
+
+    val totalDemand = demandData.sumOf { it.quantity }
+    val estimatedRevenue = demandData.sumOf { dp ->
+        if (dp.unitPrice > 0) dp.revenue else dp.quantity * basePrice
+    }
+
+    val isHighDemand = demand7Days > 0
+    val bgColor = if (isHighDemand) colors.primary.copy(alpha = 0.08f) else colors.card
+    val borderColor = if (isHighDemand) colors.primary.copy(alpha = 0.2f) else colors.divider
+
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = bgColor,
+        border = androidx.compose.foundation.BorderStroke(1.dp, borderColor),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                imageVector = if (isHighDemand) Icons.Default.Warning else Icons.Default.CheckCircle,
+                contentDescription = null,
+                tint = if (isHighDemand) colors.primary else Color(0xFF4CAF50),
+                modifier = Modifier.size(24.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = when {
+                        isHighDemand -> "$demand7Days unidades en los próximos 7 días"
+                        demandData.isNotEmpty() -> "Sin demanda inmediata"
+                        else -> "Sin eventos próximos"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isHighDemand) colors.primary else Color(0xFF4CAF50)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = when {
+                        isHighDemand && estimatedRevenue > 0 ->
+                            "Alta demanda esta semana. Ingreso estimado total: ${estimatedRevenue.asMXN()}"
+                        isHighDemand -> "Alta demanda esta semana."
+                        demandData.isNotEmpty() ->
+                            "$totalDemand unidades en ${demandData.size} evento${if (demandData.size != 1) "s" else ""} próximos."
+                        else -> "No hay eventos confirmados que incluyan este producto."
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.secondaryText
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GeneralInfoCard(
+    category: String,
+    basePrice: Double,
+    ingredientCount: Int,
+    supplyCount: Int,
+    equipmentCount: Int,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(
+                text = "INFORMACIÓN GENERAL",
+                style = MaterialTheme.typography.labelSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.secondaryText
+            )
+            InfoRow(Icons.Default.Label, "Categoría", category, colors)
+            HorizontalDivider(color = colors.divider)
+            InfoRow(Icons.Default.AttachMoney, "Precio Base", basePrice.asMXN(), colors)
+            HorizontalDivider(color = colors.divider)
+
+            val compositionText = buildString {
+                append("$ingredientCount insumos")
+                if (supplyCount > 0) append(", $supplyCount insumo(s) por evento")
+                if (equipmentCount > 0) append(", $equipmentCount equipo(s)")
+            }
+            InfoRow(Icons.Default.Layers, "Composición", compositionText, colors)
+        }
+    }
+}
+
+@Composable
+private fun InfoRow(
+    icon: ImageVector,
+    label: String,
+    value: String,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    Row(verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Icon(icon, contentDescription = null, tint = colors.primary, modifier = Modifier.size(20.dp))
+        Column {
+            Text(text = label, style = MaterialTheme.typography.labelSmall, color = colors.secondaryText)
+            Text(text = value, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.Medium, color = colors.primaryText)
+        }
+    }
+}
+
+@Composable
+private fun CompositionSection(
+    title: String,
+    icon: ImageVector,
+    iconColor: Color,
+    items: List<ProductIngredient>,
+    showCost: Boolean,
+    badge: String? = null,
+    badgeColor: Color = SolennixTheme.colors.primary,
+    totalLabel: String? = null,
+    totalValue: Double? = null,
+    totalValueColor: Color = SolennixTheme.colors.primaryText,
+    colors: com.creapolis.solennix.core.designsystem.theme.SolennixColorScheme
+) {
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(icon, contentDescription = null, tint = iconColor, modifier = Modifier.size(20.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = colors.primaryText
+                    )
+                }
+                if (badge != null) {
+                    Surface(
+                        shape = RoundedCornerShape(8.dp),
+                        color = badgeColor.copy(alpha = 0.1f)
+                    ) {
+                        Text(
+                            text = badge,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                            color = badgeColor,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                        )
+                    }
+                }
+            }
+
+            HorizontalDivider(color = colors.divider)
+
+            // Table header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(colors.surfaceGrouped)
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = "INSUMO",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.secondaryText,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = "CANTIDAD",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.secondaryText
+                )
+                if (showCost) {
+                    Spacer(modifier = Modifier.width(24.dp))
+                    Text(
+                        text = "COSTO EST.",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = colors.secondaryText
+                    )
+                }
+            }
+
+            // Rows
+            items.forEach { ingredient ->
+                HorizontalDivider(color = colors.divider.copy(alpha = 0.5f))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = ingredient.ingredientName ?: "Insumo",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colors.primaryText,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = "${ingredient.quantityRequired.let { if (it == it.toLong().toDouble()) it.toLong().toString() else "%.1f".format(it) }} ${ingredient.unit ?: ""}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = colors.primaryText
+                    )
+                    if (showCost) {
+                        Spacer(modifier = Modifier.width(24.dp))
+                        val cost = ingredient.unitCost?.let { it * ingredient.quantityRequired }
+                        Text(
+                            text = cost?.asMXN() ?: "—",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = if (totalValueColor != colors.primaryText) totalValueColor else colors.primaryText
+                        )
+                    }
+                }
+            }
+
+            // Total footer
+            if (totalLabel != null && totalValue != null) {
+                HorizontalDivider(color = colors.divider)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = totalLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = colors.secondaryText
+                    )
+                    Text(
+                        text = totalValue.asMXN(),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = totalValueColor
                     )
                 }
             }

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductFormScreen.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductFormScreen.kt
@@ -6,34 +6,37 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AttachMoney
-import androidx.compose.material.icons.filled.Category
-import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.PhotoCamera
-import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
-import com.creapolis.solennix.core.network.UrlResolver
 import com.creapolis.solennix.core.designsystem.component.PremiumButton
 import com.creapolis.solennix.core.designsystem.component.SolennixTextField
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.InventoryItem
+import com.creapolis.solennix.core.model.InventoryType
+import com.creapolis.solennix.core.model.extensions.asMXN
+import com.creapolis.solennix.core.network.UrlResolver
 import com.creapolis.solennix.feature.products.viewmodel.ProductFormViewModel
+import com.creapolis.solennix.feature.products.viewmodel.RecipeItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,14 +81,15 @@ fun ProductFormScreen(
                     .fillMaxSize()
                     .padding(padding)
                     .verticalScroll(scrollState)
-                    .padding(16.dp)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 // Image section
                 Text(
                     text = "Imagen del Producto",
                     style = MaterialTheme.typography.labelLarge,
                     color = SolennixTheme.colors.primary,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    modifier = Modifier.padding(bottom = 0.dp)
                 )
 
                 Surface(
@@ -98,7 +102,6 @@ fun ProductFormScreen(
                         modifier = Modifier.padding(16.dp),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        // Image preview
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -137,7 +140,6 @@ fun ProductFormScreen(
                                 }
                             }
 
-                            // Upload overlay
                             if (viewModel.isUploadingImage) {
                                 Box(
                                     modifier = Modifier
@@ -147,9 +149,7 @@ fun ProductFormScreen(
                                         ),
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    CircularProgressIndicator(
-                                        color = SolennixTheme.colors.primary
-                                    )
+                                    CircularProgressIndicator(color = SolennixTheme.colors.primary)
                                 }
                             }
                         }
@@ -184,23 +184,20 @@ fun ProductFormScreen(
                     }
                 }
 
-                Spacer(modifier = Modifier.height(24.dp))
-
+                // Basic info fields
                 SolennixTextField(
                     value = viewModel.name,
                     onValueChange = { viewModel.name = it },
                     label = "Nombre *",
                     leadingIcon = Icons.Default.ShoppingCart
                 )
-                Spacer(modifier = Modifier.height(16.dp))
 
                 SolennixTextField(
                     value = viewModel.category,
                     onValueChange = { viewModel.category = it },
-                    label = "Categoria *",
+                    label = "Categoría *",
                     leadingIcon = Icons.Default.Category
                 )
-                Spacer(modifier = Modifier.height(16.dp))
 
                 SolennixTextField(
                     value = viewModel.basePrice,
@@ -209,7 +206,6 @@ fun ProductFormScreen(
                     leadingIcon = Icons.Default.AttachMoney,
                     keyboardType = KeyboardType.Decimal
                 )
-                Spacer(modifier = Modifier.height(16.dp))
 
                 // Active toggle
                 Row(
@@ -217,11 +213,18 @@ fun ProductFormScreen(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = "Producto activo",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = SolennixTheme.colors.primaryText
-                    )
+                    Column {
+                        Text(
+                            text = "Producto activo",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = SolennixTheme.colors.primaryText
+                        )
+                        Text(
+                            text = "Visible en cotizaciones",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = SolennixTheme.colors.secondaryText
+                        )
+                    }
                     Switch(
                         checked = viewModel.isActive,
                         onCheckedChange = { viewModel.isActive = it },
@@ -231,32 +234,62 @@ fun ProductFormScreen(
                         )
                     )
                 }
-                Spacer(modifier = Modifier.height(16.dp))
 
-                // Recipe / preparation notes
-                OutlinedTextField(
-                    value = viewModel.recipe,
-                    onValueChange = { viewModel.recipe = it },
-                    modifier = Modifier.fillMaxWidth(),
-                    label = { Text("Receta / Notas de preparacion") },
-                    placeholder = { Text("Instrucciones de preparacion, ingredientes, etc.") },
-                    minLines = 3,
-                    maxLines = 6,
-                    shape = MaterialTheme.shapes.small,
-                    colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = SolennixTheme.colors.primary,
-                        focusedLabelColor = SolennixTheme.colors.primary,
-                        cursorColor = SolennixTheme.colors.primary
-                    )
+                // Recipe sections
+                RecipeSectionCard(
+                    title = "Composición / Insumos",
+                    description = "Solo insumos generan costo al producto.",
+                    items = viewModel.ingredients,
+                    inventoryItems = viewModel.ingredientInventoryItems,
+                    onAdd = { viewModel.addIngredient() },
+                    onRemove = { viewModel.removeIngredient(it) },
+                    onSelectInventory = { index, invId ->
+                        viewModel.updateRecipeInventory(viewModel.ingredients, index, invId)
+                    },
+                    onUpdateQuantity = { index, qty ->
+                        viewModel.updateRecipeQuantity(viewModel.ingredients, index, qty)
+                    },
+                    showCost = true
                 )
-                Spacer(modifier = Modifier.height(32.dp))
+
+                RecipeSectionCard(
+                    title = "Equipo Necesario",
+                    description = "Activos reutilizables. No se incluyen en el costo.",
+                    items = viewModel.equipment,
+                    inventoryItems = viewModel.equipmentInventoryItems,
+                    onAdd = { viewModel.addEquipment() },
+                    onRemove = { viewModel.removeEquipment(it) },
+                    onSelectInventory = { index, invId ->
+                        viewModel.updateRecipeInventory(viewModel.equipment, index, invId)
+                    },
+                    onUpdateQuantity = { index, qty ->
+                        viewModel.updateRecipeQuantity(viewModel.equipment, index, qty)
+                    },
+                    showCost = false
+                )
+
+                RecipeSectionCard(
+                    title = "Insumos por Evento",
+                    description = "Costo fijo por evento (ej. aceite, gas).",
+                    items = viewModel.supplies,
+                    inventoryItems = viewModel.supplyInventoryItems,
+                    onAdd = { viewModel.addSupply() },
+                    onRemove = { viewModel.removeSupply(it) },
+                    onSelectInventory = { index, invId ->
+                        viewModel.updateRecipeInventory(viewModel.supplies, index, invId)
+                    },
+                    onUpdateQuantity = { index, qty ->
+                        viewModel.updateRecipeQuantity(viewModel.supplies, index, qty)
+                    },
+                    showCost = true
+                )
 
                 if (viewModel.errorMessage != null) {
                     Text(
                         text = viewModel.errorMessage.orEmpty(),
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall,
-                        modifier = Modifier.padding(bottom = 16.dp)
+                        modifier = Modifier.padding(bottom = 8.dp)
                     )
                 }
 
@@ -268,6 +301,323 @@ fun ProductFormScreen(
                 )
                 Spacer(modifier = Modifier.height(32.dp))
             }
+        }
+    }
+}
+
+@Composable
+private fun RecipeSectionCard(
+    title: String,
+    description: String,
+    items: List<RecipeItem>,
+    inventoryItems: List<InventoryItem>,
+    onAdd: () -> Unit,
+    onRemove: (Int) -> Unit,
+    onSelectInventory: (Int, String) -> Unit,
+    onUpdateQuantity: (Int, Double) -> Unit,
+    showCost: Boolean
+) {
+    val colors = SolennixTheme.colors
+
+    Card(
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = colors.primaryText
+                    )
+                    Text(
+                        text = description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = colors.tertiaryText
+                    )
+                }
+                TextButton(onClick = onAdd) {
+                    Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(16.dp))
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text("Agregar")
+                }
+            }
+
+            if (items.isEmpty()) {
+                Text(
+                    text = "No hay elementos agregados",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colors.tertiaryText,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp)
+                )
+            } else {
+                items.forEachIndexed { index, item ->
+                    if (index > 0) HorizontalDivider(color = colors.divider.copy(alpha = 0.5f))
+                    RecipeItemRow(
+                        item = item,
+                        inventoryItems = inventoryItems,
+                        onSelectInventory = { invId -> onSelectInventory(index, invId) },
+                        onUpdateQuantity = { qty -> onUpdateQuantity(index, qty) },
+                        onRemove = { onRemove(index) },
+                        showCost = showCost
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RecipeItemRow(
+    item: RecipeItem,
+    inventoryItems: List<InventoryItem>,
+    onSelectInventory: (String) -> Unit,
+    onUpdateQuantity: (Double) -> Unit,
+    onRemove: () -> Unit,
+    showCost: Boolean
+) {
+    val colors = SolennixTheme.colors
+    var showPicker by remember { mutableStateOf(false) }
+    var quantityText by remember(item.quantityRequired) {
+        mutableStateOf(
+            if (item.quantityRequired == item.quantityRequired.toLong().toDouble())
+                item.quantityRequired.toLong().toString()
+            else "%.1f".format(item.quantityRequired)
+        )
+    }
+
+    if (showPicker) {
+        InventoryPickerBottomSheet(
+            inventoryItems = inventoryItems,
+            selectedId = item.inventoryId,
+            onSelect = { id ->
+                onSelectInventory(id)
+                showPicker = false
+            },
+            onDismiss = { showPicker = false }
+        )
+    }
+
+    Column(
+        modifier = Modifier.padding(vertical = 4.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        // Inventory selector
+        Surface(
+            onClick = { showPicker = true },
+            shape = RoundedCornerShape(8.dp),
+            color = colors.surfaceGrouped,
+            border = androidx.compose.foundation.BorderStroke(1.dp, colors.divider),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    Icons.Default.Inventory2,
+                    contentDescription = null,
+                    tint = if (item.inventoryId.isNotBlank()) colors.primary else colors.tertiaryText,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.inventoryName ?: "Seleccionar item...",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (item.inventoryId.isNotBlank()) colors.primaryText else colors.tertiaryText
+                    )
+                    if (item.unitCost != null && item.unitCost!! > 0 && showCost) {
+                        Text(
+                            text = "Costo: ${item.unitCost!!.asMXN()} / ${item.unit ?: "und"}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colors.secondaryText
+                        )
+                    }
+                }
+                Icon(
+                    Icons.Default.ChevronRight,
+                    contentDescription = null,
+                    tint = colors.tertiaryText,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+
+        // Quantity + cost + remove
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "Cantidad",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colors.tertiaryText
+                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedTextField(
+                        value = quantityText,
+                        onValueChange = { newValue ->
+                            quantityText = newValue
+                            newValue.toDoubleOrNull()?.let { onUpdateQuantity(it) }
+                        },
+                        modifier = Modifier.width(80.dp),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        textStyle = MaterialTheme.typography.bodyMedium,
+                        shape = RoundedCornerShape(8.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = colors.primary,
+                            cursorColor = colors.primary
+                        )
+                    )
+                    if (item.unit != null) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = item.unit!!,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = colors.tertiaryText
+                        )
+                    }
+                }
+            }
+
+            if (showCost && item.unitCost != null && item.unitCost!! > 0) {
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = "Costo est.",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = colors.tertiaryText
+                    )
+                    Text(
+                        text = (item.quantityRequired * item.unitCost!!).asMXN(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        color = colors.primaryText
+                    )
+                }
+            }
+
+            IconButton(onClick = onRemove) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Eliminar",
+                    tint = colors.error,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun InventoryPickerBottomSheet(
+    inventoryItems: List<InventoryItem>,
+    selectedId: String,
+    onSelect: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val colors = SolennixTheme.colors
+    var searchQuery by remember { mutableStateOf("") }
+
+    val filtered = if (searchQuery.isBlank()) inventoryItems
+    else inventoryItems.filter {
+        it.ingredientName.contains(searchQuery, ignoreCase = true)
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        containerColor = colors.card
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+            Text(
+                text = "Seleccionar Item",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.primaryText,
+                modifier = Modifier.padding(bottom = 12.dp)
+            )
+
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = { Text("Buscar item...") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                shape = RoundedCornerShape(12.dp),
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = colors.primary,
+                    cursorColor = colors.primary
+                )
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            LazyColumn(
+                modifier = Modifier.heightIn(max = 400.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                itemsIndexed(filtered) { _, item ->
+                    Surface(
+                        onClick = { onSelect(item.id) },
+                        shape = RoundedCornerShape(8.dp),
+                        color = if (item.id == selectedId) colors.primary.copy(alpha = 0.08f)
+                        else colors.card
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = item.ingredientName,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = colors.primaryText
+                                )
+                                Text(
+                                    text = "Stock: ${item.currentStock.toInt()} ${item.unit}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = colors.secondaryText
+                                )
+                            }
+                            if (item.unitCost != null && item.unitCost!! > 0) {
+                                Text(
+                                    text = item.unitCost!!.asMXN(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = colors.secondaryText
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                            }
+                            if (item.id == selectedId) {
+                                Icon(
+                                    Icons.Default.CheckCircle,
+                                    contentDescription = null,
+                                    tint = colors.primary,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
         }
     }
 }

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductListScreen.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductListScreen.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SortByAlpha
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -30,6 +33,7 @@ import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.Product
 import com.creapolis.solennix.core.model.extensions.asMXN
 import com.creapolis.solennix.feature.products.viewmodel.ProductListViewModel
+import com.creapolis.solennix.feature.products.viewmodel.ProductSortKey
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -99,6 +103,50 @@ fun ProductListScreen(
                     shape = MaterialTheme.shapes.medium,
                     singleLine = true
                 )
+
+                // Sort options
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        Icons.Default.SortByAlpha,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = SolennixTheme.colors.secondaryText
+                    )
+                    ProductSortKey.entries.forEach { key ->
+                        val label = when (key) {
+                            ProductSortKey.NAME -> "Nombre"
+                            ProductSortKey.PRICE -> "Precio"
+                            ProductSortKey.CATEGORY -> "Categoría"
+                        }
+                        val isSelected = uiState.sortKey == key
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = { viewModel.onSortChange(key) },
+                            label = { Text(label) },
+                            trailingIcon = if (isSelected) {
+                                {
+                                    Icon(
+                                        if (uiState.sortAscending) Icons.Default.ArrowUpward
+                                        else Icons.Default.ArrowDownward,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
+                            } else null,
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = SolennixTheme.colors.primaryLight,
+                                selectedLabelColor = SolennixTheme.colors.primary
+                            )
+                        )
+                    }
+                }
 
                 // Category filter chips
                 if (uiState.allCategories.isNotEmpty()) {

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductDetailViewModel.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductDetailViewModel.kt
@@ -10,6 +10,8 @@ import com.creapolis.solennix.core.data.repository.ClientRepository
 import com.creapolis.solennix.core.data.repository.EventRepository
 import com.creapolis.solennix.core.data.repository.ProductRepository
 import com.creapolis.solennix.core.model.Product
+import com.creapolis.solennix.core.model.ProductIngredient
+import com.creapolis.solennix.core.model.InventoryType
 import com.creapolis.solennix.feature.products.ui.DemandDataPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -19,9 +21,31 @@ import javax.inject.Inject
 
 data class ProductDetailUiState(
     val product: Product? = null,
+    val ingredients: List<ProductIngredient> = emptyList(),
     val isLoading: Boolean = false,
     val errorMessage: String? = null
-)
+) {
+    val ingredientItems: List<ProductIngredient>
+        get() = ingredients.filter { it.type == InventoryType.INGREDIENT }
+
+    val supplyItems: List<ProductIngredient>
+        get() = ingredients.filter { it.type == InventoryType.SUPPLY }
+
+    val equipmentItems: List<ProductIngredient>
+        get() = ingredients.filter { it.type == InventoryType.EQUIPMENT }
+
+    val unitCost: Double
+        get() = ingredientItems.sumOf { it.quantityRequired * (it.unitCost ?: 0.0) }
+
+    val perEventCost: Double
+        get() = supplyItems.sumOf { it.quantityRequired * (it.unitCost ?: 0.0) }
+
+    val margin: Double
+        get() {
+            val price = product?.basePrice ?: 0.0
+            return if (price > 0) ((price - unitCost) / price) * 100 else 0.0
+        }
+}
 
 @HiltViewModel
 class ProductDetailViewModel @Inject constructor(
@@ -51,7 +75,16 @@ class ProductDetailViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 val product = productRepository.getProduct(productId)
-                _uiState.value = ProductDetailUiState(product = product, isLoading = false)
+                val ingredients = try {
+                    productRepository.getProductIngredients(productId)
+                } catch (_: Exception) {
+                    emptyList()
+                }
+                _uiState.value = ProductDetailUiState(
+                    product = product,
+                    ingredients = ingredients,
+                    isLoading = false
+                )
             } catch (e: Exception) {
                 _uiState.value = ProductDetailUiState(errorMessage = e.message, isLoading = false)
             }
@@ -63,19 +96,16 @@ class ProductDetailViewModel @Inject constructor(
             try {
                 val today = LocalDate.now().toString()
 
-                // Collect upcoming events from local DB
                 val events = eventRepository.getEvents().first()
                 val upcomingEvents = events.filter { it.eventDate >= today && it.status == com.creapolis.solennix.core.model.EventStatus.CONFIRMED }
 
                 val demandPoints = mutableListOf<DemandDataPoint>()
 
                 for (event in upcomingEvents) {
-                    // Get products for this event
                     val eventProducts = eventRepository.getEventProducts(event.id).first()
                     val matchingProduct = eventProducts.find { it.productId == productId }
 
                     if (matchingProduct != null) {
-                        // Get client name
                         val client = clientRepository.getClient(event.clientId)
                         val clientName = client?.name ?: "Cliente"
 
@@ -85,16 +115,15 @@ class ProductDetailViewModel @Inject constructor(
                                 eventDate = event.eventDate,
                                 clientName = clientName,
                                 quantity = matchingProduct.quantity.toInt(),
-                                numPeople = event.numPeople
+                                numPeople = event.numPeople,
+                                unitPrice = matchingProduct.unitPrice
                             )
                         )
                     }
                 }
 
-                // Sort by date ascending
                 _demandData.value = demandPoints.sortedBy { it.eventDate }
             } catch (_: Exception) {
-                // Silently fail — demand data is supplementary
                 _demandData.value = emptyList()
             }
         }

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductFormViewModel.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductFormViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
@@ -11,20 +12,36 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.creapolis.solennix.core.data.plan.LimitCheckResult
 import com.creapolis.solennix.core.data.plan.PlanLimitsManager
+import com.creapolis.solennix.core.data.repository.InventoryRepository
 import com.creapolis.solennix.core.data.repository.ProductRepository
+import com.creapolis.solennix.core.model.InventoryItem
+import com.creapolis.solennix.core.model.InventoryType
 import com.creapolis.solennix.core.model.Plan
 import com.creapolis.solennix.core.model.Product
+import com.creapolis.solennix.core.model.ProductIngredient
 import com.creapolis.solennix.core.network.ApiService
 import com.creapolis.solennix.core.network.AuthManager
 import com.creapolis.solennix.core.network.Endpoints
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 
+data class RecipeItem(
+    val id: String = UUID.randomUUID().toString(),
+    var inventoryId: String = "",
+    var quantityRequired: Double = 1.0,
+    var inventoryName: String? = null,
+    var unit: String? = null,
+    var unitCost: Double? = null,
+    val type: InventoryType = InventoryType.INGREDIENT
+)
+
 @HiltViewModel
 class ProductFormViewModel @Inject constructor(
     private val productRepository: ProductRepository,
+    private val inventoryRepository: InventoryRepository,
     private val apiService: ApiService,
     private val planLimitsManager: PlanLimitsManager,
     private val authManager: AuthManager,
@@ -44,7 +61,25 @@ class ProductFormViewModel @Inject constructor(
     var basePrice by mutableStateOf("")
     var imageUrl by mutableStateOf("")
     var isActive by mutableStateOf(true)
-    var recipe by mutableStateOf("")
+
+    // Recipe items
+    val ingredients = mutableStateListOf<RecipeItem>()
+    val equipment = mutableStateListOf<RecipeItem>()
+    val supplies = mutableStateListOf<RecipeItem>()
+
+    // Inventory items for pickers
+    var allInventoryItems by mutableStateOf<List<InventoryItem>>(emptyList())
+        private set
+    val ingredientInventoryItems: List<InventoryItem>
+        get() = allInventoryItems.filter { it.type == InventoryType.INGREDIENT }
+    val equipmentInventoryItems: List<InventoryItem>
+        get() = allInventoryItems.filter { it.type == InventoryType.EQUIPMENT }
+    val supplyInventoryItems: List<InventoryItem>
+        get() = allInventoryItems.filter { it.type == InventoryType.SUPPLY }
+
+    // Categories
+    var existingCategories by mutableStateOf<List<String>>(emptyList())
+        private set
 
     var isLoading by mutableStateOf(false)
     var isSaving by mutableStateOf(false)
@@ -56,36 +91,96 @@ class ProductFormViewModel @Inject constructor(
         get() = name.isNotBlank() && category.isNotBlank() && basePrice.toDoubleOrNull() != null
 
     init {
-        if (productId != null) {
-            loadProduct(productId)
-        } else {
-            // Only check plan limits when creating a new product
-            viewModelScope.launch {
-                val plan = authManager.currentUser.value?.plan ?: Plan.BASIC
-                limitCheckResult = planLimitsManager.canCreateProduct(plan)
-            }
-        }
+        loadData()
     }
 
-    private fun loadProduct(id: String) {
+    private fun loadData() {
         viewModelScope.launch {
             isLoading = true
             try {
-                val product = productRepository.getProduct(id)
-                if (product != null) {
-                    name = product.name
-                    category = product.category
-                    basePrice = product.basePrice.toString()
-                    imageUrl = product.imageUrl ?: ""
-                    isActive = product.isActive
-                    recipe = product.recipe ?: ""
+                // Load inventory items
+                inventoryRepository.syncInventory()
+                allInventoryItems = inventoryRepository.getInventoryItems().first()
+
+                // Load existing categories from products
+                val products = productRepository.getProducts().first()
+                existingCategories = products.map { it.category }.distinct().sorted()
+
+                if (productId != null) {
+                    loadProduct(productId)
+                } else {
+                    val plan = authManager.currentUser.value?.plan ?: Plan.BASIC
+                    limitCheckResult = planLimitsManager.canCreateProduct(plan)
                 }
             } catch (e: Exception) {
-                errorMessage = "Error al cargar producto: ${e.message}"
+                errorMessage = "Error al cargar datos: ${e.message}"
             } finally {
                 isLoading = false
             }
         }
+    }
+
+    private suspend fun loadProduct(id: String) {
+        try {
+            val product = productRepository.getProduct(id)
+            if (product != null) {
+                name = product.name
+                category = product.category
+                basePrice = product.basePrice.toString()
+                imageUrl = product.imageUrl ?: ""
+                isActive = product.isActive
+            }
+
+            // Load ingredients
+            val productIngredients = productRepository.getProductIngredients(id)
+            ingredients.clear()
+            equipment.clear()
+            supplies.clear()
+
+            for (pi in productIngredients) {
+                val item = RecipeItem(
+                    id = pi.id,
+                    inventoryId = pi.inventoryId,
+                    quantityRequired = pi.quantityRequired,
+                    inventoryName = pi.ingredientName,
+                    unit = pi.unit,
+                    unitCost = pi.unitCost,
+                    type = pi.type ?: InventoryType.INGREDIENT
+                )
+                when (item.type) {
+                    InventoryType.INGREDIENT -> ingredients.add(item)
+                    InventoryType.EQUIPMENT -> equipment.add(item)
+                    InventoryType.SUPPLY -> supplies.add(item)
+                }
+            }
+        } catch (e: Exception) {
+            errorMessage = "Error al cargar producto: ${e.message}"
+        }
+    }
+
+    // Recipe management
+    fun addIngredient() { ingredients.add(RecipeItem(type = InventoryType.INGREDIENT)) }
+    fun addEquipment() { equipment.add(RecipeItem(type = InventoryType.EQUIPMENT)) }
+    fun addSupply() { supplies.add(RecipeItem(type = InventoryType.SUPPLY)) }
+
+    fun removeIngredient(index: Int) { if (index in ingredients.indices) ingredients.removeAt(index) }
+    fun removeEquipment(index: Int) { if (index in equipment.indices) equipment.removeAt(index) }
+    fun removeSupply(index: Int) { if (index in supplies.indices) supplies.removeAt(index) }
+
+    fun updateRecipeInventory(list: MutableList<RecipeItem>, index: Int, inventoryId: String) {
+        if (index !in list.indices) return
+        val inv = allInventoryItems.find { it.id == inventoryId }
+        list[index] = list[index].copy(
+            inventoryId = inventoryId,
+            inventoryName = inv?.ingredientName,
+            unit = inv?.unit,
+            unitCost = inv?.unitCost
+        )
+    }
+
+    fun updateRecipeQuantity(list: MutableList<RecipeItem>, index: Int, quantity: Double) {
+        if (index !in list.indices) return
+        list[index] = list[index].copy(quantityRequired = quantity)
     }
 
     fun saveProduct() {
@@ -97,22 +192,40 @@ class ProductFormViewModel @Inject constructor(
             try {
                 val product = Product(
                     id = productId ?: UUID.randomUUID().toString(),
-                    userId = "", // Managed by backend
+                    userId = "",
                     name = name,
                     category = category,
                     basePrice = basePrice.toDoubleOrNull() ?: 0.0,
-                    recipe = recipe.takeIf { it.isNotBlank() },
+                    recipe = null,
                     imageUrl = imageUrl.takeIf { it.isNotBlank() },
                     isActive = isActive,
-                    createdAt = "", // Handled by backend
-                    updatedAt = ""  // Handled by backend
+                    createdAt = "",
+                    updatedAt = ""
                 )
 
-                if (productId != null) {
+                val savedProduct = if (productId != null) {
                     productRepository.updateProduct(product)
                 } else {
                     productRepository.createProduct(product)
                 }
+
+                // Save ingredients
+                val allRecipeItems = ingredients + equipment + supplies
+                val validItems = allRecipeItems.filter { it.inventoryId.isNotBlank() }
+
+                if (validItems.isNotEmpty() || productId != null) {
+                    val ingredientBodies = validItems.map { item ->
+                        ProductIngredient(
+                            id = "",
+                            productId = savedProduct.id,
+                            inventoryId = item.inventoryId,
+                            quantityRequired = item.quantityRequired,
+                            createdAt = ""
+                        )
+                    }
+                    productRepository.updateProductIngredients(savedProduct.id, ingredientBodies)
+                }
+
                 saveSuccess = true
             } catch (e: Exception) {
                 errorMessage = "Error al guardar producto: ${e.message}"

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductListViewModel.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductListViewModel.kt
@@ -16,13 +16,19 @@ import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+enum class ProductSortKey {
+    NAME, PRICE, CATEGORY
+}
+
 data class ProductListUiState(
     val products: List<Product> = emptyList(),
     val allCategories: List<String> = emptyList(),
     val selectedCategory: String? = null,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
-    val searchQuery: String = ""
+    val searchQuery: String = "",
+    val sortKey: ProductSortKey = ProductSortKey.NAME,
+    val sortAscending: Boolean = true
 )
 
 @HiltViewModel
@@ -47,13 +53,15 @@ class ProductListViewModel @Inject constructor(
     private val _searchQuery = MutableStateFlow("")
     private val _selectedCategory = MutableStateFlow<String?>(null)
     private val _isRefreshing = MutableStateFlow(false)
+    private val _sortKey = MutableStateFlow(ProductSortKey.NAME)
+    private val _sortAscending = MutableStateFlow(true)
 
     val uiState: StateFlow<ProductListUiState> = combine(
         productRepository.getProducts(),
         _searchQuery,
         _selectedCategory,
-        _isRefreshing
-    ) { products, query, category, refreshing ->
+        combine(_isRefreshing, _sortKey, _sortAscending) { r, k, a -> Triple(r, k, a) }
+    ) { products, query, category, (refreshing, sortKey, sortAscending) ->
         val allCategories = products.map { it.category }.distinct().sorted()
         var filtered = products
         if (query.isNotBlank()) {
@@ -64,12 +72,22 @@ class ProductListViewModel @Inject constructor(
         if (category != null) {
             filtered = filtered.filter { it.category == category }
         }
+        val sorted = when (sortKey) {
+            ProductSortKey.NAME -> if (sortAscending) filtered.sortedBy { it.name.lowercase() }
+                else filtered.sortedByDescending { it.name.lowercase() }
+            ProductSortKey.PRICE -> if (sortAscending) filtered.sortedBy { it.basePrice }
+                else filtered.sortedByDescending { it.basePrice }
+            ProductSortKey.CATEGORY -> if (sortAscending) filtered.sortedBy { it.category.lowercase() }
+                else filtered.sortedByDescending { it.category.lowercase() }
+        }
         ProductListUiState(
-            products = filtered,
+            products = sorted,
             allCategories = allCategories,
             selectedCategory = category,
             isRefreshing = refreshing,
-            searchQuery = query
+            searchQuery = query,
+            sortKey = sortKey,
+            sortAscending = sortAscending
         )
     }.stateIn(
         scope = viewModelScope,
@@ -95,6 +113,15 @@ class ProductListViewModel @Inject constructor(
 
     fun onCategoryFilterChange(category: String?) {
         _selectedCategory.value = category
+    }
+
+    fun onSortChange(key: ProductSortKey) {
+        if (_sortKey.value == key) {
+            _sortAscending.value = !_sortAscending.value
+        } else {
+            _sortKey.value = key
+            _sortAscending.value = true
+        }
     }
 
     fun refresh() {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/Views/InventoryDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/Views/InventoryDetailView.swift
@@ -3,11 +3,22 @@ import SolennixCore
 import SolennixDesign
 import SolennixNetwork
 
+// MARK: - Inventory Demand Entry
+
+struct InventoryDemandEntry: Identifiable {
+    let id: String
+    let eventDate: Date
+    let eventName: String
+    let quantity: Double
+    let unit: String
+}
+
 // MARK: - Inventory Detail View
 
 public struct InventoryDetailView: View {
 
     @State private var item: InventoryItem?
+    @State private var demandEntries: [InventoryDemandEntry] = []
     @State private var isLoading: Bool = true
     @State private var errorMessage: String?
     @State private var showDeleteConfirm: Bool = false
@@ -22,6 +33,29 @@ public struct InventoryDetailView: View {
     public init(apiClient: APIClient, itemId: String) {
         self.apiClient = apiClient
         self.itemId = itemId
+    }
+
+    // MARK: - Computed
+
+    private var isLowStock: Bool {
+        guard let item else { return false }
+        return item.currentStock < item.minimumStock
+    }
+
+    private var stockValue: Double {
+        guard let item, let cost = item.unitCost else { return 0 }
+        return cost * item.currentStock
+    }
+
+    private var demand7Days: Double {
+        let today = Calendar.current.startOfDay(for: Date())
+        let in7Days = Calendar.current.date(byAdding: .day, value: 7, to: today) ?? today
+        return demandEntries.filter { $0.eventDate >= today && $0.eventDate <= in7Days }
+            .reduce(0) { $0 + $1.quantity }
+    }
+
+    private var stockAfter7Days: Double {
+        (item?.currentStock ?? 0) - demand7Days
     }
 
     public var body: some View {
@@ -94,6 +128,7 @@ public struct InventoryDetailView: View {
 
         do {
             item = try await apiClient.get(Endpoint.inventoryItem(itemId))
+            await loadDemandForecast()
         } catch {
             if let apiError = error as? APIError {
                 errorMessage = apiError.errorDescription ?? "Error al cargar"
@@ -103,6 +138,55 @@ public struct InventoryDetailView: View {
         }
 
         isLoading = false
+    }
+
+    @MainActor
+    private func loadDemandForecast() async {
+        guard let item else { return }
+
+        do {
+            let events: [Event] = try await apiClient.get(Endpoint.upcomingEvents)
+            var entries: [InventoryDemandEntry] = []
+
+            for event in events.prefix(15) {
+                let eventProducts: [EventProduct] = try await apiClient.get(Endpoint.eventProducts(event.id))
+                var eventDemand: Double = 0
+
+                for ep in eventProducts {
+                    do {
+                        let ingredients: [ProductIngredient] = try await apiClient.get(Endpoint.productIngredients(ep.productId))
+                        if let matching = ingredients.first(where: { $0.inventoryId == itemId }) {
+                            eventDemand += matching.quantityRequired * Double(ep.quantity)
+                        }
+                    } catch {
+                        // Skip failed ingredient fetches
+                    }
+                }
+
+                if eventDemand > 0 {
+                    // Try to get client name
+                    var eventName = event.serviceType ?? "Evento"
+                    if !event.clientId.isEmpty {
+                        do {
+                            let client: Client = try await apiClient.get(Endpoint.client(event.clientId))
+                            eventName = "Evento - \(client.name)"
+                        } catch {}
+                    }
+
+                    entries.append(InventoryDemandEntry(
+                        id: event.id,
+                        eventDate: ISO8601DateFormatter().date(from: event.eventDate) ?? Date(),
+                        eventName: eventName,
+                        quantity: eventDemand,
+                        unit: item.unit
+                    ))
+                }
+            }
+
+            demandEntries = entries.sorted { $0.eventDate < $1.eventDate }
+        } catch {
+            // Demand forecast is supplementary
+        }
     }
 
     @MainActor
@@ -119,8 +203,6 @@ public struct InventoryDetailView: View {
 
     @MainActor
     private func saveStockAdjustment() async {
-        guard var currentItem = item else { return }
-
         do {
             let body = ["current_stock": adjustmentQuantity]
             let updated: InventoryItem = try await apiClient.put(Endpoint.inventoryItem(itemId), body: body)
@@ -141,6 +223,18 @@ public struct InventoryDetailView: View {
                 // Stock status card
                 stockStatusCard(item)
 
+                // KPI Cards
+                kpiSection(item)
+
+                // Smart alert
+                smartAlertSection(item)
+
+                // Stock health bars
+                stockHealthBars(item)
+
+                // Demand forecast
+                demandForecastSection(item)
+
                 // Info card
                 infoCard(item)
 
@@ -148,12 +242,9 @@ public struct InventoryDetailView: View {
                 HStack {
                     Image(systemName: "clock")
                         .foregroundStyle(SolennixColors.textTertiary)
-
                     Text("Última actualización")
                         .foregroundStyle(SolennixColors.textSecondary)
-
                     Spacer()
-
                     if let date = ISO8601DateFormatter().date(from: item.lastUpdated) {
                         Text(date.formatted(date: .abbreviated, time: .shortened))
                             .foregroundStyle(SolennixColors.text)
@@ -171,21 +262,17 @@ public struct InventoryDetailView: View {
     // MARK: - Stock Status Card
 
     private func stockStatusCard(_ item: InventoryItem) -> some View {
-        let isLow = item.currentStock < item.minimumStock
         let percentage = item.minimumStock > 0 ? min(1.0, item.currentStock / item.minimumStock) : 1.0
 
         return VStack(spacing: Spacing.md) {
             HStack {
-                Image(systemName: isLow ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                Image(systemName: isLowStock ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
                     .font(.title2)
-                    .foregroundStyle(isLow ? SolennixColors.error : SolennixColors.success)
-
-                Text(isLow ? "Stock Bajo" : "Stock OK")
+                    .foregroundStyle(isLowStock ? SolennixColors.error : SolennixColors.success)
+                Text(isLowStock ? "Stock Bajo" : "Stock OK")
                     .font(.headline)
-                    .foregroundStyle(isLow ? SolennixColors.error : SolennixColors.success)
-
+                    .foregroundStyle(isLowStock ? SolennixColors.error : SolennixColors.success)
                 Spacer()
-
                 Text(item.type.rawValue.capitalized)
                     .font(.caption)
                     .fontWeight(.semibold)
@@ -196,23 +283,18 @@ public struct InventoryDetailView: View {
                     .clipShape(Capsule())
             }
 
-            // Stock display
             HStack(alignment: .lastTextBaseline, spacing: Spacing.xs) {
                 Text("\(Int(item.currentStock))")
                     .font(.system(size: 48, weight: .bold, design: .rounded))
                     .foregroundStyle(SolennixColors.text)
-
                 Text(item.unit)
                     .font(.title3)
                     .foregroundStyle(SolennixColors.textSecondary)
-
                 Spacer()
-
                 VStack(alignment: .trailing, spacing: 2) {
                     Text("Mínimo")
                         .font(.caption)
                         .foregroundStyle(SolennixColors.textTertiary)
-
                     Text("\(Int(item.minimumStock)) \(item.unit)")
                         .font(.subheadline)
                         .fontWeight(.medium)
@@ -220,21 +302,18 @@ public struct InventoryDetailView: View {
                 }
             }
 
-            // Progress bar
             GeometryReader { geo in
                 ZStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 4)
                         .fill(SolennixColors.surface)
                         .frame(height: 8)
-
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(isLow ? SolennixColors.error : SolennixColors.success)
+                        .fill(isLowStock ? SolennixColors.error : SolennixColors.success)
                         .frame(width: geo.size.width * percentage, height: 8)
                 }
             }
             .frame(height: 8)
 
-            // Quick adjust button
             Button {
                 adjustmentQuantity = item.currentStock
                 showStockAdjustment = true
@@ -259,6 +338,274 @@ public struct InventoryDetailView: View {
         .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
     }
 
+    // MARK: - KPI Section
+
+    private func kpiSection(_ item: InventoryItem) -> some View {
+        HStack(spacing: Spacing.sm) {
+            kpiCard(
+                icon: "dollarsign.circle.fill",
+                iconColor: SolennixColors.primary,
+                label: "Costo Unitario",
+                value: item.unitCost != nil && item.unitCost! > 0
+                    ? item.unitCost!.formatted(.currency(code: "MXN"))
+                    : "—",
+                subtitle: "por \(item.unit)"
+            )
+            kpiCard(
+                icon: "chart.bar.fill",
+                iconColor: SolennixColors.primary,
+                label: "Valor en Stock",
+                value: item.unitCost != nil
+                    ? stockValue.formatted(.currency(code: "MXN"))
+                    : "—",
+                subtitle: "valor total"
+            )
+        }
+    }
+
+    private func kpiCard(icon: String, iconColor: Color, label: String, value: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.caption2)
+                    .foregroundStyle(iconColor)
+                Text(label)
+                    .font(.caption2)
+                    .foregroundStyle(SolennixColors.textSecondary)
+                    .textCase(.uppercase)
+            }
+            Text(value)
+                .font(.title3)
+                .fontWeight(.black)
+                .foregroundStyle(SolennixColors.text)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(SolennixColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+
+    // MARK: - Smart Alert
+
+    private func smartAlertSection(_ item: InventoryItem) -> some View {
+        let isCritical = demand7Days > 0 && stockAfter7Days < 0
+        let isWarning = demand7Days > 0 && stockAfter7Days >= 0 && stockAfter7Days < item.minimumStock
+        let isLowOnly = isLowStock && demand7Days == 0
+
+        let alertColor: Color = isCritical || isLowOnly ? SolennixColors.error :
+            (isWarning ? .orange : .green)
+        let alertIcon = (isCritical || isWarning || isLowOnly) ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"
+
+        return HStack(alignment: .top, spacing: Spacing.md) {
+            Image(systemName: alertIcon)
+                .foregroundStyle(alertColor)
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text({
+                    if isCritical { return "¡Stock insuficiente para los proximos 7 dias!" }
+                    if isWarning { return "Stock quedara bajo el minimo tras eventos proximos" }
+                    if isLowOnly { return "Stock por debajo del minimo recomendado" }
+                    if demand7Days > 0 { return "Stock suficiente para los proximos 7 dias" }
+                    if !demandEntries.isEmpty { return "Sin demanda en los proximos 7 dias" }
+                    return "Sin eventos proximos"
+                }())
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(alertColor)
+
+                if isCritical {
+                    Text("Necesitas \(Int(demand7Days)) \(item.unit) en los proximos 7 dias. Tienes \(Int(item.currentStock)) \(item.unit). Faltan \(Int(-stockAfter7Days)) \(item.unit).")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                } else if isLowOnly {
+                    Text("Tu stock actual (\(Int(item.currentStock)) \(item.unit)) esta por debajo del minimo recomendado (\(Int(item.minimumStock)) \(item.unit)).")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(Spacing.md)
+        .background((isCritical || isLowOnly) ? SolennixColors.error.opacity(0.08) :
+                        (isWarning ? Color.orange.opacity(0.08) :
+                            (demand7Days > 0 ? Color.green.opacity(0.08) : SolennixColors.card)))
+        .overlay(
+            RoundedRectangle(cornerRadius: CornerRadius.lg)
+                .stroke((isCritical || isLowOnly) ? SolennixColors.error.opacity(0.2) :
+                            (isWarning ? Color.orange.opacity(0.2) : SolennixColors.border), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+    }
+
+    // MARK: - Stock Health Bars
+
+    private func stockHealthBars(_ item: InventoryItem) -> some View {
+        let maxBar = max(item.currentStock, item.minimumStock, demand7Days, 1)
+
+        return VStack(alignment: .leading, spacing: Spacing.md) {
+            healthBar(
+                label: "Stock Actual",
+                value: "\(Int(item.currentStock)) \(item.unit)",
+                fraction: item.currentStock / maxBar,
+                color: isLowStock ? SolennixColors.error : SolennixColors.primary
+            )
+            healthBar(
+                label: "Minimo Recomendado",
+                value: "\(Int(item.minimumStock)) \(item.unit)",
+                fraction: item.minimumStock / maxBar,
+                color: .orange
+            )
+            if demand7Days > 0 {
+                healthBar(
+                    label: "Demanda proximos 7 dias",
+                    value: "\(Int(demand7Days)) \(item.unit)",
+                    fraction: demand7Days / maxBar,
+                    color: stockAfter7Days < 0 ? SolennixColors.error : .orange
+                )
+            }
+        }
+        .padding(Spacing.md)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+
+    private func healthBar(label: String, value: String, fraction: Double, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textSecondary)
+                Spacer()
+                Text(value)
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .foregroundStyle(SolennixColors.text)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(SolennixColors.surface)
+                        .frame(height: 8)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(color)
+                        .frame(width: geo.size.width * min(1.0, fraction), height: 8)
+                }
+            }
+            .frame(height: 8)
+        }
+    }
+
+    // MARK: - Demand Forecast
+
+    private func demandForecastSection(_ item: InventoryItem) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            HStack {
+                Image(systemName: "calendar")
+                    .foregroundStyle(SolennixColors.primary)
+                Text("Demanda por Fecha")
+                    .font(.headline)
+                    .foregroundStyle(SolennixColors.text)
+                Spacer()
+                Text("Eventos confirmados")
+                    .font(.caption2)
+                    .foregroundStyle(SolennixColors.textSecondary)
+            }
+
+            if demandEntries.isEmpty {
+                VStack(spacing: Spacing.sm) {
+                    Image(systemName: "calendar.badge.clock")
+                        .font(.system(size: 28))
+                        .foregroundStyle(SolennixColors.textTertiary)
+                    Text("Sin eventos confirmados que usen este item.")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, Spacing.lg)
+            } else {
+                let today = Calendar.current.startOfDay(for: Date())
+                var accumulated = item.currentStock
+
+                ForEach(demandEntries) { entry in
+                    let _ = (accumulated -= entry.quantity)
+                    let isInsufficient = accumulated < 0
+                    let diffDays = Calendar.current.dateComponents([.day], from: today, to: Calendar.current.startOfDay(for: entry.eventDate)).day ?? 999
+                    let isWithinWeek = diffDays >= 0 && diffDays <= 7
+
+                    HStack {
+                        Circle()
+                            .fill(isInsufficient ? SolennixColors.error : (isWithinWeek ? .orange : SolennixColors.primary.opacity(0.4)))
+                            .frame(width: 8, height: 8)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 4) {
+                                Text(entry.eventDate.formatted(.dateTime.day().month(.abbreviated)))
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(SolennixColors.text)
+
+                                if diffDays == 0 {
+                                    badgeLabel("Hoy", color: SolennixColors.primary)
+                                } else if diffDays == 1 {
+                                    badgeLabel("Manana", color: .orange)
+                                } else if diffDays > 1 && diffDays <= 7 {
+                                    Text("en \(diffDays) dias")
+                                        .font(.caption2)
+                                        .foregroundStyle(SolennixColors.textSecondary)
+                                }
+                            }
+                        }
+
+                        Spacer()
+
+                        Text("\(Int(entry.quantity)) \(entry.unit)")
+                            .font(.subheadline)
+                            .fontWeight(.bold)
+                            .foregroundStyle(isInsufficient ? SolennixColors.error : SolennixColors.text)
+                    }
+                    .padding(.vertical, Spacing.xs)
+                }
+
+                Divider()
+                HStack {
+                    Text("Total demanda")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                    Spacer()
+                    let total = demandEntries.reduce(0) { $0 + $1.quantity }
+                    Text("\(Int(total)) \(item.unit)")
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                        .foregroundStyle(SolennixColors.text)
+                }
+            }
+        }
+        .padding(Spacing.md)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+
+    private func badgeLabel(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+
     // MARK: - Info Card
 
     private func infoCard(_ item: InventoryItem) -> some View {
@@ -271,12 +618,9 @@ public struct InventoryDetailView: View {
                 HStack {
                     Image(systemName: "dollarsign.circle.fill")
                         .foregroundStyle(SolennixColors.primary)
-
                     Text("Costo por unidad")
                         .foregroundStyle(SolennixColors.textSecondary)
-
                     Spacer()
-
                     Text(cost.formatted(.currency(code: "MXN")))
                         .font(.subheadline)
                         .fontWeight(.semibold)
@@ -285,16 +629,12 @@ public struct InventoryDetailView: View {
 
                 Divider()
 
-                // Total value
                 HStack {
                     Image(systemName: "chart.bar.fill")
                         .foregroundStyle(SolennixColors.textTertiary)
-
                     Text("Valor total en stock")
                         .foregroundStyle(SolennixColors.textSecondary)
-
                     Spacer()
-
                     Text((cost * item.currentStock).formatted(.currency(code: "MXN")))
                         .font(.subheadline)
                         .fontWeight(.semibold)
@@ -331,17 +671,14 @@ public struct InventoryDetailView: View {
 
                     HStack {
                         Text("Nuevo stock:")
-
                         TextField("0", value: $adjustmentQuantity, format: .number)
                             .keyboardType(.decimalPad)
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 100)
-
                         Text(item.unit)
                             .foregroundStyle(SolennixColors.textSecondary)
                     }
 
-                    // Quick adjustment buttons
                     HStack(spacing: Spacing.md) {
                         ForEach([-10, -1, 1, 10], id: \.self) { delta in
                             Button {
@@ -360,7 +697,6 @@ public struct InventoryDetailView: View {
                         }
                     }
                 }
-
                 Spacer()
             }
             .padding(Spacing.lg)
@@ -368,9 +704,7 @@ public struct InventoryDetailView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancelar") {
-                        showStockAdjustment = false
-                    }
+                    Button("Cancelar") { showStockAdjustment = false }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Guardar") {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Components/DemandForecastChart.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Components/DemandForecastChart.swift
@@ -11,31 +11,52 @@ public struct DemandDataPoint: Identifiable {
     public let clientName: String
     public let quantity: Int
     public let numPeople: Int
+    public let unitPrice: Double
 
-    public init(id: String, eventDate: Date, clientName: String, quantity: Int, numPeople: Int) {
+    public init(id: String, eventDate: Date, clientName: String, quantity: Int, numPeople: Int, unitPrice: Double = 0) {
         self.id = id
         self.eventDate = eventDate
         self.clientName = clientName
         self.quantity = quantity
         self.numPeople = numPeople
+        self.unitPrice = unitPrice
+    }
+
+    public var revenue: Double {
+        Double(quantity) * unitPrice
     }
 }
 
 // MARK: - Demand Forecast Chart
 
-/// Displays upcoming events that use this product with a bar chart
 public struct DemandForecastChart: View {
 
     let dataPoints: [DemandDataPoint]
     let productName: String
+    let basePrice: Double
 
-    public init(dataPoints: [DemandDataPoint], productName: String) {
+    public init(dataPoints: [DemandDataPoint], productName: String, basePrice: Double = 0) {
         self.dataPoints = dataPoints
         self.productName = productName
+        self.basePrice = basePrice
     }
 
     private var hasData: Bool {
         !dataPoints.isEmpty
+    }
+
+    private var totalQuantity: Int {
+        dataPoints.reduce(0) { $0 + $1.quantity }
+    }
+
+    private var totalPeople: Int {
+        dataPoints.reduce(0) { $0 + $1.numPeople }
+    }
+
+    private var totalRevenue: Double {
+        dataPoints.reduce(0) { sum, dp in
+            sum + (dp.unitPrice > 0 ? dp.revenue : Double(dp.quantity) * basePrice)
+        }
     }
 
     public var body: some View {
@@ -44,10 +65,13 @@ public struct DemandForecastChart: View {
             HStack {
                 Image(systemName: "chart.bar.fill")
                     .foregroundStyle(SolennixColors.primary)
-
-                Text("Demanda Proyectada")
+                Text("Demanda por Fecha")
                     .font(.headline)
                     .foregroundStyle(SolennixColors.text)
+                Spacer()
+                Text("Eventos confirmados")
+                    .font(.caption2)
+                    .foregroundStyle(SolennixColors.textSecondary)
             }
 
             if hasData {
@@ -61,7 +85,7 @@ public struct DemandForecastChart: View {
                     .cornerRadius(4)
                 }
                 .chartXAxis {
-                    AxisMarks(values: .stride(by: .day)) { value in
+                    AxisMarks(values: .stride(by: .day)) { _ in
                         AxisValueLabel(format: .dateTime.day().month(.abbreviated))
                     }
                 }
@@ -82,19 +106,56 @@ public struct DemandForecastChart: View {
                         .foregroundStyle(SolennixColors.textSecondary)
                 }
 
-                // Event list
                 Divider()
 
-                ForEach(dataPoints.prefix(5)) { point in
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(point.clientName)
-                                .font(.subheadline)
-                                .foregroundStyle(SolennixColors.text)
+                // Event list with urgency badges
+                let today = Calendar.current.startOfDay(for: Date())
 
-                            Text(point.eventDate.formatted(date: .abbreviated, time: .omitted))
-                                .font(.caption)
-                                .foregroundStyle(SolennixColors.textTertiary)
+                ForEach(dataPoints.prefix(5)) { point in
+                    let diffDays = Calendar.current.dateComponents([.day], from: today, to: Calendar.current.startOfDay(for: point.eventDate)).day ?? 999
+                    let isUrgent = diffDays <= 3
+                    let isThisWeek = diffDays > 3 && diffDays <= 7
+                    let pointRevenue = point.unitPrice > 0 ? point.revenue : Double(point.quantity) * basePrice
+
+                    HStack {
+                        // Urgency dot
+                        Circle()
+                            .fill(isUrgent ? SolennixColors.primary : (isThisWeek ? .orange : SolennixColors.primary.opacity(0.4)))
+                            .frame(width: 8, height: 8)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack(spacing: 4) {
+                                Text(point.eventDate.formatted(.dateTime.day().month(.abbreviated)))
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(SolennixColors.text)
+
+                                if diffDays == 0 {
+                                    urgencyBadge("Hoy", color: SolennixColors.primary)
+                                } else if diffDays == 1 {
+                                    urgencyBadge("Manana", color: .orange)
+                                } else if diffDays > 1 && diffDays <= 7 {
+                                    Text("en \(diffDays) dias")
+                                        .font(.caption2)
+                                        .foregroundStyle(SolennixColors.textSecondary)
+                                }
+                            }
+
+                            HStack(spacing: Spacing.sm) {
+                                Text(point.clientName)
+                                    .font(.caption)
+                                    .foregroundStyle(SolennixColors.textSecondary)
+
+                                if point.numPeople > 0 {
+                                    HStack(spacing: 2) {
+                                        Image(systemName: "person.2.fill")
+                                            .font(.caption2)
+                                        Text("\(point.numPeople)")
+                                            .font(.caption2)
+                                    }
+                                    .foregroundStyle(SolennixColors.textTertiary)
+                                }
+                            }
                         }
 
                         Spacer()
@@ -102,12 +163,52 @@ public struct DemandForecastChart: View {
                         VStack(alignment: .trailing, spacing: 2) {
                             Text("\(point.quantity) uds")
                                 .font(.subheadline)
-                                .fontWeight(.medium)
-                                .foregroundStyle(SolennixColors.primary)
+                                .fontWeight(.bold)
+                                .foregroundStyle(SolennixColors.text)
 
-                            Text("\(point.numPeople) personas")
+                            if pointRevenue > 0 {
+                                Text(pointRevenue.formatted(.currency(code: "MXN")))
+                                    .font(.caption)
+                                    .foregroundStyle(SolennixColors.textSecondary)
+                            }
+                        }
+                    }
+                    .padding(.vertical, Spacing.xs)
+                    .padding(.horizontal, Spacing.sm)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(isUrgent ? SolennixColors.primary.opacity(0.05) :
+                                    (isThisWeek ? Color.orange.opacity(0.05) : SolennixColors.surface))
+                    )
+                }
+
+                // Total row
+                if totalQuantity > 0 {
+                    Divider()
+
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("TOTAL DEMANDA")
+                                .font(.caption2)
+                                .foregroundStyle(SolennixColors.textSecondary)
+                            Text("\(dataPoints.count) evento\(dataPoints.count != 1 ? "s" : "")")
                                 .font(.caption)
-                                .foregroundStyle(SolennixColors.textTertiary)
+                                .foregroundStyle(SolennixColors.textSecondary)
+                        }
+
+                        Spacer()
+
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text("\(totalQuantity) unidades")
+                                .font(.subheadline)
+                                .fontWeight(.bold)
+                                .foregroundStyle(SolennixColors.text)
+
+                            if totalRevenue > 0 {
+                                Text("\(totalRevenue.formatted(.currency(code: "MXN"))) est.")
+                                    .font(.caption)
+                                    .foregroundStyle(SolennixColors.textSecondary)
+                            }
                         }
                     }
                     .padding(.vertical, Spacing.xs)
@@ -138,12 +239,15 @@ public struct DemandForecastChart: View {
         .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
     }
 
-    private var totalQuantity: Int {
-        dataPoints.reduce(0) { $0 + $1.quantity }
-    }
-
-    private var totalPeople: Int {
-        dataPoints.reduce(0) { $0 + $1.numPeople }
+    private func urgencyBadge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(color)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
     }
 }
 
@@ -152,11 +256,12 @@ public struct DemandForecastChart: View {
 #Preview("Demand Forecast Chart") {
     DemandForecastChart(
         dataPoints: [
-            DemandDataPoint(id: "1", eventDate: Date().addingTimeInterval(86400 * 2), clientName: "Maria Garcia", quantity: 50, numPeople: 100),
-            DemandDataPoint(id: "2", eventDate: Date().addingTimeInterval(86400 * 5), clientName: "Juan Lopez", quantity: 30, numPeople: 60),
-            DemandDataPoint(id: "3", eventDate: Date().addingTimeInterval(86400 * 8), clientName: "Ana Martinez", quantity: 80, numPeople: 150)
+            DemandDataPoint(id: "1", eventDate: Date().addingTimeInterval(86400 * 2), clientName: "Maria Garcia", quantity: 50, numPeople: 100, unitPrice: 150),
+            DemandDataPoint(id: "2", eventDate: Date().addingTimeInterval(86400 * 5), clientName: "Juan Lopez", quantity: 30, numPeople: 60, unitPrice: 150),
+            DemandDataPoint(id: "3", eventDate: Date().addingTimeInterval(86400 * 8), clientName: "Ana Martinez", quantity: 80, numPeople: 150, unitPrice: 150)
         ],
-        productName: "Paquete Premium"
+        productName: "Paquete Premium",
+        basePrice: 150
     )
     .padding()
 }
@@ -164,7 +269,8 @@ public struct DemandForecastChart: View {
 #Preview("Empty Demand Chart") {
     DemandForecastChart(
         dataPoints: [],
-        productName: "Producto Sin Demanda"
+        productName: "Producto Sin Demanda",
+        basePrice: 100
     )
     .padding()
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Components/RecipeSection.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Components/RecipeSection.swift
@@ -15,6 +15,7 @@ public struct RecipeSection: View {
     let onRemove: (Int) -> Void
     let onSelectInventory: (Int, String) -> Void
     let onUpdateQuantity: (Int, Double) -> Void
+    let showCost: Bool
 
     public init(
         title: String,
@@ -24,7 +25,8 @@ public struct RecipeSection: View {
         onAdd: @escaping () -> Void,
         onRemove: @escaping (Int) -> Void,
         onSelectInventory: @escaping (Int, String) -> Void,
-        onUpdateQuantity: @escaping (Int, Double) -> Void
+        onUpdateQuantity: @escaping (Int, Double) -> Void,
+        showCost: Bool = false
     ) {
         self.title = title
         self.description = description
@@ -34,6 +36,7 @@ public struct RecipeSection: View {
         self.onRemove = onRemove
         self.onSelectInventory = onSelectInventory
         self.onUpdateQuantity = onUpdateQuantity
+        self.showCost = showCost
     }
 
     public var body: some View {
@@ -81,6 +84,7 @@ public struct RecipeSection: View {
                     RecipeItemRow(
                         item: item,
                         inventoryItems: inventoryItems,
+                        showCost: showCost,
                         onSelectInventory: { inventoryId in
                             onSelectInventory(index, inventoryId)
                         },
@@ -111,6 +115,7 @@ struct RecipeItemRow: View {
 
     let item: RecipeItem
     let inventoryItems: [InventoryItem]
+    let showCost: Bool
     let onSelectInventory: (String) -> Void
     let onUpdateQuantity: (Double) -> Void
     let onRemove: () -> Void
@@ -120,6 +125,11 @@ struct RecipeItemRow: View {
 
     private var selectedItem: InventoryItem? {
         inventoryItems.first { $0.id == item.inventoryId }
+    }
+
+    private var estimatedCost: Double? {
+        guard let inv = selectedItem, let cost = inv.unitCost, cost > 0 else { return nil }
+        return item.quantityRequired * cost
     }
 
     var body: some View {
@@ -139,9 +149,17 @@ struct RecipeItemRow: View {
                             .foregroundStyle(selectedItem != nil ? SolennixColors.text : SolennixColors.textTertiary)
 
                         if let inv = selectedItem {
-                            Text("Stock: \(Int(inv.currentStock)) \(inv.unit)")
-                                .font(.caption)
-                                .foregroundStyle(SolennixColors.textSecondary)
+                            HStack(spacing: Spacing.sm) {
+                                Text("Stock: \(Int(inv.currentStock)) \(inv.unit)")
+                                    .font(.caption)
+                                    .foregroundStyle(SolennixColors.textSecondary)
+
+                                if showCost, let cost = inv.unitCost, cost > 0 {
+                                    Text("· \(cost.formatted(.currency(code: "MXN")))/\(inv.unit)")
+                                        .font(.caption)
+                                        .foregroundStyle(SolennixColors.textSecondary)
+                                }
+                            }
                         }
                     }
 
@@ -164,6 +182,7 @@ struct RecipeItemRow: View {
                 InventoryPickerSheet(
                     inventoryItems: inventoryItems,
                     selectedId: item.inventoryId,
+                    showCost: showCost,
                     onSelect: { inventoryId in
                         onSelectInventory(inventoryId)
                         showPicker = false
@@ -172,7 +191,7 @@ struct RecipeItemRow: View {
                 .presentationDetents([.medium, .large])
             }
 
-            // Quantity and remove
+            // Quantity, cost, and remove
             HStack(spacing: Spacing.sm) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Cantidad")
@@ -195,6 +214,19 @@ struct RecipeItemRow: View {
                                 .font(.caption)
                                 .foregroundStyle(SolennixColors.textTertiary)
                         }
+                    }
+                }
+
+                if showCost, let cost = estimatedCost {
+                    Spacer()
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text("Costo est.")
+                            .font(.caption)
+                            .foregroundStyle(SolennixColors.textTertiary)
+                        Text(cost.formatted(.currency(code: "MXN")))
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(SolennixColors.text)
                     }
                 }
 
@@ -221,6 +253,7 @@ private struct InventoryPickerSheet: View {
 
     let inventoryItems: [InventoryItem]
     let selectedId: String
+    let showCost: Bool
     let onSelect: (String) -> Void
 
     @Environment(\.dismiss) private var dismiss
@@ -252,7 +285,7 @@ private struct InventoryPickerSheet: View {
 
                         Spacer()
 
-                        if let cost = item.unitCost, cost > 0 {
+                        if showCost, let cost = item.unitCost, cost > 0 {
                             Text(cost.formatted(.currency(code: "MXN")))
                                 .font(.caption)
                                 .foregroundStyle(SolennixColors.textSecondary)
@@ -292,14 +325,15 @@ private struct InventoryPickerSheet: View {
             RecipeItem(inventoryId: "2", quantityRequired: 1, inventoryName: "Azucar", unit: "kg", type: .ingredient)
         ],
         inventoryItems: [
-            InventoryItem(id: "1", userId: "", ingredientName: "Harina", currentStock: 10, minimumStock: 5, unit: "kg", unitCost: nil, lastUpdated: "", type: .ingredient),
-            InventoryItem(id: "2", userId: "", ingredientName: "Azucar", currentStock: 8, minimumStock: 3, unit: "kg", unitCost: nil, lastUpdated: "", type: .ingredient),
-            InventoryItem(id: "3", userId: "", ingredientName: "Sal", currentStock: 5, minimumStock: 2, unit: "kg", unitCost: nil, lastUpdated: "", type: .ingredient)
+            InventoryItem(id: "1", userId: "", ingredientName: "Harina", currentStock: 10, minimumStock: 5, unit: "kg", unitCost: 25.0, lastUpdated: "", type: .ingredient),
+            InventoryItem(id: "2", userId: "", ingredientName: "Azucar", currentStock: 8, minimumStock: 3, unit: "kg", unitCost: 30.0, lastUpdated: "", type: .ingredient),
+            InventoryItem(id: "3", userId: "", ingredientName: "Sal", currentStock: 5, minimumStock: 2, unit: "kg", unitCost: 15.0, lastUpdated: "", type: .ingredient)
         ],
         onAdd: {},
         onRemove: { _ in },
         onSelectInventory: { _, _ in },
-        onUpdateQuantity: { _, _ in }
+        onUpdateQuantity: { _, _ in },
+        showCost: true
     )
     .padding()
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Views/ProductDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Views/ProductDetailView.swift
@@ -23,6 +23,49 @@ final class ProductDetailViewModel {
         self.productId = productId
     }
 
+    // MARK: - Computed KPIs
+
+    var ingredientItems: [ProductIngredient] {
+        ingredients.filter { $0.type == .ingredient }
+    }
+
+    var supplyItems: [ProductIngredient] {
+        ingredients.filter { $0.type == .supply }
+    }
+
+    var equipmentItems: [ProductIngredient] {
+        ingredients.filter { $0.type == .equipment }
+    }
+
+    var unitCost: Double {
+        ingredientItems.reduce(0) { $0 + $1.quantityRequired * ($1.unitCost ?? 0) }
+    }
+
+    var perEventCost: Double {
+        supplyItems.reduce(0) { $0 + $1.quantityRequired * ($1.unitCost ?? 0) }
+    }
+
+    var margin: Double {
+        guard let price = product?.basePrice, price > 0 else { return 0 }
+        return ((price - unitCost) / price) * 100
+    }
+
+    var demand7Days: Int {
+        let today = Calendar.current.startOfDay(for: Date())
+        let in7Days = Calendar.current.date(byAdding: .day, value: 7, to: today) ?? today
+        return demandData.filter { $0.eventDate >= today && $0.eventDate <= in7Days }
+            .reduce(0) { $0 + $1.quantity }
+    }
+
+    var totalDemand: Int {
+        demandData.reduce(0) { $0 + $1.quantity }
+    }
+
+    var estimatedRevenue: Double {
+        guard let price = product?.basePrice else { return 0 }
+        return Double(totalDemand) * price
+    }
+
     @MainActor
     func loadData() async {
         isLoading = true
@@ -48,21 +91,31 @@ final class ProductDetailViewModel {
 
     @MainActor
     private func loadDemandData() async {
-        // Load upcoming events and filter by this product
         do {
             let events: [Event] = try await apiClient.get(Endpoint.upcomingEvents)
 
-            // For each event, check if it uses this product
             var demand: [DemandDataPoint] = []
             for event in events.prefix(10) {
                 let eventProducts: [EventProduct] = try await apiClient.get(Endpoint.eventProducts(event.id))
                 if let ep = eventProducts.first(where: { $0.productId == productId }) {
+                    // Fetch client name
+                    var clientName = "Cliente"
+                    if !event.clientId.isEmpty {
+                        do {
+                            let client: Client = try await apiClient.get(Endpoint.client(event.clientId))
+                            clientName = client.name
+                        } catch {
+                            // Silently fail
+                        }
+                    }
+
                     let point = DemandDataPoint(
                         id: event.id,
                         eventDate: ISO8601DateFormatter().date(from: event.eventDate) ?? Date(),
-                        clientName: "Cliente", // Would need to fetch client name
+                        clientName: clientName,
                         quantity: ep.quantity,
-                        numPeople: event.numPeople
+                        numPeople: event.numPeople,
+                        unitPrice: ep.unitPrice
                     )
                     demand.append(point)
                 }
@@ -170,18 +223,60 @@ public struct ProductDetailView: View {
                 // Header with image
                 headerSection(product)
 
-                // Info section
-                infoSection(product)
+                // KPI Cards
+                kpiSection(product)
 
-                // Recipe section
-                if !viewModel.ingredients.isEmpty {
-                    recipeSection
+                // Smart alert
+                smartAlertSection(product)
+
+                // General info
+                generalInfoSection(product)
+
+                // Composition tables
+                if !viewModel.ingredientItems.isEmpty {
+                    compositionSection(
+                        title: "Composicion / Insumos",
+                        icon: "square.stack.3d.up.fill",
+                        iconColor: SolennixColors.primary,
+                        items: viewModel.ingredientItems,
+                        showCost: true,
+                        totalLabel: "Costo Total por Unidad",
+                        totalValue: viewModel.unitCost
+                    )
+                }
+
+                if !viewModel.supplyItems.isEmpty {
+                    compositionSection(
+                        title: "Insumos por Evento",
+                        icon: "flame.fill",
+                        iconColor: .orange,
+                        items: viewModel.supplyItems,
+                        showCost: true,
+                        badge: "Costo fijo por evento",
+                        badgeColor: .orange,
+                        totalLabel: "Costo por Evento",
+                        totalValue: viewModel.perEventCost,
+                        totalColor: .orange
+                    )
+                }
+
+                if !viewModel.equipmentItems.isEmpty {
+                    compositionSection(
+                        title: "Equipo Necesario",
+                        icon: "wrench.and.screwdriver.fill",
+                        iconColor: .blue,
+                        items: viewModel.equipmentItems,
+                        showCost: false,
+                        badge: "Sin costo - Reutilizable",
+                        badgeColor: .blue
+                    )
                 }
 
                 // Demand forecast
                 DemandForecastChart(
                     dataPoints: viewModel.demandData,
-                    productName: product.name
+                    productName: product.name,
+                    basePrice: product.basePrice
                 )
             }
             .padding(Spacing.lg)
@@ -192,7 +287,6 @@ public struct ProductDetailView: View {
 
     private func headerSection(_ product: Product) -> some View {
         VStack(spacing: Spacing.md) {
-            // Product image
             if let imageUrl = product.imageUrl, !imageUrl.isEmpty,
                let url = APIClient.resolveURL(imageUrl) {
                 AsyncImage(url: url) { image in
@@ -208,20 +302,17 @@ public struct ProductDetailView: View {
                 .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
             }
 
-            // Status badges
             HStack(spacing: Spacing.sm) {
-                // Category badge
                 Text(product.category)
                     .font(.caption)
                     .fontWeight(.semibold)
                     .textCase(.uppercase)
-                    .foregroundStyle(SolennixColors.textSecondary)
+                    .foregroundStyle(SolennixColors.primary)
                     .padding(.horizontal, Spacing.sm)
                     .padding(.vertical, Spacing.xs)
-                    .background(SolennixColors.surface)
+                    .background(SolennixColors.primary.opacity(0.1))
                     .clipShape(Capsule())
 
-                // Active/Inactive badge
                 if !product.isActive {
                     Text("Inactivo")
                         .font(.caption)
@@ -238,63 +329,199 @@ public struct ProductDetailView: View {
         }
     }
 
-    // MARK: - Info Section
+    // MARK: - KPI Section
 
-    private func infoSection(_ product: Product) -> some View {
-        VStack(alignment: .leading, spacing: Spacing.md) {
-            Text("Información")
-                .font(.headline)
-                .foregroundStyle(SolennixColors.text)
+    private func kpiSection(_ product: Product) -> some View {
+        VStack(spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                kpiCard(
+                    icon: "dollarsign.circle.fill",
+                    iconColor: SolennixColors.primary,
+                    label: "Precio Base",
+                    value: product.basePrice.formatted(.currency(code: "MXN")),
+                    subtitle: "por unidad"
+                )
+                kpiCard(
+                    icon: "square.stack.3d.up.fill",
+                    iconColor: SolennixColors.textSecondary,
+                    label: "Costo / Unidad",
+                    value: viewModel.unitCost.formatted(.currency(code: "MXN")),
+                    subtitle: "en insumos"
+                )
+            }
+            HStack(spacing: Spacing.sm) {
+                let marginColor: Color = viewModel.margin >= 50 ? .green :
+                    (viewModel.margin >= 20 ? SolennixColors.text : .orange)
+                kpiCard(
+                    icon: "arrow.up.right",
+                    iconColor: marginColor,
+                    label: "Margen Est.",
+                    value: String(format: "%.1f%%", viewModel.margin),
+                    subtitle: "utilidad estimada",
+                    valueColor: marginColor
+                )
+                kpiCard(
+                    icon: "calendar",
+                    iconColor: SolennixColors.primary,
+                    label: "Prox. Eventos",
+                    value: "\(viewModel.demandData.count)",
+                    subtitle: "confirmados"
+                )
+            }
+        }
+    }
 
-            // Price
-            HStack {
-                Image(systemName: "dollarsign.circle.fill")
-                    .foregroundStyle(SolennixColors.primary)
-
-                Text("Precio Base")
+    private func kpiCard(
+        icon: String,
+        iconColor: Color,
+        label: String,
+        value: String,
+        subtitle: String,
+        valueColor: Color = SolennixColors.text
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.caption2)
+                    .foregroundStyle(iconColor)
+                Text(label)
+                    .font(.caption2)
                     .foregroundStyle(SolennixColors.textSecondary)
+                    .textCase(.uppercase)
+            }
+            Text(value)
+                .font(.title2)
+                .fontWeight(.black)
+                .foregroundStyle(valueColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(SolennixColors.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Spacing.md)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
 
-                Spacer()
+    // MARK: - Smart Alert Section
 
-                Text(product.basePrice.formatted(.currency(code: "MXN")))
-                    .font(.title3)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(SolennixColors.text)
+    private func smartAlertSection(_ product: Product) -> some View {
+        let isHighDemand = viewModel.demand7Days > 0
+
+        return HStack(alignment: .top, spacing: Spacing.md) {
+            Image(systemName: isHighDemand ? "exclamationmark.triangle.fill" : "checkmark.circle.fill")
+                .foregroundStyle(isHighDemand ? SolennixColors.primary : .green)
+                .font(.title3)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(isHighDemand
+                     ? "\(viewModel.demand7Days) unidades en los proximos 7 dias"
+                     : viewModel.demandData.isEmpty ? "Sin eventos proximos" : "Sin demanda inmediata"
+                )
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(isHighDemand ? SolennixColors.primary : .green)
+
+                if isHighDemand {
+                    if viewModel.estimatedRevenue > 0 {
+                        Text("Alta demanda esta semana. Ingreso estimado total: \(viewModel.estimatedRevenue.formatted(.currency(code: "MXN")))")
+                            .font(.caption)
+                            .foregroundStyle(SolennixColors.textSecondary)
+                    } else {
+                        Text("Alta demanda esta semana.")
+                            .font(.caption)
+                            .foregroundStyle(SolennixColors.textSecondary)
+                    }
+                } else if !viewModel.demandData.isEmpty {
+                    Text("\(viewModel.totalDemand) unidades en \(viewModel.demandData.count) evento\(viewModel.demandData.count != 1 ? "s" : "") proximos.")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                } else {
+                    Text("No hay eventos confirmados que incluyan este producto.")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
             }
 
-            Divider()
+            Spacer()
+        }
+        .padding(Spacing.md)
+        .background(isHighDemand ? SolennixColors.primary.opacity(0.08) : SolennixColors.card)
+        .overlay(
+            RoundedRectangle(cornerRadius: CornerRadius.lg)
+                .stroke(isHighDemand ? SolennixColors.primary.opacity(0.2) : SolennixColors.border, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+    }
 
-            // Created date
-            HStack {
-                Image(systemName: "calendar")
-                    .foregroundStyle(SolennixColors.textTertiary)
+    // MARK: - General Info Section
 
-                Text("Creado")
-                    .foregroundStyle(SolennixColors.textSecondary)
+    private func generalInfoSection(_ product: Product) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            Text("INFORMACION GENERAL")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(SolennixColors.textSecondary)
 
-                Spacer()
-
-                if let date = ISO8601DateFormatter().date(from: product.createdAt) {
-                    Text(date.formatted(date: .abbreviated, time: .omitted))
-                        .foregroundStyle(SolennixColors.text)
+            // Category
+            HStack(spacing: Spacing.md) {
+                Image(systemName: "tag.fill")
+                    .foregroundStyle(SolennixColors.primary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Categoria")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                    Text(product.category)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
                 }
             }
 
             Divider()
 
-            // Updated date
-            HStack {
-                Image(systemName: "clock")
-                    .foregroundStyle(SolennixColors.textTertiary)
+            // Price
+            HStack(spacing: Spacing.md) {
+                Image(systemName: "dollarsign.circle.fill")
+                    .foregroundStyle(SolennixColors.primary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Precio Base")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                    Text(product.basePrice.formatted(.currency(code: "MXN")))
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+            }
 
-                Text("Actualizado")
-                    .foregroundStyle(SolennixColors.textSecondary)
+            Divider()
 
-                Spacer()
+            // Composition summary
+            HStack(spacing: Spacing.md) {
+                Image(systemName: "square.stack.3d.up.fill")
+                    .foregroundStyle(SolennixColors.primary)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Composicion")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
 
-                if let date = ISO8601DateFormatter().date(from: product.updatedAt) {
-                    Text(date.formatted(date: .abbreviated, time: .omitted))
-                        .foregroundStyle(SolennixColors.text)
+                    let compositionText: String = {
+                        var parts: [String] = []
+                        parts.append("\(viewModel.ingredientItems.count) insumos")
+                        if !viewModel.supplyItems.isEmpty {
+                            parts.append("\(viewModel.supplyItems.count) insumo(s) por evento")
+                        }
+                        if !viewModel.equipmentItems.isEmpty {
+                            parts.append("\(viewModel.equipmentItems.count) equipo(s)")
+                        }
+                        return parts.joined(separator: ", ")
+                    }()
+
+                    Text(compositionText)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
                 }
             }
         }
@@ -304,46 +531,112 @@ public struct ProductDetailView: View {
         .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
     }
 
-    // MARK: - Recipe Section
+    // MARK: - Composition Section
 
-    private var recipeSection: some View {
-        VStack(alignment: .leading, spacing: Spacing.md) {
+    private func compositionSection(
+        title: String,
+        icon: String,
+        iconColor: Color,
+        items: [ProductIngredient],
+        showCost: Bool,
+        badge: String? = nil,
+        badgeColor: Color = SolennixColors.primary,
+        totalLabel: String? = nil,
+        totalValue: Double? = nil,
+        totalColor: Color = SolennixColors.text
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
             HStack {
-                Image(systemName: "list.bullet.clipboard.fill")
-                    .foregroundStyle(SolennixColors.primary)
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: icon)
+                        .foregroundStyle(iconColor)
+                    Text(title)
+                        .font(.headline)
+                        .foregroundStyle(SolennixColors.text)
+                }
 
-                Text("Receta")
-                    .font(.headline)
-                    .foregroundStyle(SolennixColors.text)
+                Spacer()
+
+                if let badge {
+                    Text(badge)
+                        .font(.caption2)
+                        .fontWeight(.medium)
+                        .foregroundStyle(badgeColor)
+                        .padding(.horizontal, Spacing.sm)
+                        .padding(.vertical, Spacing.xs)
+                        .background(badgeColor.opacity(0.1))
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
             }
+            .padding(Spacing.md)
 
-            ForEach(viewModel.ingredients) { ingredient in
+            Divider()
+
+            // Table header
+            HStack {
+                Text("INSUMO")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(SolennixColors.textSecondary)
+                Spacer()
+                Text("CANTIDAD")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(SolennixColors.textSecondary)
+                if showCost {
+                    Text("COSTO EST.")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                        .frame(width: 80, alignment: .trailing)
+                }
+            }
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.sm)
+            .background(SolennixColors.surface)
+
+            // Items
+            ForEach(items) { ingredient in
+                Divider().opacity(0.5)
                 HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(ingredient.ingredientName ?? "Item")
-                            .font(.body)
-                            .foregroundStyle(SolennixColors.text)
-
-                        Text(ingredient.type?.rawValue.capitalized ?? "Ingrediente")
-                            .font(.caption)
-                            .foregroundStyle(SolennixColors.textTertiary)
-                    }
-
+                    Text(ingredient.ingredientName ?? "Insumo")
+                        .font(.subheadline)
+                        .foregroundStyle(SolennixColors.text)
                     Spacer()
-
                     Text("\(Int(ingredient.quantityRequired)) \(ingredient.unit ?? "und")")
                         .font(.subheadline)
-                        .fontWeight(.medium)
-                        .foregroundStyle(SolennixColors.primary)
+                        .fontWeight(.bold)
+                        .foregroundStyle(SolennixColors.text)
+                    if showCost {
+                        let cost = ingredient.quantityRequired * (ingredient.unitCost ?? 0)
+                        Text(cost > 0 ? cost.formatted(.currency(code: "MXN")) : "—")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(totalColor == .orange ? .orange : SolennixColors.text)
+                            .frame(width: 80, alignment: .trailing)
+                    }
                 }
-                .padding(.vertical, Spacing.xs)
+                .padding(.horizontal, Spacing.md)
+                .padding(.vertical, Spacing.sm)
+            }
 
-                if ingredient.id != viewModel.ingredients.last?.id {
-                    Divider()
+            // Total footer
+            if let totalLabel, let totalValue {
+                Divider()
+                HStack {
+                    Text(totalLabel)
+                        .font(.subheadline)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                    Spacer()
+                    Text(totalValue.formatted(.currency(code: "MXN")))
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundStyle(totalColor)
                 }
+                .padding(Spacing.md)
             }
         }
-        .padding(Spacing.md)
         .background(SolennixColors.card)
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
         .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Views/ProductFormView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Views/ProductFormView.swift
@@ -70,7 +70,8 @@ public struct ProductFormView: View {
                     onSelectInventory: { viewModel.updateIngredient(at: $0, inventoryId: $1) },
                     onUpdateQuantity: { index, qty in
                         viewModel.ingredients[index].quantityRequired = qty
-                    }
+                    },
+                    showCost: true
                 )
 
                 RecipeSection(
@@ -83,7 +84,8 @@ public struct ProductFormView: View {
                     onSelectInventory: { viewModel.updateEquipment(at: $0, inventoryId: $1) },
                     onUpdateQuantity: { index, qty in
                         viewModel.equipment[index].quantityRequired = qty
-                    }
+                    },
+                    showCost: false
                 )
 
                 RecipeSection(
@@ -96,7 +98,8 @@ public struct ProductFormView: View {
                     onSelectInventory: { viewModel.updateSupply(at: $0, inventoryId: $1) },
                     onUpdateQuantity: { index, qty in
                         viewModel.supplies[index].quantityRequired = qty
-                    }
+                    },
+                    showCost: true
                 )
             }
             .padding(Spacing.lg)


### PR DESCRIPTION
Android:
- ProductDetailScreen: Add KPI cards (price, cost/unit, margin, events),
  smart demand alerts, composition tables (ingredients, equipment, supplies)
  with estimated costs, enhanced demand section with urgency badges and revenue
- ProductFormScreen: Replace text-only recipe with structured ingredient/
  equipment/supply management using inventory pickers with cost display
- ProductListScreen: Add sort options (name, price, category) with direction
- ProductRepository: Add getProductIngredients and updateProductIngredients

iOS:
- ProductDetailView: Add KPI cards (price, cost/unit, margin %, events count),
  smart alert section (7-day demand, estimated revenue), composition tables
  with costs for ingredients/supplies/equipment, general info card with
  composition summary
- DemandForecastChart: Add urgency badges (Hoy/Mañana/en X días), revenue
  per event, total demand row with estimated revenue
- RecipeSection: Add cost display per ingredient (unit cost from inventory,
  estimated cost per row)
- ProductFormView: Pass showCost flag to recipe sections

PRD: Update feature parity table and platform status for products

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01ETKbnH3QTXvuYWqnyjCd6u