### PR TITLE
fix(backend): set auth cookie on Google Sign-In

### DIFF
--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -732,6 +732,7 @@ func (h *AuthHandler) GoogleSignIn(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.storeRefreshToken(r.Context(), tokens.RefreshToken, user.ID)
+		setAuthCookie(w, r, tokens.AccessToken)
 		slog.Info("auth.event", "action", "google_login", "user_id", user.ID, "email", email, "ip", clientIP(r))
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"user":   user,
@@ -753,6 +754,7 @@ func (h *AuthHandler) GoogleSignIn(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			h.storeRefreshToken(r.Context(), tokens.RefreshToken, user.ID)
+			setAuthCookie(w, r, tokens.AccessToken)
 			slog.Info("auth.event", "action", "google_login", "user_id", user.ID, "email", email, "ip", clientIP(r))
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"user":   user,
@@ -773,6 +775,7 @@ func (h *AuthHandler) GoogleSignIn(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.storeRefreshToken(r.Context(), tokens.RefreshToken, user.ID)
+		setAuthCookie(w, r, tokens.AccessToken)
 		slog.Info("auth.event", "action", "google_link_and_login", "user_id", user.ID, "email", email, "ip", clientIP(r))
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"user":   user,
@@ -807,6 +810,7 @@ func (h *AuthHandler) GoogleSignIn(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 				h.storeRefreshToken(r.Context(), tokens.RefreshToken, existingUser.ID)
+				setAuthCookie(w, r, tokens.AccessToken)
 				writeJSON(w, http.StatusOK, map[string]interface{}{
 					"user":   existingUser,
 					"tokens": tokens,
@@ -826,6 +830,7 @@ func (h *AuthHandler) GoogleSignIn(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			h.storeRefreshToken(r.Context(), tokens.RefreshToken, existingUser.ID)
+			setAuthCookie(w, r, tokens.AccessToken)
 			slog.Info("auth.event", "action", "google_link_and_login_race", "user_id", existingUser.ID, "email", email, "ip", clientIP(r))
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"user":   existingUser,
@@ -846,6 +851,7 @@ func (h *AuthHandler) GoogleSignIn(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.storeRefreshToken(r.Context(), tokens.RefreshToken, newUser.ID)
+	setAuthCookie(w, r, tokens.AccessToken)
 	slog.Info("auth.event", "action", "google_register", "user_id", newUser.ID, "email", newUser.Email, "ip", clientIP(r))
 
 	writeJSON(w, http.StatusCreated, map[string]interface{}{


### PR DESCRIPTION
## Summary
- `GoogleSignIn` handler never called `setAuthCookie()` — tokens were only in the JSON body, so the browser had no `auth_token` cookie for `GET /auth/me`
- Added `setAuthCookie(w, r, tokens.AccessToken)` to all 6 success paths, matching Login/Register/Refresh/Apple handlers
- Mobile apps unaffected (they use `Authorization: Bearer` header, not cookies)

## Root Cause
Every other auth handler (Login, Register, Refresh, Apple Sign-In) calls `setAuthCookie()` before `writeJSON()`. The Google handler was the only one that skipped it — likely an oversight when it was originally implemented.

## Test plan
- [ ] Login with Google on solennix.com → session persists, `/auth/me` returns 200
- [ ] Login with email/password → still works (regression check)
- [ ] Login from iOS/Android app with Google → still works via Bearer token
- [ ] Verify `Set-Cookie: auth_token=...` header present in Google auth response

🤖 Generated with [Claude Code](https://claude.com/claude-code)