### PR TITLE
fix(android): complete tablet layout with web-like responsive design

### DIFF
--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AdaptiveNavigationRailLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/AdaptiveNavigationRailLayout.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -72,6 +73,7 @@ fun AdaptiveNavigationRailLayout(initialDeepLinkRoute: String? = null) {
     val sectionRoutes = SidebarSection.entries.map { it.route }.toSet()
     val isAtSectionLevel = currentRoute in sectionRoutes
 
+    CompositionLocalProvider(LocalIsWideScreen provides true) {
     Row(Modifier.fillMaxSize()) {
         NavigationRail(
             containerColor = SolennixTheme.colors.card,
@@ -429,4 +431,5 @@ fun AdaptiveNavigationRailLayout(initialDeepLinkRoute: String? = null) {
             }
         }
     }
+    } // CompositionLocalProvider
 }

--- a/android/core/designsystem/src/main/java/com/creapolis/solennix/core/designsystem/component/KPICard.kt
+++ b/android/core/designsystem/src/main/java/com/creapolis/solennix/core/designsystem/component/KPICard.kt
@@ -30,7 +30,7 @@ fun KPICard(
 ) {
     Card(
         modifier = modifier
-            .width(155.dp)
+            .defaultMinSize(minWidth = 155.dp)
             .semantics(mergeDescendants = true) {
                 contentDescription = "$title: $value" + (subtitle?.let { ". $it" } ?: "")
             },

--- a/android/core/designsystem/src/main/java/com/creapolis/solennix/core/designsystem/theme/WindowSize.kt
+++ b/android/core/designsystem/src/main/java/com/creapolis/solennix/core/designsystem/theme/WindowSize.kt
@@ -1,0 +1,10 @@
+package com.creapolis.solennix.core.designsystem.theme
+
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * CompositionLocal that indicates whether the current layout is wide (tablet/desktop).
+ * Set to true in AdaptiveNavigationRailLayout, false in CompactBottomNavLayout.
+ * Screens can read this to adapt their layout for wider screens.
+ */
+val LocalIsWideScreen = compositionLocalOf { false }

--- a/android/feature/clients/src/main/java/com/creapolis/solennix/feature/clients/ui/ClientDetailScreen.kt
+++ b/android/feature/clients/src/main/java/com/creapolis/solennix/feature/clients/ui/ClientDetailScreen.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.component.Avatar
 import com.creapolis.solennix.core.designsystem.component.KPICard
 import com.creapolis.solennix.core.designsystem.component.StatusBadge
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.Event
 import com.creapolis.solennix.core.model.extensions.asMXN
@@ -82,141 +83,157 @@ fun ClientDetailScreen(
                     .padding(16.dp)
             ) {
                 // --- Header: Avatar + Name ---
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Avatar(name = client.name, photoUrl = client.photoUrl, size = 100.dp)
-                    Spacer(modifier = Modifier.height(12.dp))
-                    Text(
-                        text = client.name,
-                        style = MaterialTheme.typography.headlineMedium,
-                        color = SolennixTheme.colors.primaryText
-                    )
+                val isWide = LocalIsWideScreen.current
+                if (isWide) {
+                    // Tablet: avatar inline with name
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Avatar(name = client.name, photoUrl = client.photoUrl, size = 80.dp)
+                        Spacer(modifier = Modifier.width(20.dp))
+                        Text(
+                            text = client.name,
+                            style = MaterialTheme.typography.headlineMedium,
+                            color = SolennixTheme.colors.primaryText
+                        )
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Avatar(name = client.name, photoUrl = client.photoUrl, size = 100.dp)
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(text = client.name, style = MaterialTheme.typography.headlineMedium, color = SolennixTheme.colors.primaryText)
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                // --- Contact Info Card ---
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
-                    shape = MaterialTheme.shapes.large
-                ) {
-                    Column(modifier = Modifier.padding(20.dp)) {
-                        Text(
-                            text = "Informacion de Contacto",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = SolennixTheme.colors.primaryText
-                        )
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        InfoRow(icon = Icons.Default.Phone, label = "Telefono", value = client.phone)
-                        HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-
-                        InfoRow(
-                            icon = Icons.Default.Email,
-                            label = "Email",
-                            value = client.email ?: "No proporcionado"
-                        )
-
-                        val addr = client.address
-                        if (!addr.isNullOrBlank()) {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-                            InfoRow(
-                                icon = Icons.Default.LocationOn,
-                                label = "Direccion",
-                                value = addr
-                            )
+                // --- Contact Info + Stats: side by side on tablet ---
+                if (isWide) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        // Left: Contact Info Card
+                        Card(
+                            modifier = Modifier.weight(1f),
+                            colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                            shape = MaterialTheme.shapes.large
+                        ) {
+                            Column(modifier = Modifier.padding(20.dp)) {
+                                Text(text = "Informacion de Contacto", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                                Spacer(modifier = Modifier.height(16.dp))
+                                InfoRow(icon = Icons.Default.Phone, label = "Telefono", value = client.phone)
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                                InfoRow(icon = Icons.Default.Email, label = "Email", value = client.email ?: "No proporcionado")
+                                val addr = client.address
+                                if (!addr.isNullOrBlank()) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                                    InfoRow(icon = Icons.Default.LocationOn, label = "Direccion", value = addr)
+                                }
+                                val cCity = client.city
+                                if (!cCity.isNullOrBlank()) {
+                                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                                    InfoRow(icon = Icons.Default.LocationCity, label = "Ciudad", value = cCity)
+                                }
+                            }
                         }
 
-                        val cCity = client.city
-                        if (!cCity.isNullOrBlank()) {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-                            InfoRow(
-                                icon = Icons.Default.LocationCity,
-                                label = "Ciudad",
-                                value = cCity
-                            )
+                        // Right: Stats + Notes
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(text = "Estadisticas", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                            Spacer(modifier = Modifier.height(4.dp))
+                            if (uiState.isEventsLoading) {
+                                Box(modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp), contentAlignment = Alignment.Center) {
+                                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                                }
+                            } else {
+                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                                    KPICard(title = "Total Eventos", value = uiState.totalEvents.toString(), icon = Icons.Default.Event, iconColor = SolennixTheme.colors.kpiBlue, modifier = Modifier.weight(1f))
+                                    KPICard(title = "Total Gastado", value = uiState.totalSpent.asMXN(), icon = Icons.Default.AttachMoney, iconColor = SolennixTheme.colors.kpiGreen, modifier = Modifier.weight(1f))
+                                    KPICard(title = "Promedio", value = uiState.averagePerEvent.asMXN(), icon = Icons.Default.TrendingUp, iconColor = SolennixTheme.colors.kpiOrange, modifier = Modifier.weight(1f))
+                                }
+                            }
+                            val cNotes = client.notes
+                            if (!cNotes.isNullOrBlank()) {
+                                Spacer(modifier = Modifier.height(16.dp))
+                                Card(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                                    shape = MaterialTheme.shapes.large
+                                ) {
+                                    Column(modifier = Modifier.padding(20.dp)) {
+                                        Text(text = "Notas", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                                        Spacer(modifier = Modifier.height(8.dp))
+                                        Text(text = cNotes, style = MaterialTheme.typography.bodyMedium, color = SolennixTheme.colors.secondaryText)
+                                    }
+                                }
+                            }
                         }
                     }
-                }
-
-                // --- Notes Card ---
-                val cNotes = client.notes
-                if (!cNotes.isNullOrBlank()) {
-                    Spacer(modifier = Modifier.height(16.dp))
+                } else {
+                    // Phone: single column
                     Card(
                         modifier = Modifier.fillMaxWidth(),
                         colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
                         shape = MaterialTheme.shapes.large
                     ) {
                         Column(modifier = Modifier.padding(20.dp)) {
-                            Text(
-                                text = "Notas",
-                                style = MaterialTheme.typography.titleMedium,
-                                color = SolennixTheme.colors.primaryText
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = cNotes,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = SolennixTheme.colors.secondaryText
-                            )
+                            Text(text = "Informacion de Contacto", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                            Spacer(modifier = Modifier.height(16.dp))
+                            InfoRow(icon = Icons.Default.Phone, label = "Telefono", value = client.phone)
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                            InfoRow(icon = Icons.Default.Email, label = "Email", value = client.email ?: "No proporcionado")
+                            val addr = client.address
+                            if (!addr.isNullOrBlank()) {
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                                InfoRow(icon = Icons.Default.LocationOn, label = "Direccion", value = addr)
+                            }
+                            val cCity = client.city
+                            if (!cCity.isNullOrBlank()) {
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+                                InfoRow(icon = Icons.Default.LocationCity, label = "Ciudad", value = cCity)
+                            }
                         }
                     }
-                }
 
-                Spacer(modifier = Modifier.height(24.dp))
-
-                // --- Stats Row (3 KPI cards) ---
-                Text(
-                    text = "Estadisticas",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = SolennixTheme.colors.primaryText
-                )
-                Spacer(modifier = Modifier.height(4.dp))
-
-                if (uiState.isEventsLoading) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    val cNotes = client.notes
+                    if (!cNotes.isNullOrBlank()) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                            shape = MaterialTheme.shapes.large
+                        ) {
+                            Column(modifier = Modifier.padding(20.dp)) {
+                                Text(text = "Notas", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(text = cNotes, style = MaterialTheme.typography.bodyMedium, color = SolennixTheme.colors.secondaryText)
+                            }
+                        }
                     }
-                } else {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        KPICard(
-                            title = "Total Eventos",
-                            value = uiState.totalEvents.toString(),
-                            icon = Icons.Default.Event,
-                            iconColor = SolennixTheme.colors.kpiBlue,
-                            modifier = Modifier.weight(1f)
-                        )
-                        KPICard(
-                            title = "Total Gastado",
-                            value = uiState.totalSpent.asMXN(),
-                            icon = Icons.Default.AttachMoney,
-                            iconColor = SolennixTheme.colors.kpiGreen,
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        KPICard(
-                            title = "Promedio por Evento",
-                            value = uiState.averagePerEvent.asMXN(),
-                            icon = Icons.Default.TrendingUp,
-                            iconColor = SolennixTheme.colors.kpiOrange,
-                            modifier = Modifier.weight(1f)
-                        )
-                        // Spacer to balance the row
-                        Spacer(modifier = Modifier.weight(1f))
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Text(text = "Estadisticas", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    if (uiState.isEventsLoading) {
+                        Box(modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        }
+                    } else {
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            KPICard(title = "Total Eventos", value = uiState.totalEvents.toString(), icon = Icons.Default.Event, iconColor = SolennixTheme.colors.kpiBlue, modifier = Modifier.weight(1f))
+                            KPICard(title = "Total Gastado", value = uiState.totalSpent.asMXN(), icon = Icons.Default.AttachMoney, iconColor = SolennixTheme.colors.kpiGreen, modifier = Modifier.weight(1f))
+                        }
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                            KPICard(title = "Promedio por Evento", value = uiState.averagePerEvent.asMXN(), icon = Icons.Default.TrendingUp, iconColor = SolennixTheme.colors.kpiOrange, modifier = Modifier.weight(1f))
+                            Spacer(modifier = Modifier.weight(1f))
+                        }
                     }
                 }
 

--- a/android/feature/clients/src/main/java/com/creapolis/solennix/feature/clients/ui/ClientFormScreen.kt
+++ b/android/feature/clients/src/main/java/com/creapolis/solennix/feature/clients/ui/ClientFormScreen.kt
@@ -34,6 +34,7 @@ import coil3.request.crossfade
 import com.creapolis.solennix.core.network.UrlResolver
 import com.creapolis.solennix.core.designsystem.component.PremiumButton
 import com.creapolis.solennix.core.designsystem.component.SolennixTextField
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.feature.clients.viewmodel.ClientFormViewModel
 
@@ -152,58 +153,43 @@ fun ClientFormScreen(
 
                 Spacer(modifier = Modifier.height(24.dp))
 
-                // Form fields
-                SolennixTextField(
-                    value = viewModel.name,
-                    onValueChange = { viewModel.name = it },
-                    label = "Nombre *",
-                    leadingIcon = Icons.Default.Person,
-                    errorMessage = viewModel.nameError
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                SolennixTextField(
-                    value = viewModel.phone,
-                    onValueChange = { viewModel.phone = it },
-                    label = "Telefono *",
-                    leadingIcon = Icons.Default.Phone,
-                    keyboardType = KeyboardType.Phone,
-                    errorMessage = viewModel.phoneError
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                SolennixTextField(
-                    value = viewModel.email,
-                    onValueChange = { viewModel.email = it },
-                    label = "Correo Electronico",
-                    leadingIcon = Icons.Default.Email,
-                    keyboardType = KeyboardType.Email,
-                    errorMessage = viewModel.emailError
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                SolennixTextField(
-                    value = viewModel.address,
-                    onValueChange = { viewModel.address = it },
-                    label = "Direccion",
-                    leadingIcon = Icons.Default.LocationOn
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                SolennixTextField(
-                    value = viewModel.city,
-                    onValueChange = { viewModel.city = it },
-                    label = "Ciudad",
-                    leadingIcon = Icons.Default.LocationCity
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                SolennixTextField(
-                    value = viewModel.notes,
-                    onValueChange = { viewModel.notes = it },
-                    label = "Notas",
-                    leadingIcon = Icons.Default.Notes
-                )
+                // Form fields — 2-column on tablet, single column on phone
+                val isWide = LocalIsWideScreen.current
+                if (isWide) {
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(value = viewModel.name, onValueChange = { viewModel.name = it }, label = "Nombre *", leadingIcon = Icons.Default.Person, errorMessage = viewModel.nameError)
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(value = viewModel.phone, onValueChange = { viewModel.phone = it }, label = "Telefono *", leadingIcon = Icons.Default.Phone, keyboardType = KeyboardType.Phone, errorMessage = viewModel.phoneError)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(value = viewModel.email, onValueChange = { viewModel.email = it }, label = "Correo Electronico", leadingIcon = Icons.Default.Email, keyboardType = KeyboardType.Email, errorMessage = viewModel.emailError)
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(value = viewModel.city, onValueChange = { viewModel.city = it }, label = "Ciudad", leadingIcon = Icons.Default.LocationCity)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.address, onValueChange = { viewModel.address = it }, label = "Direccion", leadingIcon = Icons.Default.LocationOn)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.notes, onValueChange = { viewModel.notes = it }, label = "Notas", leadingIcon = Icons.Default.Notes)
+                } else {
+                    SolennixTextField(value = viewModel.name, onValueChange = { viewModel.name = it }, label = "Nombre *", leadingIcon = Icons.Default.Person, errorMessage = viewModel.nameError)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.phone, onValueChange = { viewModel.phone = it }, label = "Telefono *", leadingIcon = Icons.Default.Phone, keyboardType = KeyboardType.Phone, errorMessage = viewModel.phoneError)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.email, onValueChange = { viewModel.email = it }, label = "Correo Electronico", leadingIcon = Icons.Default.Email, keyboardType = KeyboardType.Email, errorMessage = viewModel.emailError)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.address, onValueChange = { viewModel.address = it }, label = "Direccion", leadingIcon = Icons.Default.LocationOn)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.city, onValueChange = { viewModel.city = it }, label = "Ciudad", leadingIcon = Icons.Default.LocationCity)
+                    Spacer(modifier = Modifier.height(16.dp))
+                    SolennixTextField(value = viewModel.notes, onValueChange = { viewModel.notes = it }, label = "Notas", leadingIcon = Icons.Default.Notes)
+                }
                 Spacer(modifier = Modifier.height(32.dp))
 
                 if (viewModel.errorMessage != null) {

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/DashboardScreen.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/DashboardScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.component.*
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.Event
 import com.creapolis.solennix.core.model.EventStatus
@@ -81,71 +82,65 @@ fun DashboardScreen(
                     Spacer(modifier = Modifier.height(8.dp))
                 }
 
-                // KPI Cards — horizontal scroll (matching iOS layout)
+                // KPI Cards
                 item {
-                    Row(
-                        modifier = Modifier
-                            .horizontalScroll(rememberScrollState())
-                            .padding(vertical = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Spacer(modifier = Modifier.width(4.dp))
-                        KPICard(
-                            title = "Ventas del Mes",
-                            value = uiState.revenueThisMonth.asMXN(),
-                            icon = Icons.Default.AttachMoney,
-                            iconColor = SolennixTheme.colors.kpiGreen
+                    val isWide = LocalIsWideScreen.current
+                    if (isWide) {
+                        // Tablet: grid layout (4 columns like web)
+                        val kpiItems = listOf(
+                            Triple("Ventas del Mes", uiState.revenueThisMonth.asMXN(), Triple(Icons.Default.AttachMoney, SolennixTheme.colors.kpiGreen, null as String?)),
+                            Triple("Cobrado", uiState.cashCollected.asMXN(), Triple(Icons.Default.Payments, SolennixTheme.colors.kpiOrange, "Este mes")),
+                            Triple("IVA Cobrado", uiState.vatCollected.asMXN(), Triple(Icons.Default.Receipt, SolennixTheme.colors.kpiBlue, "Este mes")),
+                            Triple("IVA Pendiente", uiState.vatOutstanding.asMXN(), Triple(Icons.Default.ReceiptLong, SolennixTheme.colors.kpiBlue, "Por cobrar")),
+                            Triple("Eventos del Mes", uiState.eventsThisMonth.toString(), Triple(Icons.Default.CalendarMonth, SolennixTheme.colors.kpiOrange, null)),
+                            Triple("Stock Bajo", uiState.lowStockCount.toString(), Triple(Icons.Default.Inventory2, if (uiState.lowStockCount > 0) SolennixTheme.colors.kpiOrange else SolennixTheme.colors.kpiGreen, null)),
+                            Triple("Clientes", uiState.totalClients.toString(), Triple(Icons.Default.People, SolennixTheme.colors.kpiBlue, "Total")),
+                            Triple("Cotizaciones", uiState.pendingQuotes.toString(), Triple(Icons.Default.RequestQuote, SolennixTheme.colors.kpiOrange, null))
                         )
-                        KPICard(
-                            title = "Cobrado",
-                            value = uiState.cashCollected.asMXN(),
-                            icon = Icons.Default.Payments,
-                            iconColor = SolennixTheme.colors.kpiOrange,
-                            subtitle = "Este mes"
-                        )
-                        KPICard(
-                            title = "IVA Cobrado",
-                            value = uiState.vatCollected.asMXN(),
-                            icon = Icons.Default.Receipt,
-                            iconColor = SolennixTheme.colors.kpiBlue,
-                            subtitle = "Este mes"
-                        )
-                        KPICard(
-                            title = "IVA Pendiente",
-                            value = uiState.vatOutstanding.asMXN(),
-                            icon = Icons.Default.ReceiptLong,
-                            iconColor = SolennixTheme.colors.kpiBlue,
-                            subtitle = "Por cobrar"
-                        )
-                        KPICard(
-                            title = "Eventos del Mes",
-                            value = uiState.eventsThisMonth.toString(),
-                            icon = Icons.Default.CalendarMonth,
-                            iconColor = SolennixTheme.colors.kpiOrange
-                        )
-                        KPICard(
-                            title = "Stock Bajo",
-                            value = uiState.lowStockCount.toString(),
-                            icon = Icons.Default.Inventory2,
-                            iconColor = if (uiState.lowStockCount > 0)
-                                SolennixTheme.colors.kpiOrange
-                            else
-                                SolennixTheme.colors.kpiGreen
-                        )
-                        KPICard(
-                            title = "Clientes",
-                            value = uiState.totalClients.toString(),
-                            icon = Icons.Default.People,
-                            iconColor = SolennixTheme.colors.kpiBlue,
-                            subtitle = "Total"
-                        )
-                        KPICard(
-                            title = "Cotizaciones",
-                            value = uiState.pendingQuotes.toString(),
-                            icon = Icons.Default.RequestQuote,
-                            iconColor = SolennixTheme.colors.kpiOrange
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
+                        Column(modifier = Modifier.padding(vertical = 8.dp)) {
+                            kpiItems.chunked(4).forEach { rowItems ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                ) {
+                                    rowItems.forEach { (title, value, iconInfo) ->
+                                        val (icon, color, subtitle) = iconInfo
+                                        KPICard(
+                                            title = title,
+                                            value = value,
+                                            icon = icon,
+                                            iconColor = color,
+                                            subtitle = subtitle,
+                                            modifier = Modifier.weight(1f)
+                                        )
+                                    }
+                                    // Fill empty slots if row is not full
+                                    repeat(4 - rowItems.size) {
+                                        Spacer(modifier = Modifier.weight(1f))
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(12.dp))
+                            }
+                        }
+                    } else {
+                        // Phone: horizontal scroll
+                        Row(
+                            modifier = Modifier
+                                .horizontalScroll(rememberScrollState())
+                                .padding(vertical = 8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Spacer(modifier = Modifier.width(4.dp))
+                            KPICard(title = "Ventas del Mes", value = uiState.revenueThisMonth.asMXN(), icon = Icons.Default.AttachMoney, iconColor = SolennixTheme.colors.kpiGreen)
+                            KPICard(title = "Cobrado", value = uiState.cashCollected.asMXN(), icon = Icons.Default.Payments, iconColor = SolennixTheme.colors.kpiOrange, subtitle = "Este mes")
+                            KPICard(title = "IVA Cobrado", value = uiState.vatCollected.asMXN(), icon = Icons.Default.Receipt, iconColor = SolennixTheme.colors.kpiBlue, subtitle = "Este mes")
+                            KPICard(title = "IVA Pendiente", value = uiState.vatOutstanding.asMXN(), icon = Icons.Default.ReceiptLong, iconColor = SolennixTheme.colors.kpiBlue, subtitle = "Por cobrar")
+                            KPICard(title = "Eventos del Mes", value = uiState.eventsThisMonth.toString(), icon = Icons.Default.CalendarMonth, iconColor = SolennixTheme.colors.kpiOrange)
+                            KPICard(title = "Stock Bajo", value = uiState.lowStockCount.toString(), icon = Icons.Default.Inventory2, iconColor = if (uiState.lowStockCount > 0) SolennixTheme.colors.kpiOrange else SolennixTheme.colors.kpiGreen)
+                            KPICard(title = "Clientes", value = uiState.totalClients.toString(), icon = Icons.Default.People, iconColor = SolennixTheme.colors.kpiBlue, subtitle = "Total")
+                            KPICard(title = "Cotizaciones", value = uiState.pendingQuotes.toString(), icon = Icons.Default.RequestQuote, iconColor = SolennixTheme.colors.kpiOrange)
+                            Spacer(modifier = Modifier.width(4.dp))
+                        }
                     }
                 }
 
@@ -160,74 +155,115 @@ fun DashboardScreen(
                     }
                 }
 
-                // Gap 3: Event Status Distribution
-                if (uiState.statusDistribution.isNotEmpty()) {
+                // On tablet: show status + pending events side by side
+                if (LocalIsWideScreen.current && (uiState.statusDistribution.isNotEmpty() || uiState.pendingEvents.isNotEmpty())) {
                     item {
                         Spacer(modifier = Modifier.height(24.dp))
-                        Text(
-                            text = "Estado de Eventos",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = SolennixTheme.colors.primaryText
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        EventStatusDistributionCard(
-                            statusCounts = uiState.statusDistribution
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            // Left column: Status Distribution
+                            Column(modifier = Modifier.weight(1f)) {
+                                if (uiState.statusDistribution.isNotEmpty()) {
+                                    Text(
+                                        text = "Estado de Eventos",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        color = SolennixTheme.colors.primaryText
+                                    )
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    EventStatusDistributionCard(statusCounts = uiState.statusDistribution)
+                                }
+                            }
+                            // Right column: Pending Events
+                            Column(modifier = Modifier.weight(1f)) {
+                                if (uiState.pendingEvents.isNotEmpty()) {
+                                    Text(
+                                        text = "Eventos Pendientes",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        color = SolennixTheme.colors.primaryText
+                                    )
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    uiState.pendingEvents.forEach { pendingEvent ->
+                                        PendingEventItem(
+                                            pendingEvent = pendingEvent,
+                                            onClick = { onEventClick(pendingEvent.event.id) }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // Phone: single column
+                    if (uiState.statusDistribution.isNotEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(text = "Estado de Eventos", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                            Spacer(modifier = Modifier.height(8.dp))
+                            EventStatusDistributionCard(statusCounts = uiState.statusDistribution)
+                        }
+                    }
+                    if (uiState.pendingEvents.isNotEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(text = "Eventos Pendientes", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        items(uiState.pendingEvents) { pendingEvent ->
+                            PendingEventItem(pendingEvent = pendingEvent, onClick = { onEventClick(pendingEvent.event.id) })
+                        }
                     }
                 }
 
-                // Gap 2: Pending Events Section
-                if (uiState.pendingEvents.isNotEmpty()) {
+                // On tablet: upcoming events and inventory alerts side by side
+                if (LocalIsWideScreen.current && (uiState.upcomingEvents.isNotEmpty() || uiState.lowStockItems.isNotEmpty())) {
                     item {
                         Spacer(modifier = Modifier.height(24.dp))
-                        Text(
-                            text = "Eventos Pendientes",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = SolennixTheme.colors.primaryText
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                if (uiState.upcomingEvents.isNotEmpty()) {
+                                    Text(text = "Proximos Eventos", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    uiState.upcomingEvents.forEach { event ->
+                                        EventListItem(event = event, onClick = { onEventClick(event.id) })
+                                    }
+                                }
+                            }
+                            Column(modifier = Modifier.weight(1f)) {
+                                if (uiState.lowStockItems.isNotEmpty()) {
+                                    Text(text = "Alertas de Inventario", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    uiState.lowStockItems.forEach { item ->
+                                        InventoryAlertItem(item = item, onClick = { onInventoryClick(item.id) })
+                                    }
+                                }
+                            }
+                        }
                     }
-
-                    items(uiState.pendingEvents) { pendingEvent ->
-                        PendingEventItem(
-                            pendingEvent = pendingEvent,
-                            onClick = { onEventClick(pendingEvent.event.id) }
-                        )
+                } else {
+                    if (uiState.upcomingEvents.isNotEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(text = "Proximos Eventos", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        items(uiState.upcomingEvents) { event ->
+                            EventListItem(event = event, onClick = { onEventClick(event.id) })
+                        }
                     }
-                }
-
-                if (uiState.upcomingEvents.isNotEmpty()) {
-                    item {
-                        Spacer(modifier = Modifier.height(24.dp))
-                        Text(
-                            text = "Proximos Eventos",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = SolennixTheme.colors.primaryText
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
-
-                    items(uiState.upcomingEvents) { event ->
-                        EventListItem(event = event, onClick = { onEventClick(event.id) })
-                    }
-                }
-
-                if (uiState.lowStockItems.isNotEmpty()) {
-                    item {
-                        Spacer(modifier = Modifier.height(24.dp))
-                        Text(
-                            text = "Alertas de Inventario",
-                            style = MaterialTheme.typography.titleMedium,
-                            color = SolennixTheme.colors.primaryText
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                    }
-
-                    items(uiState.lowStockItems) { item ->
-                        InventoryAlertItem(
-                            item = item,
-                            onClick = { onInventoryClick(item.id) }
-                        )
+                    if (uiState.lowStockItems.isNotEmpty()) {
+                        item {
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Text(text = "Alertas de Inventario", style = MaterialTheme.typography.titleMedium, color = SolennixTheme.colors.primaryText)
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        items(uiState.lowStockItems) { item ->
+                            InventoryAlertItem(item = item, onClick = { onInventoryClick(item.id) })
+                        }
                     }
                 }
 

--- a/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/ui/InventoryFormScreen.kt
+++ b/android/feature/inventory/src/main/java/com/creapolis/solennix/feature/inventory/ui/InventoryFormScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.creapolis.solennix.core.designsystem.component.PremiumButton
 import com.creapolis.solennix.core.designsystem.component.SolennixTextField
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.InventoryType
 import com.creapolis.solennix.feature.inventory.viewmodel.InventoryFormViewModel
@@ -57,112 +58,232 @@ fun InventoryFormScreen(
                     .verticalScroll(scrollState)
                     .padding(16.dp)
             ) {
-                SolennixTextField(
-                    value = viewModel.ingredientName,
-                    onValueChange = { viewModel.ingredientName = it },
-                    label = "Nombre del Item *",
-                    leadingIcon = Icons.Default.Archive
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Type selector
-                Text(
-                    text = "Tipo *",
-                    style = MaterialTheme.typography.labelMedium,
-                    color = SolennixTheme.colors.secondaryText
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                    val types = listOf(
-                        InventoryType.INGREDIENT to "Ingrediente",
-                        InventoryType.EQUIPMENT to "Equipo",
-                        InventoryType.SUPPLY to "Insumo"
-                    )
-                    types.forEachIndexed { index, (type, label) ->
-                        SegmentedButton(
-                            shape = SegmentedButtonDefaults.itemShape(index = index, count = types.size),
-                            onClick = { viewModel.type = type },
-                            selected = viewModel.type == type
-                        ) {
-                            Text(label)
-                        }
-                    }
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                    SolennixTextField(
-                        value = viewModel.currentStock,
-                        onValueChange = { viewModel.currentStock = it },
-                        label = "Stock Actual *",
-                        keyboardType = KeyboardType.Decimal,
-                        modifier = Modifier.weight(1f)
-                    )
-                    SolennixTextField(
-                        value = viewModel.minimumStock,
-                        onValueChange = { viewModel.minimumStock = it },
-                        label = "Stock Mínimo *",
-                        keyboardType = KeyboardType.Decimal,
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Unit dropdown with common options
+                // Form fields — 2-column on tablet, single column on phone
+                val isWide = LocalIsWideScreen.current
                 val commonUnits = listOf("pieza", "kg", "g", "l", "ml", "caja", "paquete")
                 var unitExpanded by remember { mutableStateOf(false) }
 
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                    ExposedDropdownMenuBox(
-                        expanded = unitExpanded,
-                        onExpandedChange = { unitExpanded = it },
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        OutlinedTextField(
-                            value = viewModel.unit,
-                            onValueChange = { viewModel.unit = it },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .menuAnchor(MenuAnchorType.PrimaryEditable),
-                            label = { Text("Unidad *") },
-                            leadingIcon = { Icon(Icons.Default.Scale, contentDescription = null) },
-                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = unitExpanded) },
-                            shape = MaterialTheme.shapes.small,
-                            colors = OutlinedTextFieldDefaults.colors(
-                                focusedBorderColor = SolennixTheme.colors.primary,
-                                focusedLabelColor = SolennixTheme.colors.primary,
-                                cursorColor = SolennixTheme.colors.primary
-                            ),
-                            singleLine = true
-                        )
-                        val filteredUnits = commonUnits.filter {
-                            it.contains(viewModel.unit, ignoreCase = true)
+                if (isWide) {
+                    // Row 1: Name + Type selector
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.ingredientName,
+                                onValueChange = { viewModel.ingredientName = it },
+                                label = "Nombre del Item *",
+                                leadingIcon = Icons.Default.Archive
+                            )
                         }
-                        if (filteredUnits.isNotEmpty()) {
-                            ExposedDropdownMenu(
-                                expanded = unitExpanded,
-                                onDismissRequest = { unitExpanded = false }
-                            ) {
-                                filteredUnits.forEach { unitOption ->
-                                    DropdownMenuItem(
-                                        text = { Text(unitOption) },
-                                        onClick = {
-                                            viewModel.unit = unitOption
-                                            unitExpanded = false
-                                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            Column {
+                                Text(
+                                    text = "Tipo *",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = SolennixTheme.colors.secondaryText
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                                    val types = listOf(
+                                        InventoryType.INGREDIENT to "Ingrediente",
+                                        InventoryType.EQUIPMENT to "Equipo",
+                                        InventoryType.SUPPLY to "Insumo"
                                     )
+                                    types.forEachIndexed { index, (type, label) ->
+                                        SegmentedButton(
+                                            shape = SegmentedButtonDefaults.itemShape(index = index, count = types.size),
+                                            onClick = { viewModel.type = type },
+                                            selected = viewModel.type == type
+                                        ) {
+                                            Text(label)
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // Row 2: Current stock + Minimum stock
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.currentStock,
+                                onValueChange = { viewModel.currentStock = it },
+                                label = "Stock Actual *",
+                                keyboardType = KeyboardType.Decimal
+                            )
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.minimumStock,
+                                onValueChange = { viewModel.minimumStock = it },
+                                label = "Stock Mínimo *",
+                                keyboardType = KeyboardType.Decimal
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // Row 3: Unit + Cost
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            ExposedDropdownMenuBox(
+                                expanded = unitExpanded,
+                                onExpandedChange = { unitExpanded = it }
+                            ) {
+                                OutlinedTextField(
+                                    value = viewModel.unit,
+                                    onValueChange = { viewModel.unit = it },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .menuAnchor(MenuAnchorType.PrimaryEditable),
+                                    label = { Text("Unidad *") },
+                                    leadingIcon = { Icon(Icons.Default.Scale, contentDescription = null) },
+                                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = unitExpanded) },
+                                    shape = MaterialTheme.shapes.small,
+                                    colors = OutlinedTextFieldDefaults.colors(
+                                        focusedBorderColor = SolennixTheme.colors.primary,
+                                        focusedLabelColor = SolennixTheme.colors.primary,
+                                        cursorColor = SolennixTheme.colors.primary
+                                    ),
+                                    singleLine = true
+                                )
+                                val filteredUnits = commonUnits.filter {
+                                    it.contains(viewModel.unit, ignoreCase = true)
+                                }
+                                if (filteredUnits.isNotEmpty()) {
+                                    ExposedDropdownMenu(
+                                        expanded = unitExpanded,
+                                        onDismissRequest = { unitExpanded = false }
+                                    ) {
+                                        filteredUnits.forEach { unitOption ->
+                                            DropdownMenuItem(
+                                                text = { Text(unitOption) },
+                                                onClick = {
+                                                    viewModel.unit = unitOption
+                                                    unitExpanded = false
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.unitCost,
+                                onValueChange = { viewModel.unitCost = it },
+                                label = "Costo Unitario",
+                                leadingIcon = Icons.Default.AttachMoney,
+                                keyboardType = KeyboardType.Decimal
+                            )
+                        }
+                    }
+                } else {
+                    // Phone: single-column layout
                     SolennixTextField(
-                        value = viewModel.unitCost,
-                        onValueChange = { viewModel.unitCost = it },
-                        label = "Costo Unitario",
-                        leadingIcon = Icons.Default.AttachMoney,
-                        keyboardType = KeyboardType.Decimal,
-                        modifier = Modifier.weight(1f)
+                        value = viewModel.ingredientName,
+                        onValueChange = { viewModel.ingredientName = it },
+                        label = "Nombre del Item *",
+                        leadingIcon = Icons.Default.Archive
                     )
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // Type selector
+                    Text(
+                        text = "Tipo *",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = SolennixTheme.colors.secondaryText
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                        val types = listOf(
+                            InventoryType.INGREDIENT to "Ingrediente",
+                            InventoryType.EQUIPMENT to "Equipo",
+                            InventoryType.SUPPLY to "Insumo"
+                        )
+                        types.forEachIndexed { index, (type, label) ->
+                            SegmentedButton(
+                                shape = SegmentedButtonDefaults.itemShape(index = index, count = types.size),
+                                onClick = { viewModel.type = type },
+                                selected = viewModel.type == type
+                            ) {
+                                Text(label)
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        SolennixTextField(
+                            value = viewModel.currentStock,
+                            onValueChange = { viewModel.currentStock = it },
+                            label = "Stock Actual *",
+                            keyboardType = KeyboardType.Decimal,
+                            modifier = Modifier.weight(1f)
+                        )
+                        SolennixTextField(
+                            value = viewModel.minimumStock,
+                            onValueChange = { viewModel.minimumStock = it },
+                            label = "Stock Mínimo *",
+                            keyboardType = KeyboardType.Decimal,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        ExposedDropdownMenuBox(
+                            expanded = unitExpanded,
+                            onExpandedChange = { unitExpanded = it },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            OutlinedTextField(
+                                value = viewModel.unit,
+                                onValueChange = { viewModel.unit = it },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .menuAnchor(MenuAnchorType.PrimaryEditable),
+                                label = { Text("Unidad *") },
+                                leadingIcon = { Icon(Icons.Default.Scale, contentDescription = null) },
+                                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = unitExpanded) },
+                                shape = MaterialTheme.shapes.small,
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = SolennixTheme.colors.primary,
+                                    focusedLabelColor = SolennixTheme.colors.primary,
+                                    cursorColor = SolennixTheme.colors.primary
+                                ),
+                                singleLine = true
+                            )
+                            val filteredUnits = commonUnits.filter {
+                                it.contains(viewModel.unit, ignoreCase = true)
+                            }
+                            if (filteredUnits.isNotEmpty()) {
+                                ExposedDropdownMenu(
+                                    expanded = unitExpanded,
+                                    onDismissRequest = { unitExpanded = false }
+                                ) {
+                                    filteredUnits.forEach { unitOption ->
+                                        DropdownMenuItem(
+                                            text = { Text(unitOption) },
+                                            onClick = {
+                                                viewModel.unit = unitOption
+                                                unitExpanded = false
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        SolennixTextField(
+                            value = viewModel.unitCost,
+                            onValueChange = { viewModel.unitCost = it },
+                            label = "Costo Unitario",
+                            leadingIcon = Icons.Default.AttachMoney,
+                            keyboardType = KeyboardType.Decimal,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
                 }
                 Spacer(modifier = Modifier.height(32.dp))
 

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductFormScreen.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductFormScreen.kt
@@ -30,6 +30,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.creapolis.solennix.core.designsystem.component.PremiumButton
 import com.creapolis.solennix.core.designsystem.component.SolennixTextField
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.InventoryItem
 import com.creapolis.solennix.core.model.InventoryType
@@ -185,54 +186,126 @@ fun ProductFormScreen(
                 }
 
                 // Basic info fields
-                SolennixTextField(
-                    value = viewModel.name,
-                    onValueChange = { viewModel.name = it },
-                    label = "Nombre *",
-                    leadingIcon = Icons.Default.ShoppingCart
-                )
+                val isWideScreen = LocalIsWideScreen.current
 
-                SolennixTextField(
-                    value = viewModel.category,
-                    onValueChange = { viewModel.category = it },
-                    label = "Categoría *",
-                    leadingIcon = Icons.Default.Category
-                )
+                if (isWideScreen) {
+                    // Tablet: 2-column layout for related fields
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.name,
+                                onValueChange = { viewModel.name = it },
+                                label = "Nombre *",
+                                leadingIcon = Icons.Default.ShoppingCart
+                            )
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.category,
+                                onValueChange = { viewModel.category = it },
+                                label = "Categoría *",
+                                leadingIcon = Icons.Default.Category
+                            )
+                        }
+                    }
 
-                SolennixTextField(
-                    value = viewModel.basePrice,
-                    onValueChange = { viewModel.basePrice = it },
-                    label = "Precio Base *",
-                    leadingIcon = Icons.Default.AttachMoney,
-                    keyboardType = KeyboardType.Decimal
-                )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Box(modifier = Modifier.weight(1f)) {
+                            SolennixTextField(
+                                value = viewModel.basePrice,
+                                onValueChange = { viewModel.basePrice = it },
+                                label = "Precio Base *",
+                                leadingIcon = Icons.Default.AttachMoney,
+                                keyboardType = KeyboardType.Decimal
+                            )
+                        }
+                        Box(modifier = Modifier.weight(1f)) {
+                            // Active toggle alongside price on tablet
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column {
+                                    Text(
+                                        text = "Producto activo",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = SolennixTheme.colors.primaryText
+                                    )
+                                    Text(
+                                        text = "Visible en cotizaciones",
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = SolennixTheme.colors.secondaryText
+                                    )
+                                }
+                                Switch(
+                                    checked = viewModel.isActive,
+                                    onCheckedChange = { viewModel.isActive = it },
+                                    colors = SwitchDefaults.colors(
+                                        checkedThumbColor = SolennixTheme.colors.primary,
+                                        checkedTrackColor = SolennixTheme.colors.primaryLight
+                                    )
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    // Phone: single-column layout
+                    SolennixTextField(
+                        value = viewModel.name,
+                        onValueChange = { viewModel.name = it },
+                        label = "Nombre *",
+                        leadingIcon = Icons.Default.ShoppingCart
+                    )
 
-                // Active toggle
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column {
-                        Text(
-                            text = "Producto activo",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = SolennixTheme.colors.primaryText
-                        )
-                        Text(
-                            text = "Visible en cotizaciones",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = SolennixTheme.colors.secondaryText
+                    SolennixTextField(
+                        value = viewModel.category,
+                        onValueChange = { viewModel.category = it },
+                        label = "Categoría *",
+                        leadingIcon = Icons.Default.Category
+                    )
+
+                    SolennixTextField(
+                        value = viewModel.basePrice,
+                        onValueChange = { viewModel.basePrice = it },
+                        label = "Precio Base *",
+                        leadingIcon = Icons.Default.AttachMoney,
+                        keyboardType = KeyboardType.Decimal
+                    )
+
+                    // Active toggle
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column {
+                            Text(
+                                text = "Producto activo",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Text(
+                                text = "Visible en cotizaciones",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = SolennixTheme.colors.secondaryText
+                            )
+                        }
+                        Switch(
+                            checked = viewModel.isActive,
+                            onCheckedChange = { viewModel.isActive = it },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = SolennixTheme.colors.primary,
+                                checkedTrackColor = SolennixTheme.colors.primaryLight
+                            )
                         )
                     }
-                    Switch(
-                        checked = viewModel.isActive,
-                        onCheckedChange = { viewModel.isActive = it },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = SolennixTheme.colors.primary,
-                            checkedTrackColor = SolennixTheme.colors.primaryLight
-                        )
-                    )
                 }
 
                 // Recipe sections

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/SettingsScreen.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.component.Avatar
+import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.ThemeConfig
 import com.creapolis.solennix.feature.settings.viewmodel.SettingsViewModel
@@ -97,36 +98,63 @@ fun SettingsScreen(
                 }
             }
 
-            SettingsSection(title = "Apariencia") {
-                val themeLabel = when (themeConfig) {
-                    ThemeConfig.SYSTEM_DEFAULT -> "Predeterminado del Sistema"
-                    ThemeConfig.LIGHT -> "Claro"
-                    ThemeConfig.DARK -> "Oscuro"
+            val isWide = LocalIsWideScreen.current
+            if (isWide) {
+                // Tablet: 2-column settings sections
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        SettingsSection(title = "Apariencia") {
+                            val themeLabel = when (themeConfig) {
+                                ThemeConfig.SYSTEM_DEFAULT -> "Predeterminado del Sistema"
+                                ThemeConfig.LIGHT -> "Claro"
+                                ThemeConfig.DARK -> "Oscuro"
+                            }
+                            SettingsItemValue(icon = Icons.Default.Palette, label = "Tema", value = themeLabel, onClick = { showThemeDialog = true })
+                        }
+                        SettingsSection(title = "Cuenta") {
+                            SettingsItem(icon = Icons.Default.Person, label = "Editar Perfil", onClick = onEditProfile)
+                            SettingsItem(icon = Icons.Default.Lock, label = "Cambiar Contraseña", onClick = onChangePassword)
+                            SettingsItem(icon = Icons.Default.Business, label = "Ajustes del Negocio", onClick = onBusinessSettings)
+                            SettingsItem(icon = Icons.Default.Receipt, label = "Valores del Contrato", onClick = onContractDefaults)
+                        }
+                    }
+                    Column(modifier = Modifier.weight(1f)) {
+                        SettingsSection(title = "Suscripción") {
+                            SettingsItem(icon = Icons.Default.Star, label = "Gestionar Plan", onClick = onPricing)
+                        }
+                        SettingsSection(title = "Información") {
+                            SettingsItem(icon = Icons.Default.Info, label = "Acerca de", onClick = onAbout)
+                            SettingsItem(icon = Icons.Default.Shield, label = "Política de Privacidad", onClick = onPrivacy)
+                            SettingsItem(icon = Icons.Default.Description, label = "Términos y Condiciones", onClick = onTerms)
+                        }
+                    }
                 }
-
-                SettingsItemValue(
-                    icon = Icons.Default.Palette,
-                    label = "Tema",
-                    value = themeLabel,
-                    onClick = { showThemeDialog = true }
-                )
-            }
-
-            SettingsSection(title = "Cuenta") {
-                SettingsItem(icon = Icons.Default.Person, label = "Editar Perfil", onClick = onEditProfile)
-                SettingsItem(icon = Icons.Default.Lock, label = "Cambiar Contraseña", onClick = onChangePassword)
-                SettingsItem(icon = Icons.Default.Business, label = "Ajustes del Negocio", onClick = onBusinessSettings)
-                SettingsItem(icon = Icons.Default.Receipt, label = "Valores del Contrato", onClick = onContractDefaults)
-            }
-
-            SettingsSection(title = "Suscripción") {
-                SettingsItem(icon = Icons.Default.Star, label = "Gestionar Plan", onClick = onPricing)
-            }
-
-            SettingsSection(title = "Información") {
-                SettingsItem(icon = Icons.Default.Info, label = "Acerca de", onClick = onAbout)
-                SettingsItem(icon = Icons.Default.Shield, label = "Política de Privacidad", onClick = onPrivacy)
-                SettingsItem(icon = Icons.Default.Description, label = "Términos y Condiciones", onClick = onTerms)
+            } else {
+                SettingsSection(title = "Apariencia") {
+                    val themeLabel = when (themeConfig) {
+                        ThemeConfig.SYSTEM_DEFAULT -> "Predeterminado del Sistema"
+                        ThemeConfig.LIGHT -> "Claro"
+                        ThemeConfig.DARK -> "Oscuro"
+                    }
+                    SettingsItemValue(icon = Icons.Default.Palette, label = "Tema", value = themeLabel, onClick = { showThemeDialog = true })
+                }
+                SettingsSection(title = "Cuenta") {
+                    SettingsItem(icon = Icons.Default.Person, label = "Editar Perfil", onClick = onEditProfile)
+                    SettingsItem(icon = Icons.Default.Lock, label = "Cambiar Contraseña", onClick = onChangePassword)
+                    SettingsItem(icon = Icons.Default.Business, label = "Ajustes del Negocio", onClick = onBusinessSettings)
+                    SettingsItem(icon = Icons.Default.Receipt, label = "Valores del Contrato", onClick = onContractDefaults)
+                }
+                SettingsSection(title = "Suscripción") {
+                    SettingsItem(icon = Icons.Default.Star, label = "Gestionar Plan", onClick = onPricing)
+                }
+                SettingsSection(title = "Información") {
+                    SettingsItem(icon = Icons.Default.Info, label = "Acerca de", onClick = onAbout)
+                    SettingsItem(icon = Icons.Default.Shield, label = "Política de Privacidad", onClick = onPrivacy)
+                    SettingsItem(icon = Icons.Default.Description, label = "Términos y Condiciones", onClick = onTerms)
+                }
             }
 
             Spacer(modifier = Modifier.height(32.dp))


### PR DESCRIPTION
## Summary

- **Full tablet navigation**: Replaced all "Phase 6" placeholders in `AdaptiveNavigationRailLayout` with a complete `NavHost` containing all 27 routes (matching phone layout parity)
- **9 sidebar sections**: Added Events and Quick Quote to the tablet sidebar so all features accessible via the phone's "More" menu are directly reachable
- **Responsive auth screens**: Login, Register, Forgot/Reset Password now use a split layout on tablets (premium branding panel left 40% + form right), matching the web app design
- **Web-like multi-column layouts** across all major screens using `LocalIsWideScreen` CompositionLocal:
  - Dashboard: 4-column KPI grid + side-by-side sections
  - ClientDetail: contact info + stats/notes side-by-side
  - ClientForm, ProductForm, InventoryForm: 2-column form fields
  - Settings: 2-column settings sections
- **Deep link support** on tablet layout
- **FAB support** with expandable calendar FAB on tablet

### Files changed (18 files, +1608 / -591)

| Area | Files |
|------|-------|
| Navigation | `AdaptiveNavigationRailLayout.kt`, `SidebarSection.kt`, `AuthNavHost.kt`, `MainNavHost.kt`, `CompactBottomNavLayout.kt` |
| Design System | `WindowSize.kt` (new), `KPICard.kt` |
| Auth | `AuthBrandingPanel.kt` (new), `LoginScreen.kt`, `RegisterScreen.kt`, `ForgotPasswordScreen.kt`, `ResetPasswordScreen.kt` |
| Screens | `DashboardScreen.kt`, `ClientDetailScreen.kt`, `ClientFormScreen.kt`, `ProductFormScreen.kt`, `InventoryFormScreen.kt`, `SettingsScreen.kt` |

## Test plan

- [ ] Test on tablet emulator (10"+, width > 600dp): all 9 sidebar sections load real screens
- [ ] Test navigation within sections (list → detail → edit → back)
- [ ] Test cross-section navigation (e.g., Search → client detail)
- [ ] Test FAB creates new events; calendar expandable FAB works
- [ ] Test login/register screens show split layout on tablet
- [ ] Test login/register on phone still shows single-column layout
- [ ] Test Dashboard KPIs display in 4-column grid on tablet
- [ ] Test form screens show 2-column fields on tablet
- [ ] Test Settings shows 2-column sections on tablet
- [ ] Test on phone emulator to verify no regression

https://claude.ai/code/session_01HEnKhSZ4LCtEoHLgjfEsKi