### PR TITLE
fix(android): implement full tablet navigation replacing Phase 6 placeholders

### DIFF
--- a/android/app/src/main/java/com/creapolis/solennix/MainNavHost.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/MainNavHost.kt
@@ -94,7 +94,7 @@ fun MainNavHost(deepLinkIntent: Intent? = null) {
         }
         AuthManager.AuthState.Authenticated -> {
             if (windowSizeClass != null && windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact) {
-                AdaptiveNavigationRailLayout()
+                AdaptiveNavigationRailLayout(initialDeepLinkRoute = deepLinkRoute)
             } else {
                 CompactBottomNavLayout(initialDeepLinkRoute = deepLinkRoute)
             }

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AdaptiveNavigationRailLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AdaptiveNavigationRailLayout.kt
@@ -1,23 +1,76 @@
 package com.creapolis.solennix.ui.navigation
 
-import androidx.compose.foundation.background
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.creapolis.solennix.core.designsystem.theme.SolennixElevation
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.designsystem.theme.SolennixTitle
+import com.creapolis.solennix.feature.calendar.ui.CalendarScreen
 import com.creapolis.solennix.feature.clients.ui.ClientDetailScreen
+import com.creapolis.solennix.feature.clients.ui.ClientFormScreen
 import com.creapolis.solennix.feature.clients.ui.ClientListScreen
+import com.creapolis.solennix.feature.clients.ui.QuickQuoteScreen
 import com.creapolis.solennix.feature.dashboard.ui.DashboardScreen
+import com.creapolis.solennix.feature.events.ui.EventChecklistScreen
+import com.creapolis.solennix.feature.events.ui.EventDetailScreen
+import com.creapolis.solennix.feature.events.ui.EventFormScreen
+import com.creapolis.solennix.feature.events.ui.EventListScreen
+import com.creapolis.solennix.feature.inventory.ui.InventoryDetailScreen
+import com.creapolis.solennix.feature.inventory.ui.InventoryFormScreen
+import com.creapolis.solennix.feature.inventory.ui.InventoryListScreen
+import com.creapolis.solennix.feature.products.ui.ProductDetailScreen
+import com.creapolis.solennix.feature.products.ui.ProductFormScreen
+import com.creapolis.solennix.feature.products.ui.ProductListScreen
+import com.creapolis.solennix.feature.search.ui.SearchScreen
+import com.creapolis.solennix.feature.settings.ui.AboutScreen
+import com.creapolis.solennix.feature.settings.ui.BusinessSettingsScreen
+import com.creapolis.solennix.feature.settings.ui.ChangePasswordScreen
+import com.creapolis.solennix.feature.settings.ui.ContractDefaultsScreen
+import com.creapolis.solennix.feature.settings.ui.EditProfileScreen
+import com.creapolis.solennix.feature.settings.ui.PricingScreen
+import com.creapolis.solennix.feature.settings.ui.PrivacyScreen
+import com.creapolis.solennix.feature.settings.ui.SettingsScreen
+import com.creapolis.solennix.feature.settings.ui.TermsScreen
 
 @Composable
-fun AdaptiveNavigationRailLayout() {
+fun AdaptiveNavigationRailLayout(initialDeepLinkRoute: String? = null) {
     var selectedSection by remember { mutableStateOf(SidebarSection.DASHBOARD) }
+    val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+    var calendarBlockDatesRequested by remember { mutableStateOf(false) }
+
+    // Navigate to deep link after NavHost is initialized
+    LaunchedEffect(initialDeepLinkRoute) {
+        initialDeepLinkRoute?.let { route ->
+            navController.navigate(route) {
+                launchSingleTop = true
+            }
+        }
+    }
+
+    // Determine if we are at a section-level route (for FAB visibility)
+    val sectionRoutes = SidebarSection.entries.map { it.route }.toSet() + setOf("events")
+    val isAtSectionLevel = currentRoute in sectionRoutes
 
     Row(Modifier.fillMaxSize()) {
         NavigationRail(
@@ -34,8 +87,15 @@ fun AdaptiveNavigationRailLayout() {
             SidebarSection.entries.forEach { section ->
                 NavigationRailItem(
                     selected = selectedSection == section,
-                    onClick = { 
+                    onClick = {
                         selectedSection = section
+                        navController.navigate(section.route) {
+                            popUpTo(navController.graph.startDestinationId) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
                     },
                     icon = { Icon(section.icon, section.label) },
                     label = { Text(section.label) },
@@ -48,20 +108,322 @@ fun AdaptiveNavigationRailLayout() {
             }
         }
 
-        // Simple content area for now to avoid adaptive library issues
-        Box(
-            Modifier
-                .fillMaxSize()
-                .background(SolennixTheme.colors.surfaceGrouped)
-        ) {
-            when (selectedSection) {
-                SidebarSection.DASHBOARD -> DashboardScreen(viewModel = hiltViewModel())
-                SidebarSection.CLIENTS -> ClientListScreen(
-                    viewModel = hiltViewModel(),
-                    onClientClick = {},
-                    onAddClientClick = {}
-                )
-                else -> PlaceholderScreen("${selectedSection.label} — Phase 6")
+        // Content area with NavHost
+        Scaffold(
+            floatingActionButton = {
+                // Simple FAB on section-level routes (except calendar and search)
+                val showSimpleFab = isAtSectionLevel
+                    && currentRoute != "calendar"
+                    && currentRoute != "search"
+
+                if (showSimpleFab) {
+                    FloatingActionButton(
+                        onClick = { navController.navigate("event_form?eventId=") },
+                        containerColor = SolennixTheme.colors.primary,
+                        elevation = FloatingActionButtonDefaults.elevation(
+                            defaultElevation = SolennixElevation.fab
+                        )
+                    ) {
+                        Icon(Icons.Filled.Add, "Nuevo Evento", tint = Color.White)
+                    }
+                }
+
+                // Expandable FAB for Calendar
+                if (currentRoute == "calendar") {
+                    var expanded by remember { mutableStateOf(false) }
+
+                    Column(
+                        horizontalAlignment = Alignment.End,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        AnimatedVisibility(
+                            visible = expanded,
+                            enter = fadeIn() + slideInVertically(initialOffsetY = { it }),
+                            exit = fadeOut() + slideOutVertically(targetOffsetY = { it })
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.End,
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                // Block dates option
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Surface(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = SolennixTheme.colors.card,
+                                        shadowElevation = 2.dp
+                                    ) {
+                                        Text(
+                                            "Bloquear Fechas",
+                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = SolennixTheme.colors.primaryText
+                                        )
+                                    }
+                                    SmallFloatingActionButton(
+                                        onClick = {
+                                            expanded = false
+                                            calendarBlockDatesRequested = true
+                                        },
+                                        containerColor = SolennixTheme.colors.primary,
+                                        contentColor = Color.White
+                                    ) {
+                                        Icon(Icons.Default.Block, contentDescription = "Bloquear Fechas")
+                                    }
+                                }
+
+                                // New event option
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Surface(
+                                        shape = RoundedCornerShape(8.dp),
+                                        color = SolennixTheme.colors.card,
+                                        shadowElevation = 2.dp
+                                    ) {
+                                        Text(
+                                            "Nuevo Evento",
+                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = SolennixTheme.colors.primaryText
+                                        )
+                                    }
+                                    SmallFloatingActionButton(
+                                        onClick = {
+                                            expanded = false
+                                            navController.navigate("event_form?eventId=")
+                                        },
+                                        containerColor = SolennixTheme.colors.primary,
+                                        contentColor = Color.White
+                                    ) {
+                                        Icon(Icons.Filled.Add, contentDescription = "Nuevo Evento")
+                                    }
+                                }
+                            }
+                        }
+
+                        // Main FAB (toggle)
+                        FloatingActionButton(
+                            onClick = { expanded = !expanded },
+                            containerColor = SolennixTheme.colors.primary,
+                            elevation = FloatingActionButtonDefaults.elevation(
+                                defaultElevation = SolennixElevation.fab
+                            )
+                        ) {
+                            Icon(
+                                if (expanded) Icons.Default.Close else Icons.Filled.Add,
+                                contentDescription = if (expanded) "Cerrar menú" else "Opciones",
+                                tint = Color.White
+                            )
+                        }
+                    }
+                }
+            },
+            floatingActionButtonPosition = FabPosition.End
+        ) { innerPadding ->
+            NavHost(
+                navController = navController,
+                startDestination = "home",
+                modifier = Modifier.padding(innerPadding)
+            ) {
+                // ── Top-level section screens ──
+                composable("home") {
+                    DashboardScreen(
+                        viewModel = hiltViewModel(),
+                        onEventClick = { id -> navController.navigate("event_detail/$id") },
+                        onInventoryClick = { id -> navController.navigate("inventory_detail/$id") },
+                        onUpgradeClick = { navController.navigate("pricing") }
+                    )
+                }
+                composable("calendar") {
+                    CalendarScreen(
+                        viewModel = hiltViewModel(),
+                        onEventClick = { id -> navController.navigate("event_detail/$id") },
+                        onBlockDatesRequested = calendarBlockDatesRequested,
+                        onBlockDatesConsumed = { calendarBlockDatesRequested = false }
+                    )
+                }
+                composable("clients") {
+                    ClientListScreen(
+                        viewModel = hiltViewModel(),
+                        onClientClick = { id -> navController.navigate("client_detail/$id") },
+                        onAddClientClick = { navController.navigate("client_form") }
+                    )
+                }
+                composable("products") {
+                    ProductListScreen(
+                        viewModel = hiltViewModel(),
+                        onProductClick = { id -> navController.navigate("product_detail/$id") },
+                        onAddProductClick = { navController.navigate("product_form") },
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("inventory") {
+                    InventoryListScreen(
+                        viewModel = hiltViewModel(),
+                        onItemClick = { id -> navController.navigate("inventory_detail/$id") },
+                        onAddItemClick = { navController.navigate("inventory_form") },
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("search") {
+                    SearchScreen(
+                        viewModel = hiltViewModel(),
+                        onClientClick = { id -> navController.navigate("client_detail/$id") },
+                        onEventClick = { id -> navController.navigate("event_detail/$id") },
+                        onProductClick = { id -> navController.navigate("product_detail/$id") },
+                        onInventoryClick = { id -> navController.navigate("inventory_detail/$id") },
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("settings") {
+                    SettingsScreen(
+                        viewModel = hiltViewModel(),
+                        onEditProfile = { navController.navigate("edit_profile") },
+                        onChangePassword = { navController.navigate("change_password") },
+                        onBusinessSettings = { navController.navigate("business_settings") },
+                        onContractDefaults = { navController.navigate("contract_defaults") },
+                        onPricing = { navController.navigate("pricing") },
+                        onAbout = { navController.navigate("about") },
+                        onPrivacy = { navController.navigate("privacy") },
+                        onTerms = { navController.navigate("terms") },
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+
+                // ── Events ──
+                composable("events") {
+                    EventListScreen(
+                        viewModel = hiltViewModel(),
+                        onEventClick = { id -> navController.navigate("event_detail/$id") },
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("event_detail/{eventId}") {
+                    EventDetailScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() },
+                        onEditClick = { id -> navController.navigate("event_form?eventId=$id") },
+                        onChecklistClick = { id -> navController.navigate("event_checklist/$id") }
+                    )
+                }
+                composable("event_form?eventId={eventId}") {
+                    EventFormScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("event_checklist/{eventId}") {
+                    EventChecklistScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+
+                // ── Clients ──
+                composable("client_detail/{clientId}") {
+                    ClientDetailScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() },
+                        onEditClick = { id -> navController.navigate("client_form?clientId=$id") },
+                        onEventClick = { id -> navController.navigate("event_detail/$id") }
+                    )
+                }
+                composable("client_form?clientId={clientId}") {
+                    ClientFormScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+
+                // ── Products ──
+                composable("product_detail/{productId}") {
+                    ProductDetailScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() },
+                        onEditClick = { id -> navController.navigate("product_form?productId=$id") }
+                    )
+                }
+                composable("product_form?productId={productId}") {
+                    ProductFormScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+
+                // ── Inventory ──
+                composable("inventory_detail/{itemId}") {
+                    InventoryDetailScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() },
+                        onEditClick = { id -> navController.navigate("inventory_form?itemId=$id") }
+                    )
+                }
+                composable("inventory_form?itemId={itemId}") {
+                    InventoryFormScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+
+                // ── Settings sub-screens ──
+                composable("edit_profile") {
+                    EditProfileScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("change_password") {
+                    ChangePasswordScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("business_settings") {
+                    BusinessSettingsScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("contract_defaults") {
+                    ContractDefaultsScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("pricing") {
+                    PricingScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("about") {
+                    AboutScreen(
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("privacy") {
+                    PrivacyScreen(
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+                composable("terms") {
+                    TermsScreen(
+                        onNavigateBack = { navController.popBackStack() }
+                    )
+                }
+
+                // ── Quick Quote ──
+                composable("quick_quote?clientId={clientId}") {
+                    QuickQuoteScreen(
+                        viewModel = hiltViewModel(),
+                        onNavigateBack = { navController.popBackStack() },
+                        onConvertToEvent = { navController.navigate("event_form?eventId=") }
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AdaptiveNavigationRailLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AdaptiveNavigationRailLayout.kt
@@ -69,7 +69,7 @@ fun AdaptiveNavigationRailLayout(initialDeepLinkRoute: String? = null) {
     }
 
     // Determine if we are at a section-level route (for FAB visibility)
-    val sectionRoutes = SidebarSection.entries.map { it.route }.toSet() + setOf("events")
+    val sectionRoutes = SidebarSection.entries.map { it.route }.toSet()
     val isAtSectionLevel = currentRoute in sectionRoutes
 
     Row(Modifier.fillMaxSize()) {
@@ -111,10 +111,12 @@ fun AdaptiveNavigationRailLayout(initialDeepLinkRoute: String? = null) {
         // Content area with NavHost
         Scaffold(
             floatingActionButton = {
-                // Simple FAB on section-level routes (except calendar and search)
+                // Simple FAB on section-level routes (except calendar, search, quick_quote, and settings)
                 val showSimpleFab = isAtSectionLevel
                     && currentRoute != "calendar"
                     && currentRoute != "search"
+                    && currentRoute != "quick_quote"
+                    && currentRoute != "settings"
 
                 if (showSimpleFab) {
                     FloatingActionButton(

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AuthNavHost.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AuthNavHost.kt
@@ -1,6 +1,11 @@
 package com.creapolis.solennix.ui.navigation
 
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -14,10 +19,17 @@ import com.creapolis.solennix.feature.auth.ui.RegisterScreen
 import com.creapolis.solennix.feature.auth.ui.ResetPasswordScreen
 import com.creapolis.solennix.feature.auth.viewmodel.AuthViewModel
 
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @Composable
 fun AuthNavHost(onAuthenticated: () -> Unit = {}) {
     val navController = rememberNavController()
     val viewModel: AuthViewModel = hiltViewModel()
+
+    val context = LocalContext.current
+    val activity = context as? FragmentActivity
+    val windowSizeClass = activity?.let { calculateWindowSizeClass(it) }
+    val isWideScreen = windowSizeClass != null &&
+        windowSizeClass.widthSizeClass != WindowWidthSizeClass.Compact
 
     NavHost(navController = navController, startDestination = "login") {
         composable("login") {
@@ -25,20 +37,23 @@ fun AuthNavHost(onAuthenticated: () -> Unit = {}) {
                 viewModel = viewModel,
                 onNavigateToRegister = { navController.navigate("register") },
                 onNavigateToForgot = { navController.navigate("forgot") },
-                onLoginSuccess = onAuthenticated
+                onLoginSuccess = onAuthenticated,
+                isWideScreen = isWideScreen
             )
         }
         composable("register") {
             RegisterScreen(
                 viewModel = viewModel,
                 onNavigateBack = { navController.popBackStack() },
-                onLoginSuccess = onAuthenticated
+                onLoginSuccess = onAuthenticated,
+                isWideScreen = isWideScreen
             )
         }
         composable("forgot") {
             ForgotPasswordScreen(
                 viewModel = viewModel,
-                onNavigateBack = { navController.popBackStack() }
+                onNavigateBack = { navController.popBackStack() },
+                isWideScreen = isWideScreen
             )
         }
         composable(
@@ -57,7 +72,8 @@ fun AuthNavHost(onAuthenticated: () -> Unit = {}) {
             ResetPasswordScreen(
                 token = token,
                 viewModel = viewModel,
-                onNavigateToLogin = { navController.navigate("login") }
+                onNavigateToLogin = { navController.navigate("login") },
+                isWideScreen = isWideScreen
             )
         }
     }

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
@@ -509,9 +509,3 @@ fun MenuCard(
     }
 }
 
-@Composable
-fun PlaceholderScreen(text: String) {
-    Surface(modifier = Modifier.padding(16.dp)) {
-        Text(text = text, style = MaterialTheme.typography.headlineMedium)
-    }
-}

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/SidebarSection.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/SidebarSection.kt
@@ -7,9 +7,11 @@ import androidx.compose.ui.graphics.vector.ImageVector
 enum class SidebarSection(val label: String, val icon: ImageVector, val route: String) {
     DASHBOARD("Inicio", Icons.Default.Home, "home"),
     CALENDAR("Calendario", Icons.Default.DateRange, "calendar"),
+    EVENTS("Eventos", Icons.Default.Event, "events"),
     CLIENTS("Clientes", Icons.Default.Person, "clients"),
     PRODUCTS("Productos", Icons.Default.ShoppingCart, "products"),
     INVENTORY("Inventario", Icons.Default.Inventory, "inventory"),
+    QUICK_QUOTE("Cotización", Icons.Default.Description, "quick_quote"),
     SEARCH("Buscar", Icons.Default.Search, "search"),
     SETTINGS("Ajustes", Icons.Default.Settings, "settings")
 }

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/SidebarSection.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/SidebarSection.kt
@@ -4,12 +4,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.ui.graphics.vector.ImageVector
 
-enum class SidebarSection(val label: String, val icon: ImageVector) {
-    DASHBOARD("Inicio", Icons.Default.Home),
-    CALENDAR("Calendario", Icons.Default.DateRange),
-    CLIENTS("Clientes", Icons.Default.Person),
-    PRODUCTS("Productos", Icons.Default.ShoppingCart),
-    INVENTORY("Inventario", Icons.Default.Inventory),
-    SEARCH("Buscar", Icons.Default.Search),
-    SETTINGS("Ajustes", Icons.Default.Settings)
+enum class SidebarSection(val label: String, val icon: ImageVector, val route: String) {
+    DASHBOARD("Inicio", Icons.Default.Home, "home"),
+    CALENDAR("Calendario", Icons.Default.DateRange, "calendar"),
+    CLIENTS("Clientes", Icons.Default.Person, "clients"),
+    PRODUCTS("Productos", Icons.Default.ShoppingCart, "products"),
+    INVENTORY("Inventario", Icons.Default.Inventory, "inventory"),
+    SEARCH("Buscar", Icons.Default.Search, "search"),
+    SETTINGS("Ajustes", Icons.Default.Settings, "settings")
 }

--- a/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/AuthBrandingPanel.kt
+++ b/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/AuthBrandingPanel.kt
@@ -1,0 +1,159 @@
+package com.creapolis.solennix.feature.auth.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.creapolis.solennix.core.designsystem.theme.SolennixGold
+import com.creapolis.solennix.core.designsystem.theme.SolennixGoldDark
+import com.creapolis.solennix.core.designsystem.theme.SolennixTitle
+
+/**
+ * Branding panel shown on the left side of auth screens on tablet layout.
+ * Mirrors the web app's premium gradient left panel on login/register pages.
+ */
+@Composable
+fun AuthBrandingPanel(modifier: Modifier = Modifier) {
+    val premiumGradient = Brush.linearGradient(
+        colors = listOf(SolennixGold, SolennixGoldDark)
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .background(premiumGradient)
+            .padding(40.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            // Logo at top
+            Text(
+                text = "SOLENNIX",
+                style = SolennixTitle,
+                color = Color.White,
+                fontSize = 28.sp
+            )
+
+            // Main copy in center
+            Column {
+                Text(
+                    text = "Gestiona tus eventos\ncomo un profesional",
+                    style = MaterialTheme.typography.headlineLarge.copy(
+                        fontWeight = FontWeight.Black,
+                        lineHeight = 40.sp
+                    ),
+                    color = Color.White
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Organiza, cotiza y controla cada detalle de tus celebraciones desde un solo lugar.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Color.White.copy(alpha = 0.85f)
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                // Feature highlights
+                FeatureHighlight(
+                    icon = Icons.Default.Event,
+                    text = "Gestión completa de eventos"
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                FeatureHighlight(
+                    icon = Icons.Default.Description,
+                    text = "Cotizaciones y contratos profesionales"
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                FeatureHighlight(
+                    icon = Icons.Default.Inventory,
+                    text = "Control de inventario en tiempo real"
+                )
+            }
+
+            // Social proof at bottom
+            Column {
+                HorizontalDivider(
+                    color = Color.White.copy(alpha = 0.3f),
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                Text(
+                    text = "Más de 500 organizadores confían en Solennix",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Start
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeatureHighlight(icon: ImageVector, text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(Color.White.copy(alpha = 0.2f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            color = Color.White.copy(alpha = 0.9f)
+        )
+    }
+}
+
+/**
+ * Wrapper that applies split layout on tablets (branding left + content right)
+ * or single-column layout on phones.
+ */
+@Composable
+fun AdaptiveAuthLayout(
+    isWideScreen: Boolean,
+    content: @Composable () -> Unit
+) {
+    if (isWideScreen) {
+        Row(modifier = Modifier.fillMaxSize()) {
+            AuthBrandingPanel(
+                modifier = Modifier.fillMaxWidth(0.4f)
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                Box(modifier = Modifier.widthIn(max = 480.dp)) {
+                    content()
+                }
+            }
+        }
+    } else {
+        content()
+    }
+}

--- a/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/ForgotPasswordScreen.kt
+++ b/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/ForgotPasswordScreen.kt
@@ -23,21 +23,40 @@ import com.creapolis.solennix.feature.auth.viewmodel.AuthViewModel
 @Composable
 fun ForgotPasswordScreen(
     viewModel: AuthViewModel,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
+    isWideScreen: Boolean = false
+) {
+    AdaptiveAuthLayout(isWideScreen = isWideScreen) {
+        ForgotPasswordFormContent(
+            viewModel = viewModel,
+            onNavigateBack = onNavigateBack,
+            isWideScreen = isWideScreen
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ForgotPasswordFormContent(
+    viewModel: AuthViewModel,
+    onNavigateBack: () -> Unit,
+    isWideScreen: Boolean
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Recuperar Contrasena") },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = SolennixTheme.colors.background
+            if (!isWideScreen) {
+                TopAppBar(
+                    title = { Text("Recuperar Contrasena") },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = SolennixTheme.colors.background
+                    )
                 )
-            )
+            }
         },
         containerColor = SolennixTheme.colors.background
     ) { padding ->
@@ -45,10 +64,28 @@ fun ForgotPasswordScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .padding(24.dp),
+                .padding(horizontal = if (isWideScreen) 40.dp else 24.dp, vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            if (isWideScreen) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Recuperar Contraseña",
+                        style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+                        color = SolennixTheme.colors.primaryText
+                    )
+                }
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
             if (viewModel.forgotSuccess) {
                 Icon(
                     imageVector = Icons.Default.CheckCircle,

--- a/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/LoginScreen.kt
+++ b/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/LoginScreen.kt
@@ -35,15 +35,33 @@ fun LoginScreen(
     viewModel: AuthViewModel,
     onNavigateToRegister: () -> Unit,
     onNavigateToForgot: () -> Unit,
-    onLoginSuccess: () -> Unit = {}
+    onLoginSuccess: () -> Unit = {},
+    isWideScreen: Boolean = false
 ) {
     LaunchedEffect(Unit) {
         viewModel.loginSuccess.collect { onLoginSuccess() }
     }
 
+    AdaptiveAuthLayout(isWideScreen = isWideScreen) {
+        LoginFormContent(
+            viewModel = viewModel,
+            onNavigateToRegister = onNavigateToRegister,
+            onNavigateToForgot = onNavigateToForgot,
+            isWideScreen = isWideScreen
+        )
+    }
+}
+
+@Composable
+private fun LoginFormContent(
+    viewModel: AuthViewModel,
+    onNavigateToRegister: () -> Unit,
+    onNavigateToForgot: () -> Unit,
+    isWideScreen: Boolean
+) {
     val scrollState = rememberScrollState()
-    
-    // Animation for logo
+
+    // Animation for logo (only on phone)
     val infiniteTransition = rememberInfiniteTransition(label = "logo")
     val logoScale by infiniteTransition.animateFloat(
         initialValue = 0.95f,
@@ -60,33 +78,50 @@ fun LoginScreen(
             .fillMaxSize()
             .background(SolennixTheme.colors.background)
             .verticalScroll(scrollState)
-            .padding(24.dp),
+            .padding(horizontal = if (isWideScreen) 40.dp else 24.dp, vertical = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Spacer(modifier = Modifier.height(60.dp))
+        if (!isWideScreen) {
+            Spacer(modifier = Modifier.height(60.dp))
 
-        // Logo Section
-        Box(contentAlignment = Alignment.Center) {
-            // Tulip cup icon placeholder or actual resource if available
+            // Logo Section (phone only — tablet has branding panel)
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = "SOLENNIX",
+                    style = SolennixTitle,
+                    color = SolennixTheme.colors.primary,
+                    modifier = Modifier
+                        .scale(logoScale)
+                        .alpha(0.9f)
+                )
+            }
+
             Text(
-                text = "SOLENNIX",
-                style = SolennixTitle,
-                color = SolennixTheme.colors.primary,
-                modifier = Modifier
-                    .scale(logoScale)
-                    .alpha(0.9f)
+                text = "CADA DETALLE IMPORTA",
+                style = TaglineStyle,
+                color = SolennixTheme.colors.secondaryText,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 8.dp)
             )
-        }
-        
-        Text(
-            text = "CADA DETALLE IMPORTA",
-            style = TaglineStyle,
-            color = SolennixTheme.colors.secondaryText,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(top = 8.dp)
-        )
 
-        Spacer(modifier = Modifier.height(64.dp))
+            Spacer(modifier = Modifier.height(64.dp))
+        } else {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Iniciar Sesión",
+                style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+                color = SolennixTheme.colors.primaryText
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Ingresa tus credenciales para continuar",
+                style = MaterialTheme.typography.bodyMedium,
+                color = SolennixTheme.colors.secondaryText
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+        }
 
         // Form Section
         SolennixTextField(

--- a/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/RegisterScreen.kt
+++ b/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/RegisterScreen.kt
@@ -28,27 +28,46 @@ import androidx.compose.ui.graphics.vector.ImageVector
 fun RegisterScreen(
     viewModel: AuthViewModel,
     onNavigateBack: () -> Unit,
-    onLoginSuccess: () -> Unit = {}
+    onLoginSuccess: () -> Unit = {},
+    isWideScreen: Boolean = false
 ) {
     LaunchedEffect(Unit) {
         viewModel.loginSuccess.collect { onLoginSuccess() }
     }
 
+    AdaptiveAuthLayout(isWideScreen = isWideScreen) {
+        RegisterFormContent(
+            viewModel = viewModel,
+            onNavigateBack = onNavigateBack,
+            isWideScreen = isWideScreen
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RegisterFormContent(
+    viewModel: AuthViewModel,
+    onNavigateBack: () -> Unit,
+    isWideScreen: Boolean
+) {
     val scrollState = rememberScrollState()
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Crear Cuenta", style = MaterialTheme.typography.titleLarge) },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = SolennixTheme.colors.background
+            if (!isWideScreen) {
+                TopAppBar(
+                    title = { Text("Crear Cuenta", style = MaterialTheme.typography.titleLarge) },
+                    navigationIcon = {
+                        IconButton(onClick = onNavigateBack) {
+                            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = SolennixTheme.colors.background
+                    )
                 )
-            )
+            }
         },
         containerColor = SolennixTheme.colors.background
     ) { padding ->
@@ -57,9 +76,27 @@ fun RegisterScreen(
                 .fillMaxSize()
                 .padding(padding)
                 .verticalScroll(scrollState)
-                .padding(24.dp),
+                .padding(horizontal = if (isWideScreen) 40.dp else 24.dp, vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            if (isWideScreen) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Crear Cuenta",
+                        style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+                        color = SolennixTheme.colors.primaryText
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
             Text(
                 text = "Unete a Solennix y gestiona tus eventos como un profesional.",
                 style = MaterialTheme.typography.bodyMedium,
@@ -69,45 +106,100 @@ fun RegisterScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            SolennixTextField(
-                value = viewModel.registerName,
-                onValueChange = { viewModel.registerName = it },
-                label = "Nombre Completo",
-                placeholder = "Juan Perez",
-                leadingIcon = Icons.Default.Person
-            )
+            // On wide screens, show name + email side by side
+            if (isWideScreen) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        SolennixTextField(
+                            value = viewModel.registerName,
+                            onValueChange = { viewModel.registerName = it },
+                            label = "Nombre Completo",
+                            placeholder = "Juan Perez",
+                            leadingIcon = Icons.Default.Person
+                        )
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        SolennixTextField(
+                            value = viewModel.registerEmail,
+                            onValueChange = { viewModel.registerEmail = it },
+                            label = "Correo Electronico",
+                            placeholder = "ejemplo@correo.com",
+                            leadingIcon = Icons.Default.Email,
+                            keyboardType = KeyboardType.Email
+                        )
+                    }
+                }
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-            SolennixTextField(
-                value = viewModel.registerEmail,
-                onValueChange = { viewModel.registerEmail = it },
-                label = "Correo Electronico",
-                placeholder = "ejemplo@correo.com",
-                leadingIcon = Icons.Default.Email,
-                keyboardType = KeyboardType.Email
-            )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        SolennixTextField(
+                            value = viewModel.registerPassword,
+                            onValueChange = { viewModel.registerPassword = it },
+                            label = "Contrasena",
+                            leadingIcon = Icons.Default.Lock,
+                            isPassword = true
+                        )
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        SolennixTextField(
+                            value = viewModel.registerConfirmPassword,
+                            onValueChange = { viewModel.registerConfirmPassword = it },
+                            label = "Confirmar Contrasena",
+                            leadingIcon = Icons.Default.Lock,
+                            isPassword = true,
+                            imeAction = ImeAction.Done
+                        )
+                    }
+                }
+            } else {
+                SolennixTextField(
+                    value = viewModel.registerName,
+                    onValueChange = { viewModel.registerName = it },
+                    label = "Nombre Completo",
+                    placeholder = "Juan Perez",
+                    leadingIcon = Icons.Default.Person
+                )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-            SolennixTextField(
-                value = viewModel.registerPassword,
-                onValueChange = { viewModel.registerPassword = it },
-                label = "Contrasena",
-                leadingIcon = Icons.Default.Lock,
-                isPassword = true
-            )
+                SolennixTextField(
+                    value = viewModel.registerEmail,
+                    onValueChange = { viewModel.registerEmail = it },
+                    label = "Correo Electronico",
+                    placeholder = "ejemplo@correo.com",
+                    leadingIcon = Icons.Default.Email,
+                    keyboardType = KeyboardType.Email
+                )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-            SolennixTextField(
-                value = viewModel.registerConfirmPassword,
-                onValueChange = { viewModel.registerConfirmPassword = it },
-                label = "Confirmar Contrasena",
-                leadingIcon = Icons.Default.Lock,
-                isPassword = true,
-                imeAction = ImeAction.Done
-            )
+                SolennixTextField(
+                    value = viewModel.registerPassword,
+                    onValueChange = { viewModel.registerPassword = it },
+                    label = "Contrasena",
+                    leadingIcon = Icons.Default.Lock,
+                    isPassword = true
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                SolennixTextField(
+                    value = viewModel.registerConfirmPassword,
+                    onValueChange = { viewModel.registerConfirmPassword = it },
+                    label = "Confirmar Contrasena",
+                    leadingIcon = Icons.Default.Lock,
+                    isPassword = true,
+                    imeAction = ImeAction.Done
+                )
+            }
 
             Spacer(modifier = Modifier.height(32.dp))
 
@@ -149,13 +241,13 @@ fun RegisterScreen(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
-            
+
             Spacer(modifier = Modifier.height(24.dp))
-            
+
             HorizontalDivider()
-            
+
             Spacer(modifier = Modifier.height(24.dp))
-            
+
             GoogleSignInButton(
                 onSuccess = { idToken, fullName ->
                     viewModel.loginWithGoogle(idToken, fullName)

--- a/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/ResetPasswordScreen.kt
+++ b/android/feature/auth/src/main/java/com/creapolis/solennix/feature/auth/ui/ResetPasswordScreen.kt
@@ -22,7 +22,8 @@ import com.creapolis.solennix.feature.auth.viewmodel.AuthViewModel
 fun ResetPasswordScreen(
     token: String?,
     viewModel: AuthViewModel,
-    onNavigateToLogin: () -> Unit
+    onNavigateToLogin: () -> Unit,
+    isWideScreen: Boolean = false
 ) {
     LaunchedEffect(token) {
         if (token != null) {
@@ -30,10 +31,25 @@ fun ResetPasswordScreen(
         }
     }
 
+    AdaptiveAuthLayout(isWideScreen = isWideScreen) {
+        ResetPasswordFormContent(
+            viewModel = viewModel,
+            onNavigateToLogin = onNavigateToLogin,
+            isWideScreen = isWideScreen
+        )
+    }
+}
+
+@Composable
+private fun ResetPasswordFormContent(
+    viewModel: AuthViewModel,
+    onNavigateToLogin: () -> Unit,
+    isWideScreen: Boolean
+) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(24.dp),
+            .padding(horizontal = if (isWideScreen) 40.dp else 24.dp, vertical = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -80,24 +96,52 @@ fun ResetPasswordScreen(
 
             Spacer(modifier = Modifier.height(40.dp))
 
-            SolennixTextField(
-                value = viewModel.newPassword,
-                onValueChange = { viewModel.newPassword = it },
-                label = "Nueva Contrasena",
-                leadingIcon = Icons.Default.Lock,
-                isPassword = true
-            )
+            // On wide screens, show passwords side by side
+            if (isWideScreen) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        SolennixTextField(
+                            value = viewModel.newPassword,
+                            onValueChange = { viewModel.newPassword = it },
+                            label = "Nueva Contrasena",
+                            leadingIcon = Icons.Default.Lock,
+                            isPassword = true
+                        )
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        SolennixTextField(
+                            value = viewModel.confirmNewPassword,
+                            onValueChange = { viewModel.confirmNewPassword = it },
+                            label = "Confirmar Nueva Contrasena",
+                            leadingIcon = Icons.Default.Lock,
+                            isPassword = true,
+                            imeAction = ImeAction.Done
+                        )
+                    }
+                }
+            } else {
+                SolennixTextField(
+                    value = viewModel.newPassword,
+                    onValueChange = { viewModel.newPassword = it },
+                    label = "Nueva Contrasena",
+                    leadingIcon = Icons.Default.Lock,
+                    isPassword = true
+                )
 
-            Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
-            SolennixTextField(
-                value = viewModel.confirmNewPassword,
-                onValueChange = { viewModel.confirmNewPassword = it },
-                label = "Confirmar Nueva Contrasena",
-                leadingIcon = Icons.Default.Lock,
-                isPassword = true,
-                imeAction = ImeAction.Done
-            )
+                SolennixTextField(
+                    value = viewModel.confirmNewPassword,
+                    onValueChange = { viewModel.confirmNewPassword = it },
+                    label = "Confirmar Nueva Contrasena",
+                    leadingIcon = Icons.Default.Lock,
+                    isPassword = true,
+                    imeAction = ImeAction.Done
+                )
+            }
 
             Spacer(modifier = Modifier.height(32.dp))
 


### PR DESCRIPTION
The tablet layout (AdaptiveNavigationRailLayout) only had Dashboard and Clients
working — all other sections showed "Phase 6" placeholder text. This rewrites
the tablet layout with a full NavHost mirroring the phone layout's navigation
graph, enabling all 7 sidebar sections (Dashboard, Calendar, Clients, Products,
Inventory, Search, Settings) with complete navigation support including detail
screens, forms, and sub-screens. Also adds FAB support and deep linking.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01HEnKhSZ4LCtEoHLgjfEsKi