### PR TITLE
fix(android): filter event checklist to show only event-specific items

### DIFF
--- a/PRD/11_CURRENT_STATUS.md
+++ b/PRD/11_CURRENT_STATUS.md
@@ -770,3 +770,4 @@ Refactors planificados para lograr paridad total entre las 6 plataformas (iPhone
 | ~~Calendario: BlockedDatesSheet iOS~~ | ✅ | Implementado con CRUD completo | 0h | ✅ |
 | ~~Web: Fotos de evento~~ | ✅ | Tab de fotos con galeria, upload, lightbox y eliminacion | 0h | ✅ |
 | ~~Web: Checklist interactivo~~ | ✅ | Tab de checklist con secciones, checkboxes y progreso | 0h | ✅ |
+| ~~Android: Checklist mostraba todo el inventario~~ | ✅ | Corregido para mostrar solo items del evento (equipo, insumos, ingredientes). Layout tablet ajustado | 0h | ✅ |

--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/EventRepository.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/EventRepository.kt
@@ -44,6 +44,8 @@ interface EventRepository {
     // Direct API access (bypasses Room cache)
     suspend fun getEventsFromApi(): List<Event>
     suspend fun getEventProductsFromApi(eventId: String): List<EventProduct>
+    suspend fun getEventEquipmentFromApi(eventId: String): List<EventEquipment>
+    suspend fun getEventSuppliesFromApi(eventId: String): List<EventSupply>
 
     // Equipment and Supplies
     suspend fun getEquipmentConflicts(
@@ -175,6 +177,20 @@ class OfflineFirstEventRepository @Inject constructor(
     override suspend fun getEventProductsFromApi(eventId: String): List<EventProduct> =
         try {
             apiService.get(Endpoints.eventProducts(eventId))
+        } catch (_: Exception) {
+            emptyList()
+        }
+
+    override suspend fun getEventEquipmentFromApi(eventId: String): List<EventEquipment> =
+        try {
+            apiService.get(Endpoints.eventEquipment(eventId))
+        } catch (_: Exception) {
+            emptyList()
+        }
+
+    override suspend fun getEventSuppliesFromApi(eventId: String): List<EventSupply> =
+        try {
+            apiService.get(Endpoints.eventSupplies(eventId))
         } catch (_: Exception) {
             emptyList()
         }

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventChecklistScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventChecklistScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.component.EmptyState
 import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
-import com.creapolis.solennix.core.designsystem.component.adaptive.AdaptiveCenteredContent
 import com.creapolis.solennix.core.designsystem.theme.LocalIsWideScreen
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.extensions.asMXN
@@ -58,12 +57,9 @@ fun EventChecklistScreen(
             )
         }
     ) { padding ->
-        AdaptiveCenteredContent(
-            modifier = Modifier.padding(padding),
-            maxWidth = 700.dp
-        ) {
         Column(
             modifier = Modifier
+                .padding(padding)
                 .fillMaxSize()
         ) {
             if (uiState.isLoading) {
@@ -87,28 +83,28 @@ fun EventChecklistScreen(
                 ChecklistProgressHeader(uiState = uiState)
 
                 if (isWideScreen) {
-                    // Tablet: 2-column layout with sections side by side
+                    // Tablet: 2-column layout matching iOS
                     Row(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(16.dp),
                         horizontalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        // Left column: Equipment + Stock
+                        // Left column: Equipment
                         LazyColumn(
                             modifier = Modifier.weight(1f),
                             verticalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
                             checklistEquipmentSection(uiState, viewModel)
-                            checklistStockSection(uiState, viewModel)
                             item { Spacer(modifier = Modifier.height(32.dp)) }
                         }
 
-                        // Right column: Purchase
+                        // Right column: Stock + Purchase
                         LazyColumn(
                             modifier = Modifier.weight(1f),
                             verticalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
+                            checklistStockSection(uiState, viewModel)
                             checklistPurchaseSection(uiState, viewModel)
                             item { Spacer(modifier = Modifier.height(32.dp)) }
                         }
@@ -127,7 +123,6 @@ fun EventChecklistScreen(
                     }
                 }
             }
-        }
         }
     }
 

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventChecklistViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventChecklistViewModel.kt
@@ -6,10 +6,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.creapolis.solennix.core.data.repository.EventRepository
-import com.creapolis.solennix.core.data.repository.InventoryRepository
-import com.creapolis.solennix.core.model.InventoryType
+import com.creapolis.solennix.core.data.repository.ProductRepository
+import com.creapolis.solennix.core.model.SupplySource
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -55,7 +56,7 @@ data class EventChecklistUiState(
 class EventChecklistViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val eventRepository: EventRepository,
-    private val inventoryRepository: InventoryRepository,
+    private val productRepository: ProductRepository,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -74,49 +75,92 @@ class EventChecklistViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             try {
-                // Get event details
                 val event = eventRepository.getEvent(eventId)
                 if (event == null) {
                     _uiState.update { it.copy(isLoading = false, error = "Evento no encontrado") }
                     return@launch
                 }
 
-                // Collect all checklist items
+                // Fetch event-specific data concurrently
+                val productsDeferred = async { eventRepository.getEventProductsFromApi(eventId) }
+                val equipmentDeferred = async { eventRepository.getEventEquipmentFromApi(eventId) }
+                val suppliesDeferred = async { eventRepository.getEventSuppliesFromApi(eventId) }
+
+                val products = productsDeferred.await()
+                val equipment = equipmentDeferred.await()
+                val supplies = suppliesDeferred.await()
+
                 val checklistItems = mutableListOf<ChecklistItem>()
 
-                // Get inventory items and categorize them
-                inventoryRepository.getInventoryItems().first().forEach { item ->
-                    when (item.type) {
-                        InventoryType.EQUIPMENT -> {
-                            checklistItems.add(
-                                ChecklistItem(
-                                    id = "eq_${item.id}",
-                                    name = item.ingredientName,
-                                    quantity = 1.0,
-                                    unit = item.unit,
-                                    section = ChecklistSection.EQUIPMENT
-                                )
-                            )
-                        }
-                        InventoryType.SUPPLY, InventoryType.INGREDIENT -> {
-                            // Determine if from stock or purchase based on current stock
-                            val section = if (item.currentStock >= item.minimumStock) {
-                                ChecklistSection.STOCK
+                // 1. Equipment items from event assignments
+                for (item in equipment) {
+                    checklistItems.add(
+                        ChecklistItem(
+                            id = "eq_${item.id}",
+                            name = item.equipmentName ?: "Equipo",
+                            quantity = item.quantity.toDouble(),
+                            unit = item.unit ?: "",
+                            section = ChecklistSection.EQUIPMENT
+                        )
+                    )
+                }
+
+                // 2. Product ingredients with bringToEvent=true, aggregated by inventoryId
+                data class IngredientAgg(var name: String, var quantity: Double, var unit: String)
+                val ingredientMap = mutableMapOf<String, IngredientAgg>()
+
+                for (product in products) {
+                    try {
+                        val ingredients = productRepository.getProductIngredients(product.productId)
+                        for (ingredient in ingredients) {
+                            if (ingredient.bringToEvent != true) continue
+                            val key = ingredient.inventoryId
+                            val totalQty = ingredient.quantityRequired * product.quantity
+                            val existing = ingredientMap[key]
+                            if (existing != null) {
+                                existing.quantity += totalQty
                             } else {
-                                ChecklistSection.PURCHASE
-                            }
-                            checklistItems.add(
-                                ChecklistItem(
-                                    id = "sup_${item.id}",
-                                    name = item.ingredientName,
-                                    quantity = item.minimumStock,
-                                    unit = item.unit,
-                                    section = section,
-                                    unitCost = item.unitCost ?: 0.0
+                                ingredientMap[key] = IngredientAgg(
+                                    name = ingredient.ingredientName ?: "Ingrediente",
+                                    quantity = totalQty,
+                                    unit = ingredient.unit ?: ""
                                 )
-                            )
+                            }
                         }
+                    } catch (_: Exception) {
+                        // Skip products whose ingredients can't be fetched
                     }
+                }
+
+                for ((inventoryId, info) in ingredientMap) {
+                    checklistItems.add(
+                        ChecklistItem(
+                            id = "ing_$inventoryId",
+                            name = info.name,
+                            quantity = info.quantity,
+                            unit = info.unit,
+                            section = ChecklistSection.STOCK
+                        )
+                    )
+                }
+
+                // 3. Supply items — section determined by source field
+                for (supply in supplies) {
+                    val section = if (supply.source == SupplySource.STOCK) {
+                        ChecklistSection.STOCK
+                    } else {
+                        ChecklistSection.PURCHASE
+                    }
+                    checklistItems.add(
+                        ChecklistItem(
+                            id = "sup_${supply.id}",
+                            name = supply.supplyName ?: "Insumo",
+                            quantity = supply.quantity,
+                            unit = supply.unit ?: "",
+                            section = section,
+                            unitCost = supply.unitCost
+                        )
+                    )
                 }
 
                 _uiState.update {


### PR DESCRIPTION
The checklist was loading ALL inventory items globally instead of only
items assigned to the specific event. Now fetches event equipment,
supplies, and product ingredients from dedicated API endpoints (matching
iOS/Web behavior). Also fixes tablet layout by removing the 700dp
max-width constraint and rearranging columns (Equipment left,
Stock+Purchase right) to match iOS.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01WUPvieyQRWAGSFNnPcP9dU