### PR TITLE
feat(all): add shareable event form links feature

### DIFF
--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
@@ -79,6 +79,7 @@ import com.creapolis.solennix.feature.settings.ui.EditProfileScreen
 import com.creapolis.solennix.feature.settings.ui.PrivacyScreen
 import com.creapolis.solennix.feature.settings.ui.SettingsScreen
 import com.creapolis.solennix.feature.settings.ui.SubscriptionScreen
+import com.creapolis.solennix.feature.settings.ui.EventFormLinksScreen
 import com.creapolis.solennix.feature.settings.ui.TermsScreen
 
 @Composable
@@ -276,6 +277,7 @@ fun CompactBottomNavLayout(initialDeepLinkRoute: String? = null) {
                     onBusinessSettings = { navController.navigate("business_settings") },
                     onContractDefaults = { navController.navigate("contract_defaults") },
                     onPricing = { navController.navigate("pricing") },
+                    onEventFormLinks = { navController.navigate("event_form_links") },
                     onAbout = { navController.navigate("about") },
                     onPrivacy = { navController.navigate("privacy") },
                     onTerms = { navController.navigate("terms") },
@@ -301,6 +303,12 @@ fun CompactBottomNavLayout(initialDeepLinkRoute: String? = null) {
                 // instructions. The legacy PricingScreen (static marketing copy with a
                 // broken upgrade button) was removed in Bloque C.
                 SubscriptionScreen(
+                    viewModel = hiltViewModel(),
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable("event_form_links") {
+                EventFormLinksScreen(
                     viewModel = hiltViewModel(),
                     onNavigateBack = { navController.popBackStack() }
                 )

--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/Route.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/Route.kt
@@ -23,4 +23,5 @@ sealed class Route {
     @Serializable data object About : Route()
     @Serializable data object Privacy : Route()
     @Serializable data object Terms : Route()
+    @Serializable data object EventFormLinks : Route()
 }

--- a/android/core/model/src/main/java/com/creapolis/solennix/core/model/EventFormLink.kt
+++ b/android/core/model/src/main/java/com/creapolis/solennix/core/model/EventFormLink.kt
@@ -1,0 +1,26 @@
+package com.creapolis.solennix.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EventFormLink(
+    val id: String = "",
+    @SerialName("user_id") val userId: String = "",
+    val token: String = "",
+    val label: String? = null,
+    val status: String = "active",
+    @SerialName("submitted_event_id") val submittedEventId: String? = null,
+    @SerialName("submitted_client_id") val submittedClientId: String? = null,
+    val url: String = "",
+    @SerialName("expires_at") val expiresAt: String = "",
+    @SerialName("used_at") val usedAt: String? = null,
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("updated_at") val updatedAt: String = ""
+)
+
+@Serializable
+data class GenerateEventFormLinkRequest(
+    val label: String? = null,
+    @SerialName("ttl_days") val ttlDays: Int? = null
+)

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
@@ -62,6 +62,10 @@ object Endpoints {
     // Subscriptions
     const val SUBSCRIPTION_STATUS = "subscriptions/status"
 
+    // Event Form Links
+    const val EVENT_FORM_LINKS = "event-forms"
+    fun eventFormLink(id: String) = "event-forms/$id"
+
     // Devices
     const val REGISTER_DEVICE = "devices/register"
     const val UNREGISTER_DEVICE = "devices/unregister"

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/EventFormLinksScreen.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/EventFormLinksScreen.kt
@@ -1,0 +1,469 @@
+package com.creapolis.solennix.feature.settings.ui
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.creapolis.solennix.core.designsystem.component.EmptyState
+import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
+import com.creapolis.solennix.core.designsystem.component.adaptive.AdaptiveCenteredContent
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.EventFormLink
+import com.creapolis.solennix.core.model.extensions.parseFlexibleDate
+import com.creapolis.solennix.feature.settings.viewmodel.EventFormLinksUiState
+import com.creapolis.solennix.feature.settings.viewmodel.EventFormLinksViewModel
+import java.time.format.DateTimeFormatter
+import java.util.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EventFormLinksScreen(
+    viewModel: EventFormLinksViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarMessage by viewModel.snackbarMessage.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    var showGenerateDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(snackbarMessage) {
+        snackbarMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearSnackbar()
+        }
+    }
+
+    if (showGenerateDialog) {
+        GenerateLinkDialog(
+            isGenerating = (uiState as? EventFormLinksUiState.Success)?.isGenerating == true,
+            onGenerate = { label, ttlDays ->
+                viewModel.generateLink(label, ttlDays)
+                showGenerateDialog = false
+            },
+            onDismiss = { showGenerateDialog = false }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            SolennixTopAppBar(
+                title = { Text("Enlaces de Formulario") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Regresar")
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            val isLoading = uiState is EventFormLinksUiState.Loading
+            val isGenerating = (uiState as? EventFormLinksUiState.Success)?.isGenerating == true
+            ExtendedFloatingActionButton(
+                onClick = { showGenerateDialog = true },
+                icon = { Icon(Icons.Default.Add, contentDescription = null) },
+                text = { Text("Nuevo enlace") },
+                containerColor = SolennixTheme.colors.primary,
+                contentColor = Color.White,
+                expanded = !isLoading && !isGenerating
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        AdaptiveCenteredContent(maxWidth = 700.dp) {
+            when (val state = uiState) {
+                is EventFormLinksUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = SolennixTheme.colors.primary)
+                    }
+                }
+
+                is EventFormLinksUiState.Error -> {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(padding)
+                            .padding(32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            Icons.Default.Error,
+                            contentDescription = null,
+                            modifier = Modifier.size(64.dp),
+                            tint = SolennixTheme.colors.error
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = SolennixTheme.colors.primaryText
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        OutlinedButton(onClick = { viewModel.loadLinks() }) {
+                            Text("Reintentar")
+                        }
+                    }
+                }
+
+                is EventFormLinksUiState.Success -> {
+                    if (state.links.isEmpty()) {
+                        EmptyState(
+                            icon = Icons.Default.Link,
+                            title = "Sin enlaces",
+                            message = "Crea un enlace para que tus clientes soliciten eventos",
+                            modifier = Modifier.padding(padding)
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(padding),
+                            contentPadding = PaddingValues(
+                                start = 16.dp,
+                                end = 16.dp,
+                                top = 8.dp,
+                                bottom = 88.dp
+                            ),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            items(state.links, key = { it.id }) { link ->
+                                EventFormLinkCard(
+                                    link = link,
+                                    isDeleting = state.deletingId == link.id,
+                                    onShare = { shareLink(context, link) },
+                                    onCopy = { copyLink(context, link) },
+                                    onDelete = { viewModel.deleteLink(link.id) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EventFormLinkCard(
+    link: EventFormLink,
+    isDeleting: Boolean,
+    onShare: () -> Unit,
+    onCopy: () -> Unit,
+    onDelete: () -> Unit
+) {
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Eliminar enlace") },
+            text = { Text("¿Estás seguro de que querés eliminar este enlace? Esta acción no se puede deshacer.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteConfirm = false
+                        onDelete()
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = SolennixTheme.colors.error)
+                ) {
+                    Text("Eliminar")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) {
+                    Text("Cancelar")
+                }
+            }
+        )
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Header: label + status
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = link.label ?: "Sin etiqueta",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = SolennixTheme.colors.primaryText,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                FormLinkStatusChip(status = link.status)
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // URL (truncated)
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.Link,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = SolennixTheme.colors.secondaryText
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = link.url,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // Dates
+            val dateFormatter = remember {
+                DateTimeFormatter.ofPattern("dd MMM yyyy", Locale("es", "MX"))
+            }
+            val createdDate = remember(link.createdAt) {
+                parseFlexibleDate(link.createdAt)?.format(dateFormatter) ?: link.createdAt
+            }
+            val expiresDate = remember(link.expiresAt) {
+                parseFlexibleDate(link.expiresAt)?.format(dateFormatter) ?: link.expiresAt
+            }
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.CalendarToday,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = SolennixTheme.colors.secondaryText
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Creado: $createdDate",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText
+                )
+            }
+
+            Spacer(modifier = Modifier.height(2.dp))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Default.Schedule,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = SolennixTheme.colors.secondaryText
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = "Expira: $expiresDate",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.secondaryText
+                )
+            }
+
+            // Used at (if submitted)
+            link.usedAt?.let { usedAt ->
+                Spacer(modifier = Modifier.height(2.dp))
+                val usedDate = remember(usedAt) {
+                    parseFlexibleDate(usedAt)?.format(dateFormatter) ?: usedAt
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.CheckCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = SolennixTheme.colors.success
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = "Usado: $usedDate",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = SolennixTheme.colors.success
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            HorizontalDivider(color = SolennixTheme.colors.divider)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Actions
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (isDeleting) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                        color = SolennixTheme.colors.error
+                    )
+                } else {
+                    // Share
+                    IconButton(onClick = onShare) {
+                        Icon(
+                            Icons.Default.Share,
+                            contentDescription = "Compartir enlace",
+                            tint = SolennixTheme.colors.primary
+                        )
+                    }
+                    // Copy
+                    IconButton(onClick = onCopy) {
+                        Icon(
+                            Icons.Default.ContentCopy,
+                            contentDescription = "Copiar enlace",
+                            tint = SolennixTheme.colors.secondaryText
+                        )
+                    }
+                    // Delete
+                    IconButton(onClick = { showDeleteConfirm = true }) {
+                        Icon(
+                            Icons.Default.Delete,
+                            contentDescription = "Eliminar enlace",
+                            tint = SolennixTheme.colors.error
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FormLinkStatusChip(status: String) {
+    val (label, color) = when (status.lowercase()) {
+        "active" -> "Activo" to SolennixTheme.colors.success
+        "used" -> "Usado" to SolennixTheme.colors.primary
+        "expired" -> "Expirado" to SolennixTheme.colors.error
+        "revoked" -> "Revocado" to SolennixTheme.colors.secondaryText
+        else -> status.replaceFirstChar { it.uppercase() } to SolennixTheme.colors.secondaryText
+    }
+
+    Surface(
+        color = color.copy(alpha = 0.18f),
+        shape = RoundedCornerShape(6.dp)
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            color = color,
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold)
+        )
+    }
+}
+
+@Composable
+private fun GenerateLinkDialog(
+    isGenerating: Boolean,
+    onGenerate: (label: String?, ttlDays: Int?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var label by remember { mutableStateOf("") }
+    var ttlDaysText by remember { mutableStateOf("7") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Nuevo enlace de formulario") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = label,
+                    onValueChange = { label = it },
+                    label = { Text("Etiqueta (opcional)") },
+                    placeholder = { Text("Ej: Boda García") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = SolennixTheme.colors.primary,
+                        unfocusedBorderColor = SolennixTheme.colors.divider
+                    )
+                )
+                OutlinedTextField(
+                    value = ttlDaysText,
+                    onValueChange = { ttlDaysText = it.filter { c -> c.isDigit() } },
+                    label = { Text("Días de vigencia") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = SolennixTheme.colors.primary,
+                        unfocusedBorderColor = SolennixTheme.colors.divider
+                    )
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    val ttl = ttlDaysText.toIntOrNull()
+                    onGenerate(label.takeIf { it.isNotBlank() }, ttl)
+                },
+                enabled = !isGenerating
+            ) {
+                if (isGenerating) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                        color = SolennixTheme.colors.primary
+                    )
+                } else {
+                    Text("Generar", color = SolennixTheme.colors.primary)
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancelar")
+            }
+        }
+    )
+}
+
+private fun shareLink(context: Context, link: EventFormLink) {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_TEXT, link.url)
+        putExtra(
+            Intent.EXTRA_SUBJECT,
+            "Formulario de evento${link.label?.let { " - $it" } ?: ""}"
+        )
+    }
+    context.startActivity(Intent.createChooser(intent, "Compartir enlace"))
+}
+
+private fun copyLink(context: Context, link: EventFormLink) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("Enlace de formulario", link.url)
+    clipboard.setPrimaryClip(clip)
+}

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/SettingsScreen.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/ui/SettingsScreen.kt
@@ -37,6 +37,7 @@ fun SettingsScreen(
     onBusinessSettings: () -> Unit,
     onContractDefaults: () -> Unit,
     onPricing: () -> Unit,
+    onEventFormLinks: () -> Unit = {},
     onAbout: () -> Unit,
     onPrivacy: () -> Unit,
     onTerms: () -> Unit,
@@ -129,6 +130,7 @@ fun SettingsScreen(
                             SettingsItem(icon = Icons.Default.Lock, label = "Cambiar Contraseña", onClick = onChangePassword)
                             SettingsItem(icon = Icons.Default.Business, label = "Ajustes del Negocio", onClick = onBusinessSettings)
                             SettingsItem(icon = Icons.Default.Receipt, label = "Valores del Contrato", onClick = onContractDefaults)
+                            SettingsItem(icon = Icons.Default.Link, label = "Enlaces de Formulario", onClick = onEventFormLinks)
                             LogoutItem(onClick = { viewModel.logout() })
                         }
                     }
@@ -157,6 +159,7 @@ fun SettingsScreen(
                     SettingsItem(icon = Icons.Default.Lock, label = "Cambiar Contraseña", onClick = onChangePassword)
                     SettingsItem(icon = Icons.Default.Business, label = "Ajustes del Negocio", onClick = onBusinessSettings)
                     SettingsItem(icon = Icons.Default.Receipt, label = "Valores del Contrato", onClick = onContractDefaults)
+                    SettingsItem(icon = Icons.Default.Link, label = "Enlaces de Formulario", onClick = onEventFormLinks)
                     LogoutItem(onClick = { viewModel.logout() })
                 }
                 SettingsSection(title = "Suscripción") {

--- a/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/viewmodel/EventFormLinksViewModel.kt
+++ b/android/feature/settings/src/main/java/com/creapolis/solennix/feature/settings/viewmodel/EventFormLinksViewModel.kt
@@ -1,0 +1,107 @@
+package com.creapolis.solennix.feature.settings.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.model.EventFormLink
+import com.creapolis.solennix.core.model.GenerateEventFormLinkRequest
+import com.creapolis.solennix.core.network.ApiService
+import com.creapolis.solennix.core.network.Endpoints
+import com.creapolis.solennix.core.network.get
+import com.creapolis.solennix.core.network.post
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed interface EventFormLinksUiState {
+    data object Loading : EventFormLinksUiState
+    data class Success(
+        val links: List<EventFormLink>,
+        val isGenerating: Boolean = false,
+        val deletingId: String? = null
+    ) : EventFormLinksUiState
+    data class Error(val message: String) : EventFormLinksUiState
+}
+
+@HiltViewModel
+class EventFormLinksViewModel @Inject constructor(
+    private val apiService: ApiService
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<EventFormLinksUiState>(EventFormLinksUiState.Loading)
+    val uiState: StateFlow<EventFormLinksUiState> = _uiState.asStateFlow()
+
+    private val _snackbarMessage = MutableStateFlow<String?>(null)
+    val snackbarMessage: StateFlow<String?> = _snackbarMessage.asStateFlow()
+
+    init {
+        loadLinks()
+    }
+
+    fun loadLinks() {
+        viewModelScope.launch {
+            _uiState.value = EventFormLinksUiState.Loading
+            try {
+                val links: List<EventFormLink> = apiService.get(Endpoints.EVENT_FORM_LINKS)
+                _uiState.value = EventFormLinksUiState.Success(links = links)
+            } catch (e: Exception) {
+                _uiState.value = EventFormLinksUiState.Error(
+                    message = e.message ?: "Error al cargar los enlaces"
+                )
+            }
+        }
+    }
+
+    fun generateLink(label: String?, ttlDays: Int?) {
+        viewModelScope.launch {
+            val current = _uiState.value
+            if (current is EventFormLinksUiState.Success) {
+                _uiState.value = current.copy(isGenerating = true)
+            }
+            try {
+                val request = GenerateEventFormLinkRequest(
+                    label = label?.takeIf { it.isNotBlank() },
+                    ttlDays = ttlDays
+                )
+                val newLink: EventFormLink = apiService.post(Endpoints.EVENT_FORM_LINKS, request)
+                val updated = (_uiState.value as? EventFormLinksUiState.Success)
+                    ?.let { it.copy(links = listOf(newLink) + it.links, isGenerating = false) }
+                    ?: EventFormLinksUiState.Success(links = listOf(newLink))
+                _uiState.value = updated
+                _snackbarMessage.value = "Enlace generado"
+            } catch (e: Exception) {
+                if (_uiState.value is EventFormLinksUiState.Success) {
+                    _uiState.update { state ->
+                        (state as? EventFormLinksUiState.Success)?.copy(isGenerating = false) ?: state
+                    }
+                }
+                _snackbarMessage.value = e.message ?: "Error al generar enlace"
+            }
+        }
+    }
+
+    fun deleteLink(id: String) {
+        viewModelScope.launch {
+            val current = _uiState.value as? EventFormLinksUiState.Success ?: return@launch
+            _uiState.value = current.copy(deletingId = id)
+            try {
+                apiService.delete(Endpoints.eventFormLink(id))
+                _uiState.value = current.copy(
+                    links = current.links.filter { it.id != id },
+                    deletingId = null
+                )
+                _snackbarMessage.value = "Enlace eliminado"
+            } catch (e: Exception) {
+                _uiState.value = current.copy(deletingId = null)
+                _snackbarMessage.value = e.message ?: "Error al eliminar enlace"
+            }
+        }
+    }
+
+    fun clearSnackbar() {
+        _snackbarMessage.value = null
+    }
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -82,6 +82,7 @@ func main() {
 	revokedTokenRepo := repository.NewRevokedTokenRepo(pool)
 	refreshTokenRepo := repository.NewRefreshTokenRepo(pool)
 	liveActivityRepo := repository.NewLiveActivityTokenRepo(pool)
+	eventFormLinkRepo := repository.NewEventFormLinkRepo(pool)
 
 	// Set persistent token blacklist (replaces in-memory sync.Map)
 	mw.SetTokenBlacklist(revokedTokenRepo)
@@ -134,9 +135,10 @@ func main() {
 	unavailHandler := handlers.NewUnavailableDateHandler(unavailRepo)
 	deviceHandler := handlers.NewDeviceHandler(deviceRepo)
 	liveActivityHandler := handlers.NewLiveActivityHandler(liveActivityRepo)
+	eventFormHandler := handlers.NewEventFormHandler(eventFormLinkRepo, productRepo, userRepo, cfg.FrontendURL, pool)
 
 	// Create router
-	r := router.New(authHandler, crudHandler, subHandler, searchHandler, eventPaymentHandler, uploadHandler, adminHandler, dashboardHandler, auditHandler, unavailHandler, deviceHandler, liveActivityHandler, authService, userRepo, auditRepo, pool, cfg.CORSAllowedOrigins, cfg.UploadDir)
+	r := router.New(authHandler, crudHandler, subHandler, searchHandler, eventPaymentHandler, uploadHandler, adminHandler, dashboardHandler, auditHandler, unavailHandler, deviceHandler, liveActivityHandler, eventFormHandler, authService, userRepo, auditRepo, pool, cfg.CORSAllowedOrigins, cfg.UploadDir)
 
 	// Background job: expire gifted plans that have passed their expiry date.
 	// Runs once at startup then every hour.
@@ -164,6 +166,24 @@ func main() {
 		defer ticker.Stop()
 		for range ticker.C {
 			notificationService.ProcessPendingReminders(context.Background())
+		}
+	}()
+
+	// Background job: expire stale event form links.
+	go func() {
+		runExpiry := func() {
+			count, err := eventFormLinkRepo.ExpireStale(context.Background())
+			if err != nil {
+				slog.Error("Failed to expire stale event form links", "error", err)
+			} else if count > 0 {
+				slog.Info("Expired stale event form links", "count", count)
+			}
+		}
+		runExpiry()
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for range ticker.C {
+			runExpiry()
 		}
 	}()
 

--- a/backend/internal/database/migrations/038_add_event_form_links.down.sql
+++ b/backend/internal/database/migrations/038_add_event_form_links.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_event_form_links_expires_at;
+DROP INDEX IF EXISTS idx_event_form_links_user_id;
+DROP INDEX IF EXISTS idx_event_form_links_token;
+DROP TABLE IF EXISTS event_form_links;

--- a/backend/internal/database/migrations/038_add_event_form_links.up.sql
+++ b/backend/internal/database/migrations/038_add_event_form_links.up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS event_form_links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL UNIQUE,
+    label TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    submitted_event_id UUID REFERENCES events(id) ON DELETE SET NULL,
+    submitted_client_id UUID REFERENCES clients(id) ON DELETE SET NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_form_links_token ON event_form_links(token);
+CREATE INDEX IF NOT EXISTS idx_event_form_links_user_id ON event_form_links(user_id);
+CREATE INDEX IF NOT EXISTS idx_event_form_links_expires_at ON event_form_links(expires_at) WHERE status = 'active';

--- a/backend/internal/handlers/event_form_handler.go
+++ b/backend/internal/handlers/event_form_handler.go
@@ -1,0 +1,529 @@
+package handlers
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tiagofur/solennix-backend/internal/middleware"
+	"github.com/tiagofur/solennix-backend/internal/models"
+	"github.com/tiagofur/solennix-backend/internal/repository"
+)
+
+// EventFormLinkRepository defines the operations needed for event form links.
+type EventFormLinkRepository interface {
+	Create(ctx context.Context, link *models.EventFormLink) error
+	GetByToken(ctx context.Context, token string) (*models.EventFormLink, error)
+	GetByUserID(ctx context.Context, userID uuid.UUID) ([]models.EventFormLink, error)
+	MarkUsedTx(ctx context.Context, tx pgx.Tx, linkID, eventID, clientID uuid.UUID) error
+	Delete(ctx context.Context, id, userID uuid.UUID) error
+	CountActiveByUserID(ctx context.Context, userID uuid.UUID) (int, error)
+	GetPool() *pgxpool.Pool
+}
+
+// EventFormHandler manages shareable event form links.
+type EventFormHandler struct {
+	linkRepo    EventFormLinkRepository
+	productRepo ProductRepository
+	userRepo    FullUserRepository
+	frontendURL string
+	pool        *pgxpool.Pool
+}
+
+// NewEventFormHandler creates a new EventFormHandler.
+func NewEventFormHandler(
+	linkRepo EventFormLinkRepository,
+	productRepo ProductRepository,
+	userRepo FullUserRepository,
+	frontendURL string,
+	pool *pgxpool.Pool,
+) *EventFormHandler {
+	return &EventFormHandler{
+		linkRepo:    linkRepo,
+		productRepo: productRepo,
+		userRepo:    userRepo,
+		frontendURL: frontendURL,
+		pool:        pool,
+	}
+}
+
+// --- Authenticated endpoints ---
+
+// GenerateLink creates a new shareable event form link.
+// POST /api/event-forms
+func (h *EventFormHandler) GenerateLink(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+
+	var req struct {
+		Label   *string `json:"label"`
+		TTLDays *int    `json:"ttl_days"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		// Allow empty body (all fields optional)
+		req.Label = nil
+		req.TTLDays = nil
+	}
+
+	// Validate TTL
+	ttlDays := 7 // default
+	if req.TTLDays != nil {
+		ttlDays = *req.TTLDays
+	}
+	if ttlDays < 1 || ttlDays > 30 {
+		writeError(w, http.StatusBadRequest, "ttl_days must be between 1 and 30")
+		return
+	}
+
+	// Sanitize label
+	label := sanitizeOptionalString(req.Label)
+	if label != nil {
+		if err := validateStringLength("label", *label, MaxNameLength); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+
+	// Plan limits: basic users max 3 active links
+	user, err := h.userRepo.GetByID(r.Context(), userID)
+	if err != nil {
+		slog.Error("Failed to get user", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to get user")
+		return
+	}
+
+	if user.Plan == "basic" {
+		count, err := h.linkRepo.CountActiveByUserID(r.Context(), userID)
+		if err != nil {
+			slog.Error("Failed to count active links", "error", err)
+			writeError(w, http.StatusInternalServerError, "Failed to check link limits")
+			return
+		}
+		if count >= 3 {
+			writePlanLimitError(w, "event_form_links", count, 3)
+			return
+		}
+	}
+
+	// Generate cryptographically random token
+	token, err := generateFormToken()
+	if err != nil {
+		slog.Error("Failed to generate token", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to generate link")
+		return
+	}
+
+	link := &models.EventFormLink{
+		UserID:    userID,
+		Token:     token,
+		Label:     label,
+		ExpiresAt: time.Now().UTC().Add(time.Duration(ttlDays) * 24 * time.Hour),
+	}
+
+	if err := h.linkRepo.Create(r.Context(), link); err != nil {
+		slog.Error("Failed to create event form link", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to create link")
+		return
+	}
+
+	link.URL = h.buildFormURL(link.Token)
+	writeJSON(w, http.StatusCreated, link)
+}
+
+// ListLinks lists all event form links for the authenticated user.
+// GET /api/event-forms
+func (h *EventFormHandler) ListLinks(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+
+	links, err := h.linkRepo.GetByUserID(r.Context(), userID)
+	if err != nil {
+		slog.Error("Failed to list event form links", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to list links")
+		return
+	}
+
+	for i := range links {
+		links[i].URL = h.buildFormURL(links[i].Token)
+	}
+
+	writeJSON(w, http.StatusOK, links)
+}
+
+// DeleteLink revokes an event form link.
+// DELETE /api/event-forms/{id}
+func (h *EventFormHandler) DeleteLink(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	idStr := chi.URLParam(r, "id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid link ID")
+		return
+	}
+
+	if err := h.linkRepo.Delete(r.Context(), id, userID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "Link not found")
+			return
+		}
+		slog.Error("Failed to delete event form link", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to delete link")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Public endpoints (no auth) ---
+
+// PublicProduct is a DTO that strips pricing info from products.
+type PublicProduct struct {
+	ID       uuid.UUID `json:"id"`
+	Name     string    `json:"name"`
+	Category string    `json:"category"`
+	ImageURL *string   `json:"image_url,omitempty"`
+}
+
+// PublicOrganizer is a DTO with organizer branding only.
+type PublicOrganizer struct {
+	BusinessName *string `json:"business_name,omitempty"`
+	LogoURL      *string `json:"logo_url,omitempty"`
+	BrandColor   *string `json:"brand_color,omitempty"`
+}
+
+// GetFormData returns the organizer branding and product catalog (without prices) for a form link.
+// GET /api/public/event-forms/{token}
+func (h *EventFormHandler) GetFormData(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "Token is required")
+		return
+	}
+
+	link, err := h.linkRepo.GetByToken(r.Context(), token)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{
+			"error":   "link_invalid",
+			"message": "Este enlace ya no es válido o ha expirado.",
+		})
+		return
+	}
+
+	// Load organizer info for branding
+	user, err := h.userRepo.GetByID(r.Context(), link.UserID)
+	if err != nil {
+		slog.Error("Failed to get organizer", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to load form")
+		return
+	}
+
+	// Load organizer's active products (without prices)
+	products, err := h.productRepo.GetAll(r.Context(), link.UserID)
+	if err != nil {
+		slog.Error("Failed to get products", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to load products")
+		return
+	}
+
+	publicProducts := make([]PublicProduct, 0, len(products))
+	for _, p := range products {
+		if !p.IsActive {
+			continue
+		}
+		publicProducts = append(publicProducts, PublicProduct{
+			ID:       p.ID,
+			Name:     p.Name,
+			Category: p.Category,
+			ImageURL: p.ImageURL,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"organizer": PublicOrganizer{
+			BusinessName: user.BusinessName,
+			LogoURL:      user.LogoURL,
+			BrandColor:   user.BrandColor,
+		},
+		"products":   publicProducts,
+		"link_id":    link.ID,
+		"expires_at": link.ExpiresAt,
+	})
+}
+
+// EventFormSubmission is the request body for submitting a public event form.
+type EventFormSubmission struct {
+	ClientName  string  `json:"client_name"`
+	ClientPhone string  `json:"client_phone"`
+	ClientEmail *string `json:"client_email,omitempty"`
+	EventDate   string  `json:"event_date"`
+	ServiceType string  `json:"service_type"`
+	NumPeople   int     `json:"num_people"`
+	Location    *string `json:"location,omitempty"`
+	City        *string `json:"city,omitempty"`
+	Notes       *string `json:"notes,omitempty"`
+	Products    []struct {
+		ProductID string  `json:"product_id"`
+		Quantity  float64 `json:"quantity"`
+	} `json:"products"`
+}
+
+// SubmitForm processes a public event form submission.
+// Creates a Client + Event + EventProducts in a single transaction, then marks the link as used.
+// POST /api/public/event-forms/{token}
+func (h *EventFormHandler) SubmitForm(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		writeError(w, http.StatusBadRequest, "Token is required")
+		return
+	}
+
+	link, err := h.linkRepo.GetByToken(r.Context(), token)
+	if err != nil {
+		writeJSON(w, http.StatusGone, map[string]string{
+			"error":   "link_invalid",
+			"message": "Este enlace ya no es válido o ha expirado.",
+		})
+		return
+	}
+
+	var req EventFormSubmission
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	// Validate required fields
+	if err := h.validateSubmission(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Sanitize inputs
+	req.ClientName = sanitizeString(req.ClientName)
+	req.ClientPhone = sanitizeString(req.ClientPhone)
+	req.ClientEmail = sanitizeOptionalString(req.ClientEmail)
+	req.ServiceType = sanitizeString(req.ServiceType)
+	req.Location = sanitizeOptionalString(req.Location)
+	req.City = sanitizeOptionalString(req.City)
+	req.Notes = sanitizeOptionalString(req.Notes)
+
+	// Parse product IDs
+	productIDs := make([]uuid.UUID, 0, len(req.Products))
+	for _, p := range req.Products {
+		id, err := uuid.Parse(p.ProductID)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("Invalid product ID: %s", p.ProductID))
+			return
+		}
+		productIDs = append(productIDs, id)
+	}
+
+	// Execute everything in a transaction
+	tx, err := h.pool.Begin(r.Context())
+	if err != nil {
+		slog.Error("Failed to begin transaction", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process form")
+		return
+	}
+	defer tx.Rollback(r.Context())
+
+	// Verify product ownership within transaction
+	if len(productIDs) > 0 {
+		if err := repository.VerifyProductOwnershipTx(r.Context(), tx, link.UserID, productIDs); err != nil {
+			writeError(w, http.StatusBadRequest, "One or more selected products are not available")
+			return
+		}
+	}
+
+	// Fetch products to get base_price for event_products
+	var productsMap map[uuid.UUID]models.Product
+	if len(productIDs) > 0 {
+		products, err := repository.GetProductsByUserIDTx(r.Context(), tx, link.UserID, productIDs)
+		if err != nil {
+			slog.Error("Failed to get products for pricing", "error", err)
+			writeError(w, http.StatusInternalServerError, "Failed to process form")
+			return
+		}
+		productsMap = make(map[uuid.UUID]models.Product, len(products))
+		for _, p := range products {
+			productsMap[p.ID] = p
+		}
+	}
+
+	// Create client
+	client := &models.Client{
+		UserID: link.UserID,
+		Name:   req.ClientName,
+		Phone:  req.ClientPhone,
+		Email:  req.ClientEmail,
+	}
+	if err := repository.CreateClientTx(r.Context(), tx, client); err != nil {
+		slog.Error("Failed to create client", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process form")
+		return
+	}
+
+	// Create event (status: "quoted", amount: 0 — organizer sets later)
+	formNotes := "Enviado desde formulario compartible"
+	if req.Notes != nil && *req.Notes != "" {
+		formNotes = *req.Notes + "\n\n— Enviado desde formulario compartible"
+	}
+	event := &models.Event{
+		UserID:      link.UserID,
+		ClientID:    client.ID,
+		EventDate:   req.EventDate,
+		ServiceType: req.ServiceType,
+		NumPeople:   req.NumPeople,
+		Status:      "quoted",
+		Location:    req.Location,
+		City:        req.City,
+		Notes:       &formNotes,
+	}
+	if err := repository.CreateEventTx(r.Context(), tx, event); err != nil {
+		slog.Error("Failed to create event", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process form")
+		return
+	}
+
+	// Create event products with organizer's base_price
+	if len(req.Products) > 0 {
+		eventProducts := make([]models.EventProduct, 0, len(req.Products))
+		for _, rp := range req.Products {
+			pid, _ := uuid.Parse(rp.ProductID)
+			product, ok := productsMap[pid]
+			if !ok {
+				continue
+			}
+			eventProducts = append(eventProducts, models.EventProduct{
+				EventID:   event.ID,
+				ProductID: pid,
+				Quantity:  rp.Quantity,
+				UnitPrice: product.BasePrice,
+				Discount:  0,
+			})
+		}
+		if err := repository.CreateEventProductsTx(r.Context(), tx, event.ID, eventProducts); err != nil {
+			slog.Error("Failed to create event products", "error", err)
+			writeError(w, http.StatusInternalServerError, "Failed to process form")
+			return
+		}
+	}
+
+	// Update client stats
+	if err := repository.UpdateClientStatsTx(r.Context(), tx, client.ID); err != nil {
+		slog.Error("Failed to update client stats", "error", err)
+		// Non-critical, continue
+	}
+
+	// Mark link as used (atomic — prevents double submission)
+	if err := h.linkRepo.MarkUsedTx(r.Context(), tx, link.ID, event.ID, client.ID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeJSON(w, http.StatusConflict, map[string]string{
+				"error":   "link_already_used",
+				"message": "Este enlace ya fue utilizado.",
+			})
+			return
+		}
+		slog.Error("Failed to mark link as used", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process form")
+		return
+	}
+
+	// Commit transaction
+	if err := tx.Commit(r.Context()); err != nil {
+		slog.Error("Failed to commit transaction", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to process form")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"success":   true,
+		"message":   "Gracias, tu solicitud ha sido enviada.",
+		"event_id":  event.ID,
+		"client_id": client.ID,
+	})
+}
+
+// --- Helpers ---
+
+func (h *EventFormHandler) validateSubmission(req *EventFormSubmission) error {
+	if strings.TrimSpace(req.ClientName) == "" {
+		return ValidationError{Field: "client_name", Message: "is required"}
+	}
+	if err := validateStringLength("client_name", req.ClientName, MaxNameLength); err != nil {
+		return err
+	}
+	if strings.TrimSpace(req.ClientPhone) == "" {
+		return ValidationError{Field: "client_phone", Message: "is required"}
+	}
+	if err := validateStringLength("client_phone", req.ClientPhone, MaxPhoneLength); err != nil {
+		return err
+	}
+	if req.ClientEmail != nil {
+		if err := validateStringLength("client_email", *req.ClientEmail, MaxEmailLength); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(req.EventDate) == "" {
+		return ValidationError{Field: "event_date", Message: "is required"}
+	}
+	// Basic date format validation (YYYY-MM-DD)
+	if len(req.EventDate) != 10 || req.EventDate[4] != '-' || req.EventDate[7] != '-' {
+		return ValidationError{Field: "event_date", Message: "must be in YYYY-MM-DD format"}
+	}
+	if strings.TrimSpace(req.ServiceType) == "" {
+		return ValidationError{Field: "service_type", Message: "is required"}
+	}
+	if err := validateStringLength("service_type", req.ServiceType, MaxServiceTypeLength); err != nil {
+		return err
+	}
+	if req.NumPeople < 1 {
+		return ValidationError{Field: "num_people", Message: "must be at least 1"}
+	}
+	if req.Location != nil {
+		if err := validateStringLength("location", *req.Location, MaxLocationLength); err != nil {
+			return err
+		}
+	}
+	if req.City != nil {
+		if err := validateStringLength("city", *req.City, MaxCityLength); err != nil {
+			return err
+		}
+	}
+	if req.Notes != nil {
+		if err := validateStringLength("notes", *req.Notes, MaxNotesLength); err != nil {
+			return err
+		}
+	}
+	// Validate products
+	for _, p := range req.Products {
+		if strings.TrimSpace(p.ProductID) == "" {
+			return ValidationError{Field: "products.product_id", Message: "is required"}
+		}
+		if p.Quantity < 1 {
+			return ValidationError{Field: "products.quantity", Message: "must be at least 1"}
+		}
+	}
+	return nil
+}
+
+func (h *EventFormHandler) buildFormURL(token string) string {
+	return fmt.Sprintf("%s/form/%s", strings.TrimRight(h.frontendURL, "/"), token)
+}
+
+// generateFormToken creates a cryptographically random 64-character hex string (256 bits of entropy).
+func generateFormToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random token: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -288,3 +288,21 @@ type LiveActivityToken struct {
 	CreatedAt time.Time  `json:"created_at"`
 	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
+
+// EventFormLink represents a shareable, single-use link that a prospective client
+// opens in a browser to fill out event details and select products (without prices).
+// On submission it creates a draft Event + Client for the organizer.
+type EventFormLink struct {
+	ID                uuid.UUID  `json:"id"`
+	UserID            uuid.UUID  `json:"user_id"`
+	Token             string     `json:"token"`
+	Label             *string    `json:"label,omitempty"`
+	Status            string     `json:"status"` // "active" | "used" | "expired"
+	SubmittedEventID  *uuid.UUID `json:"submitted_event_id,omitempty"`
+	SubmittedClientID *uuid.UUID `json:"submitted_client_id,omitempty"`
+	ExpiresAt         time.Time  `json:"expires_at"`
+	UsedAt            *time.Time `json:"used_at,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	URL               string     `json:"url,omitempty"` // Computed, not stored
+}

--- a/backend/internal/repository/event_form_link_repo.go
+++ b/backend/internal/repository/event_form_link_repo.go
@@ -1,0 +1,281 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tiagofur/solennix-backend/internal/models"
+)
+
+// EventFormLinkRepo persists shareable event form links.
+type EventFormLinkRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewEventFormLinkRepo(pool *pgxpool.Pool) *EventFormLinkRepo {
+	return &EventFormLinkRepo{pool: pool}
+}
+
+const eventFormLinkColumns = `id, user_id, token, label, status, submitted_event_id, submitted_client_id, expires_at, used_at, created_at, updated_at`
+
+func scanEventFormLink(row pgx.Row) (*models.EventFormLink, error) {
+	var l models.EventFormLink
+	err := row.Scan(
+		&l.ID, &l.UserID, &l.Token, &l.Label, &l.Status,
+		&l.SubmittedEventID, &l.SubmittedClientID,
+		&l.ExpiresAt, &l.UsedAt, &l.CreatedAt, &l.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &l, nil
+}
+
+// Create inserts a new event form link.
+func (r *EventFormLinkRepo) Create(ctx context.Context, link *models.EventFormLink) error {
+	query := `
+		INSERT INTO event_form_links (user_id, token, label, expires_at)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, user_id, token, label, status, submitted_event_id, submitted_client_id, expires_at, used_at, created_at, updated_at`
+
+	row := r.pool.QueryRow(ctx, query, link.UserID, link.Token, link.Label, link.ExpiresAt)
+	result, err := scanEventFormLink(row)
+	if err != nil {
+		return fmt.Errorf("failed to create event form link: %w", err)
+	}
+	*link = *result
+	return nil
+}
+
+// GetByToken returns an active, non-expired link by its token.
+// Returns pgx.ErrNoRows if not found, expired, or already used.
+func (r *EventFormLinkRepo) GetByToken(ctx context.Context, token string) (*models.EventFormLink, error) {
+	query := fmt.Sprintf(`
+		SELECT %s FROM event_form_links
+		WHERE token = $1 AND status = 'active' AND expires_at > NOW()`, eventFormLinkColumns)
+
+	row := r.pool.QueryRow(ctx, query, token)
+	link, err := scanEventFormLink(row)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get event form link by token: %w", err)
+	}
+	return link, nil
+}
+
+// GetByUserID lists all links for an organizer, ordered by created_at DESC.
+func (r *EventFormLinkRepo) GetByUserID(ctx context.Context, userID uuid.UUID) ([]models.EventFormLink, error) {
+	query := fmt.Sprintf(`
+		SELECT %s FROM event_form_links
+		WHERE user_id = $1
+		ORDER BY created_at DESC`, eventFormLinkColumns)
+
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list event form links: %w", err)
+	}
+	defer rows.Close()
+
+	links := make([]models.EventFormLink, 0)
+	for rows.Next() {
+		var l models.EventFormLink
+		if err := rows.Scan(
+			&l.ID, &l.UserID, &l.Token, &l.Label, &l.Status,
+			&l.SubmittedEventID, &l.SubmittedClientID,
+			&l.ExpiresAt, &l.UsedAt, &l.CreatedAt, &l.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan event form link: %w", err)
+		}
+		links = append(links, l)
+	}
+	return links, nil
+}
+
+// MarkUsed atomically marks a link as used. Returns an error wrapping pgx.ErrNoRows
+// if the link was already used or expired (race condition protection).
+func (r *EventFormLinkRepo) MarkUsed(ctx context.Context, linkID, eventID, clientID uuid.UUID) error {
+	query := `
+		UPDATE event_form_links
+		SET status = 'used', used_at = NOW(), submitted_event_id = $2, submitted_client_id = $3, updated_at = NOW()
+		WHERE id = $1 AND status = 'active'`
+
+	tag, err := r.pool.Exec(ctx, query, linkID, eventID, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to mark event form link as used: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("link already used or expired: %w", pgx.ErrNoRows)
+	}
+	return nil
+}
+
+// Delete removes a link. Only the owner can delete.
+func (r *EventFormLinkRepo) Delete(ctx context.Context, id, userID uuid.UUID) error {
+	query := `DELETE FROM event_form_links WHERE id = $1 AND user_id = $2`
+	tag, err := r.pool.Exec(ctx, query, id, userID)
+	if err != nil {
+		return fmt.Errorf("failed to delete event form link: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("event form link not found: %w", pgx.ErrNoRows)
+	}
+	return nil
+}
+
+// CountActiveByUserID returns the number of active links for a user.
+func (r *EventFormLinkRepo) CountActiveByUserID(ctx context.Context, userID uuid.UUID) (int, error) {
+	query := `SELECT COUNT(*) FROM event_form_links WHERE user_id = $1 AND status = 'active' AND expires_at > NOW()`
+	var count int
+	err := r.pool.QueryRow(ctx, query, userID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count active event form links: %w", err)
+	}
+	return count, nil
+}
+
+// ExpireStale marks active links whose TTL has passed as expired.
+// Returns the number of links expired.
+func (r *EventFormLinkRepo) ExpireStale(ctx context.Context) (int, error) {
+	query := `
+		UPDATE event_form_links
+		SET status = 'expired', updated_at = NOW()
+		WHERE status = 'active' AND expires_at < NOW()`
+
+	tag, err := r.pool.Exec(ctx, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to expire stale event form links: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// Pool exposes the connection pool for transaction support in the handler.
+func (r *EventFormLinkRepo) Pool() *pgxpool.Pool {
+	return r.pool
+}
+
+// MarkUsedTx marks a link as used within an existing transaction.
+func (r *EventFormLinkRepo) MarkUsedTx(ctx context.Context, tx pgx.Tx, linkID, eventID, clientID uuid.UUID) error {
+	query := `
+		UPDATE event_form_links
+		SET status = 'used', used_at = NOW(), submitted_event_id = $2, submitted_client_id = $3, updated_at = NOW()
+		WHERE id = $1 AND status = 'active'`
+
+	tag, err := tx.Exec(ctx, query, linkID, eventID, clientID)
+	if err != nil {
+		return fmt.Errorf("failed to mark event form link as used: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("link already used or expired: %w", pgx.ErrNoRows)
+	}
+	return nil
+}
+
+// GetPool returns the underlying connection pool for transaction management.
+func (r *EventFormLinkRepo) GetPool() *pgxpool.Pool {
+	return r.pool
+}
+
+// CreateClientTx creates a client within a transaction.
+func CreateClientTx(ctx context.Context, tx pgx.Tx, c *models.Client) error {
+	query := `
+		INSERT INTO clients (user_id, name, phone, email, notes)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, created_at, updated_at`
+
+	return tx.QueryRow(ctx, query, c.UserID, c.Name, c.Phone, c.Email, c.Notes).
+		Scan(&c.ID, &c.CreatedAt, &c.UpdatedAt)
+}
+
+// CreateEventTx creates an event within a transaction.
+func CreateEventTx(ctx context.Context, tx pgx.Tx, e *models.Event) error {
+	query := `
+		INSERT INTO events (user_id, client_id, event_date, start_time, end_time, service_type, num_people, status, location, city, notes)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id, created_at, updated_at`
+
+	return tx.QueryRow(ctx, query,
+		e.UserID, e.ClientID, e.EventDate, e.StartTime, e.EndTime,
+		e.ServiceType, e.NumPeople, e.Status, e.Location, e.City, e.Notes,
+	).Scan(&e.ID, &e.CreatedAt, &e.UpdatedAt)
+}
+
+// CreateEventProductsTx creates event product records within a transaction.
+func CreateEventProductsTx(ctx context.Context, tx pgx.Tx, eventID uuid.UUID, products []models.EventProduct) error {
+	for i := range products {
+		query := `
+			INSERT INTO event_products (event_id, product_id, quantity, unit_price, discount)
+			VALUES ($1, $2, $3, $4, $5)
+			RETURNING id, created_at`
+
+		err := tx.QueryRow(ctx, query,
+			eventID, products[i].ProductID, products[i].Quantity,
+			products[i].UnitPrice, products[i].Discount,
+		).Scan(&products[i].ID, &products[i].CreatedAt)
+		if err != nil {
+			return fmt.Errorf("failed to create event product: %w", err)
+		}
+	}
+	return nil
+}
+
+// UpdateClientStatsTx updates a client's total_events and total_spent within a transaction.
+func UpdateClientStatsTx(ctx context.Context, tx pgx.Tx, clientID uuid.UUID) error {
+	query := `
+		UPDATE clients SET
+			total_events = (SELECT COUNT(*) FROM events WHERE client_id = $1),
+			total_spent = COALESCE((SELECT SUM(total_amount) FROM events WHERE client_id = $1), 0),
+			updated_at = NOW()
+		WHERE id = $1`
+
+	_, err := tx.Exec(ctx, query, clientID)
+	return err
+}
+
+// GetProductsByUserIDTx fetches active products for a user within a transaction.
+func GetProductsByUserIDTx(ctx context.Context, tx pgx.Tx, userID uuid.UUID, productIDs []uuid.UUID) ([]models.Product, error) {
+	query := `
+		SELECT id, user_id, name, category, base_price, image_url, is_active, created_at, updated_at
+		FROM products
+		WHERE user_id = $1 AND id = ANY($2) AND is_active = true`
+
+	rows, err := tx.Query(ctx, query, userID, productIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get products: %w", err)
+	}
+	defer rows.Close()
+
+	var products []models.Product
+	for rows.Next() {
+		var p models.Product
+		if err := rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Category, &p.BasePrice, &p.ImageURL, &p.IsActive, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan product: %w", err)
+		}
+		products = append(products, p)
+	}
+	return products, nil
+}
+
+// VerifyProductOwnershipTx verifies that all product IDs belong to the user within a transaction.
+func VerifyProductOwnershipTx(ctx context.Context, tx pgx.Tx, userID uuid.UUID, productIDs []uuid.UUID) error {
+	if len(productIDs) == 0 {
+		return nil
+	}
+	query := `SELECT COUNT(*) FROM products WHERE id = ANY($1) AND user_id = $2`
+	var count int
+	err := tx.QueryRow(ctx, query, productIDs, userID).Scan(&count)
+	if err != nil {
+		return fmt.Errorf("failed to verify product ownership: %w", err)
+	}
+	if count != len(productIDs) {
+		return fmt.Errorf("one or more products do not belong to user")
+	}
+	return nil
+}
+
+func init() {
+	// Ensure time is always UTC for consistency.
+	_ = time.UTC
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -16,7 +16,7 @@ import (
 func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, subHandler *handlers.SubscriptionHandler,
 	searchHandler *handlers.SearchHandler, eventPaymentHandler *handlers.EventPaymentHandler, uploadHandler *handlers.UploadHandler,
 	adminHandler *handlers.AdminHandler, dashboardHandler *handlers.DashboardHandler, auditHandler *handlers.AuditHandler, unavailHandler *handlers.UnavailableDateHandler, deviceHandler *handlers.DeviceHandler,
-	liveActivityHandler *handlers.LiveActivityHandler,
+	liveActivityHandler *handlers.LiveActivityHandler, eventFormHandler *handlers.EventFormHandler,
 	authService *services.AuthService, userRepo *repository.UserRepo, auditRepo mw.AuditLogger, pool *pgxpool.Pool, corsOrigins []string, uploadDir string) http.Handler {
 
 	r := chi.NewRouter()
@@ -124,6 +124,13 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 		legacyFileServer.ServeHTTP(w, r)
 	})
 
+	// Public event form routes (no auth — validated by token)
+	apiRouter.Route("/public/event-forms", func(r chi.Router) {
+		r.Use(mw.RateLimit(10, 1*time.Minute))
+		r.Get("/{token}", eventFormHandler.GetFormData)
+		r.Post("/{token}", eventFormHandler.SubmitForm)
+	})
+
 	// Protected routes
 	apiRouter.Group(func(r chi.Router) {
 		r.Use(mw.Auth(authService))
@@ -228,6 +235,13 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 		r.Route("/live-activities", func(r chi.Router) {
 			r.Post("/register", liveActivityHandler.Register)
 			r.Delete("/by-event/{eventId}", liveActivityHandler.DeleteByEvent)
+		})
+
+		// Event form links (shareable forms for prospective clients)
+		r.Route("/event-forms", func(r chi.Router) {
+			r.Get("/", eventFormHandler.ListLinks)
+			r.Post("/", eventFormHandler.GenerateLink)
+			r.Delete("/{id}", eventFormHandler.DeleteLink)
 		})
 
 		// Search — rate limited to prevent abuse

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/EventFormLink.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/EventFormLink.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct EventFormLink: Codable, Identifiable, Sendable {
+    public let id: String
+    public let userId: String
+    public let token: String
+    public var label: String?
+    public let status: String
+    public var submittedEventId: String?
+    public var submittedClientId: String?
+    public let url: String
+    public let expiresAt: String
+    public var usedAt: String?
+    public let createdAt: String
+    public let updatedAt: String
+
+    public init(id: String, userId: String, token: String, label: String? = nil,
+                status: String, submittedEventId: String? = nil, submittedClientId: String? = nil,
+                url: String, expiresAt: String, usedAt: String? = nil,
+                createdAt: String, updatedAt: String) {
+        self.id = id
+        self.userId = userId
+        self.token = token
+        self.label = label
+        self.status = status
+        self.submittedEventId = submittedEventId
+        self.submittedClientId = submittedClientId
+        self.url = url
+        self.expiresAt = expiresAt
+        self.usedAt = usedAt
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Route.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Route.swift
@@ -40,6 +40,9 @@ public enum Route: Hashable {
     case search(query: String = "")
     case settings
 
+    // MARK: Event Form Links
+    case eventFormLinks
+
     // MARK: Settings Sub-Routes
     case editProfile
     case changePassword

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/EventFormLinks/ViewModels/EventFormLinksViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/EventFormLinks/ViewModels/EventFormLinksViewModel.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Observation
+import SolennixCore
+import SolennixNetwork
+
+// MARK: - Create Link Request
+
+private struct CreateEventFormLinkRequest: Encodable {
+    let label: String?
+    let ttlDays: Int
+}
+
+// MARK: - Event Form Links View Model
+
+@Observable
+public final class EventFormLinksViewModel {
+
+    // MARK: - Properties
+
+    public var links: [EventFormLink] = []
+    public var isLoading: Bool = false
+    public var isGenerating: Bool = false
+    public var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let apiClient: APIClient
+
+    // MARK: - Init
+
+    public init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Data Loading
+
+    @MainActor
+    public func loadLinks() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let result: [EventFormLink] = try await apiClient.getAll(Endpoint.eventFormLinks)
+            links = result.sorted { $0.createdAt > $1.createdAt }
+        } catch {
+            errorMessage = mapError(error)
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Generate Link
+
+    @MainActor
+    public func generateLink(label: String?, ttlDays: Int) async {
+        isGenerating = true
+        errorMessage = nil
+
+        do {
+            let body = CreateEventFormLinkRequest(
+                label: label?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true ? nil : label?.trimmingCharacters(in: .whitespacesAndNewlines),
+                ttlDays: ttlDays
+            )
+            let newLink: EventFormLink = try await apiClient.post(Endpoint.eventFormLinks, body: body)
+            links.insert(newLink, at: 0)
+        } catch {
+            errorMessage = mapError(error)
+        }
+
+        isGenerating = false
+    }
+
+    // MARK: - Delete Link
+
+    @MainActor
+    public func deleteLink(id: String) async {
+        do {
+            try await apiClient.delete(Endpoint.eventFormLink(id))
+            links.removeAll { $0.id == id }
+        } catch {
+            errorMessage = mapError(error)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Returns a localized display status for the link.
+    public func displayStatus(for link: EventFormLink) -> String {
+        switch link.status {
+        case "active":
+            // Check if expired by date
+            if isExpired(link) {
+                return "Expirado"
+            }
+            return "Activo"
+        case "used":
+            return "Usado"
+        case "expired":
+            return "Expirado"
+        default:
+            return link.status.capitalized
+        }
+    }
+
+    /// Returns the effective status considering expiration date.
+    public func effectiveStatus(for link: EventFormLink) -> String {
+        if link.status == "active" && isExpired(link) {
+            return "expired"
+        }
+        return link.status
+    }
+
+    /// Whether the link has passed its expiration date.
+    public func isExpired(_ link: EventFormLink) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let expiresDate = formatter.date(from: link.expiresAt) {
+            return expiresDate < Date()
+        }
+        // Try without fractional seconds
+        formatter.formatOptions = [.withInternetDateTime]
+        if let expiresDate = formatter.date(from: link.expiresAt) {
+            return expiresDate < Date()
+        }
+        return false
+    }
+
+    // MARK: - Error Mapping
+
+    private func mapError(_ error: Error) -> String {
+        if let apiError = error as? APIError {
+            return apiError.errorDescription ?? "Ocurrió un error inesperado."
+        }
+        return "Ocurrió un error inesperado. Intenta de nuevo."
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/EventFormLinks/Views/EventFormLinksView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/EventFormLinks/Views/EventFormLinksView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+import SolennixCore
+import SolennixDesign
+import SolennixNetwork
+
+// MARK: - Event Form Links View
+
+public struct EventFormLinksView: View {
+
+    @State private var viewModel: EventFormLinksViewModel
+    @State private var showGenerateSheet: Bool = false
+    @State private var showDeleteConfirm: Bool = false
+    @State private var deleteTarget: EventFormLink?
+    @Environment(ToastManager.self) private var toastManager
+
+    public init(apiClient: APIClient) {
+        _viewModel = State(initialValue: EventFormLinksViewModel(apiClient: apiClient))
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            content
+        }
+        .background(SolennixColors.surfaceGrouped)
+        .navigationTitle("Links de Formulario")
+        .navigationBarTitleDisplayMode(.large)
+        .refreshable { await viewModel.loadLinks() }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showGenerateSheet = true
+                } label: {
+                    Image(systemName: "plus.circle")
+                        .font(.body)
+                        .foregroundStyle(SolennixColors.primary)
+                        .accessibilityLabel("Generar link")
+                }
+            }
+        }
+        .sheet(isPresented: $showGenerateSheet) {
+            GenerateLinkSheet(viewModel: viewModel, isPresented: $showGenerateSheet)
+        }
+        .confirmationDialog(
+            "Eliminar link",
+            isPresented: $showDeleteConfirm,
+            presenting: deleteTarget
+        ) { link in
+            Button("Eliminar", role: .destructive) {
+                HapticsHelper.play(.success)
+                Task { await viewModel.deleteLink(id: link.id) }
+                toastManager.show(message: "Link eliminado", type: .success)
+            }
+            Button("Cancelar", role: .cancel) {}
+        } message: { link in
+            Text("Se eliminara el link \"\(link.label ?? "sin etiqueta")\". Esta accion no se puede deshacer.")
+        }
+        .task {
+            await viewModel.loadLinks()
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = viewModel.errorMessage, viewModel.links.isEmpty, !viewModel.isLoading {
+            EmptyStateView(
+                icon: "wifi.exclamationmark",
+                title: "Error al cargar",
+                message: error,
+                actionTitle: "Reintentar"
+            ) {
+                Task { await viewModel.loadLinks() }
+            }
+        } else if viewModel.isLoading && viewModel.links.isEmpty {
+            skeletonList
+        } else if viewModel.links.isEmpty && !viewModel.isLoading {
+            EmptyStateView(
+                icon: "link.badge.plus",
+                title: "Sin links",
+                message: "Genera un link para que tus clientes llenen su informacion de evento",
+                actionTitle: "Generar Link"
+            ) {
+                showGenerateSheet = true
+            }
+        } else {
+            linkList
+        }
+    }
+
+    // MARK: - Link List
+
+    private var linkList: some View {
+        List {
+            ForEach(viewModel.links) { link in
+                linkRow(link)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            HapticsHelper.play(.warning)
+                            deleteTarget = link
+                            showDeleteConfirm = true
+                        } label: {
+                            Label("Eliminar", systemImage: "trash")
+                        }
+                    }
+                    .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                        Button {
+                            copyLink(link)
+                        } label: {
+                            Label("Copiar", systemImage: "doc.on.doc")
+                        }
+                        .tint(SolennixColors.info)
+
+                        ShareLink(item: link.url) {
+                            Label("Compartir", systemImage: "square.and.arrow.up")
+                        }
+                        .tint(SolennixColors.primary)
+                    }
+                    .contextMenu {
+                        Button {
+                            copyLink(link)
+                        } label: {
+                            Label("Copiar Link", systemImage: "doc.on.doc")
+                        }
+
+                        ShareLink(item: link.url) {
+                            Label("Compartir", systemImage: "square.and.arrow.up")
+                        }
+
+                        if viewModel.effectiveStatus(for: link) == "used",
+                           let eventId = link.submittedEventId {
+                            NavigationLink(value: Route.eventDetail(id: eventId)) {
+                                Label("Ver Evento", systemImage: "calendar")
+                            }
+                        }
+
+                        Divider()
+
+                        Button(role: .destructive) {
+                            HapticsHelper.play(.warning)
+                            deleteTarget = link
+                            showDeleteConfirm = true
+                        } label: {
+                            Label("Eliminar", systemImage: "trash")
+                        }
+                    }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(SolennixColors.surfaceGrouped)
+    }
+
+    // MARK: - Link Row
+
+    private func linkRow(_ link: EventFormLink) -> some View {
+        HStack(spacing: Spacing.md) {
+            statusIndicator(for: link)
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                HStack(spacing: Spacing.sm) {
+                    Text(link.label ?? "Sin etiqueta")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(SolennixColors.text)
+                        .lineLimit(1)
+
+                    linkStatusBadge(for: link)
+                }
+
+                Text(formattedDate(link.createdAt))
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textSecondary)
+
+                if viewModel.effectiveStatus(for: link) == "active" {
+                    Text("Expira: \(formattedDate(link.expiresAt))")
+                        .font(.caption2)
+                        .foregroundStyle(SolennixColors.textTertiary)
+                }
+
+                if viewModel.effectiveStatus(for: link) == "used" {
+                    HStack(spacing: Spacing.xs) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.success)
+                        Text("Formulario completado")
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.success)
+                    }
+                }
+            }
+
+            Spacer()
+
+            // Quick share button
+            if viewModel.effectiveStatus(for: link) == "active" {
+                ShareLink(item: link.url) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.body)
+                        .foregroundStyle(SolennixColors.primary)
+                }
+                .buttonStyle(.plain)
+            } else if viewModel.effectiveStatus(for: link) == "used",
+                      let eventId = link.submittedEventId {
+                NavigationLink(value: Route.eventDetail(id: eventId)) {
+                    Image(systemName: "arrow.right.circle")
+                        .font(.body)
+                        .foregroundStyle(SolennixColors.primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+
+    // MARK: - Status Indicator
+
+    private func statusIndicator(for link: EventFormLink) -> some View {
+        let status = viewModel.effectiveStatus(for: link)
+
+        return ZStack {
+            Circle()
+                .fill(statusBackgroundColor(status))
+                .frame(width: 36, height: 36)
+
+            Image(systemName: statusIcon(status))
+                .font(.caption)
+                .foregroundStyle(statusForegroundColor(status))
+        }
+    }
+
+    private func linkStatusBadge(for link: EventFormLink) -> some View {
+        let display = viewModel.displayStatus(for: link)
+        let status = viewModel.effectiveStatus(for: link)
+
+        return Text(display)
+            .font(.caption2)
+            .fontWeight(.semibold)
+            .foregroundStyle(statusForegroundColor(status))
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xxs)
+            .background(statusBackgroundColor(status))
+            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
+    }
+
+    // MARK: - Status Colors & Icons
+
+    private func statusForegroundColor(_ status: String) -> Color {
+        switch status {
+        case "active": return SolennixColors.success
+        case "used": return SolennixColors.info
+        case "expired": return SolennixColors.textTertiary
+        default: return SolennixColors.textSecondary
+        }
+    }
+
+    private func statusBackgroundColor(_ status: String) -> Color {
+        switch status {
+        case "active": return SolennixColors.successBg
+        case "used": return SolennixColors.infoBg
+        case "expired": return SolennixColors.surfaceAlt
+        default: return SolennixColors.surfaceAlt
+        }
+    }
+
+    private func statusIcon(_ status: String) -> String {
+        switch status {
+        case "active": return "link"
+        case "used": return "checkmark.circle.fill"
+        case "expired": return "clock.badge.xmark"
+        default: return "questionmark.circle"
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func copyLink(_ link: EventFormLink) {
+        UIPasteboard.general.string = link.url
+        HapticsHelper.play(.success)
+        toastManager.show(message: "Link copiado", type: .success)
+    }
+
+    private func formattedDate(_ isoString: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: isoString) {
+            return date.formatted(.dateTime.day().month(.abbreviated).year().hour().minute())
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        if let date = formatter.date(from: isoString) {
+            return date.formatted(.dateTime.day().month(.abbreviated).year().hour().minute())
+        }
+        return isoString
+    }
+
+    // MARK: - Skeleton Loading
+
+    private var skeletonList: some View {
+        List(0..<4, id: \.self) { _ in
+            HStack(spacing: Spacing.md) {
+                Circle()
+                    .fill(SolennixColors.surfaceAlt)
+                    .frame(width: 36, height: 36)
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    RoundedRectangle(cornerRadius: CornerRadius.sm)
+                        .fill(SolennixColors.surfaceAlt)
+                        .frame(width: 140, height: 14)
+
+                    RoundedRectangle(cornerRadius: CornerRadius.sm)
+                        .fill(SolennixColors.surfaceAlt)
+                        .frame(width: 100, height: 10)
+                }
+
+                Spacer()
+            }
+            .padding(.vertical, Spacing.xs)
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(SolennixColors.surfaceGrouped)
+        .redacted(reason: .placeholder)
+    }
+}
+
+// MARK: - Generate Link Sheet
+
+private struct GenerateLinkSheet: View {
+
+    let viewModel: EventFormLinksViewModel
+    @Binding var isPresented: Bool
+    @State private var label: String = ""
+    @State private var ttlDays: Int = 7
+
+    private let ttlOptions = [1, 3, 7, 14, 30]
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Etiqueta (opcional)") {
+                    TextField("Ej: Boda Rodriguez, Evento Mayo", text: $label)
+                }
+
+                Section("Vigencia del link") {
+                    Picker("Dias de vigencia", selection: $ttlDays) {
+                        ForEach(ttlOptions, id: \.self) { days in
+                            Text(days == 1 ? "1 dia" : "\(days) dias").tag(days)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section {
+                    Text("El cliente podra llenar sus datos de evento a traves de este link. Una vez usado, no podra volver a utilizarse.")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            }
+            .scrollContentBackground(.hidden)
+            .background(SolennixColors.surfaceGrouped)
+            .navigationTitle("Generar Link")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancelar") {
+                        isPresented = false
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Generar") {
+                        Task {
+                            await viewModel.generateLink(
+                                label: label.isEmpty ? nil : label,
+                                ttlDays: ttlDays
+                            )
+                            isPresented = false
+                        }
+                    }
+                    .fontWeight(.semibold)
+                    .disabled(viewModel.isGenerating)
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Event Form Links") {
+    NavigationStack {
+        EventFormLinksView(apiClient: APIClient())
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Settings/Views/SettingsView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Settings/Views/SettingsView.swift
@@ -156,6 +156,10 @@ public struct SettingsView: View {
         NavigationLink(value: Route.contractDefaults) {
             Label("Valores del Contrato", systemImage: "doc.text")
         }
+
+        NavigationLink(value: Route.eventFormLinks) {
+            Label("Links de Formulario", systemImage: "link")
+        }
     }
 
     @ViewBuilder

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
@@ -116,6 +116,14 @@ public enum Endpoint {
     public static let registerDevice = "/devices/register"
     public static let unregisterDevice = "/devices/unregister"
 
+    // MARK: - Event Form Links
+
+    public static let eventFormLinks = "/event-forms"
+
+    public static func eventFormLink(_ id: String) -> String {
+        "/event-forms/\(id)"
+    }
+
     // MARK: - Live Activities (iOS Dynamic Island remote updates)
 
     public static let registerLiveActivityToken = "/live-activities/register"

--- a/ios/Solennix/Navigation/RouteDestination.swift
+++ b/ios/Solennix/Navigation/RouteDestination.swift
@@ -68,6 +68,10 @@ struct RouteDestination: View {
         case .inventoryForm(let id):
             InventoryFormView(apiClient: apiClient, itemId: id)
 
+        // Event Form Links
+        case .eventFormLinks:
+            EventFormLinksView(apiClient: apiClient)
+
         // Tools
         case .search(let query):
             SearchView(initialQuery: query)

--- a/obsidian/Solennix/Android/Android MOC.md
+++ b/obsidian/Solennix/Android/Android MOC.md
@@ -46,6 +46,7 @@
 | Vista de calendario | [[Módulo Calendario]] |
 | Configuración y perfil | [[Módulo Settings]] |
 | Generación de PDFs | [[Sistema de PDFs]] |
+| Formularios compartibles | [[Módulo Formularios Compartibles]] |
 
 ## Calidad
 

--- a/obsidian/Solennix/Android/Módulo Formularios Compartibles.md
+++ b/obsidian/Solennix/Android/Módulo Formularios Compartibles.md
@@ -1,0 +1,109 @@
+# Módulo Formularios Compartibles
+
+#android #formularios #módulo
+
+> [!abstract] Resumen
+> Permite al organizador crear enlaces compartibles desde la app Android. Genera un link, lo comparte via WhatsApp/email/etc., y su cliente potencial lo abre en el navegador para llenar datos de evento y seleccionar productos. Android solo gestiona la creacion y seguimiento de enlaces — el formulario en si es web.
+
+---
+
+## Modelo
+
+**Archivo:** `android/core/model/.../EventFormLink.kt`
+
+```kotlin
+@Serializable
+data class EventFormLink(
+    val id: String = "",
+    @SerialName("user_id") val userId: String = "",
+    val token: String = "",
+    val label: String? = null,
+    val status: String = "active",
+    @SerialName("submitted_event_id") val submittedEventId: String? = null,
+    @SerialName("submitted_client_id") val submittedClientId: String? = null,
+    val url: String = "",
+    @SerialName("expires_at") val expiresAt: String = "",
+    @SerialName("used_at") val usedAt: String? = null,
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("updated_at") val updatedAt: String = ""
+)
+```
+
+---
+
+## Endpoints
+
+| Metodo | Endpoint | Descripcion |
+|--------|----------|-------------|
+| GET | `/event-forms` | Listar enlaces |
+| POST | `/event-forms` | Crear enlace |
+| DELETE | `/event-forms/{id}` | Revocar enlace |
+
+---
+
+## ViewModel
+
+**Archivo:** `android/feature/clients/.../EventFormLinksViewModel.kt`
+
+Patron: `@HiltViewModel` con `StateFlow<UiState>`
+
+```kotlin
+sealed interface EventFormLinksUiState {
+    data object Loading : EventFormLinksUiState
+    data class Success(val links: List<EventFormLink>) : EventFormLinksUiState
+    data class Error(val message: String) : EventFormLinksUiState
+}
+```
+
+| Metodo | Descripcion |
+|--------|-------------|
+| `loadLinks()` | GET → actualiza StateFlow |
+| `generateLink(label, ttlDays)` | POST → agrega a lista |
+| `deleteLink(id)` | DELETE → remueve de lista |
+
+---
+
+## Screen
+
+**Archivo:** `android/feature/clients/.../EventFormLinksScreen.kt`
+
+### UI (Jetpack Compose)
+
+- **Scaffold** con TopAppBar "Formularios"
+- **LazyColumn** con cada link mostrando:
+  - Label o "Sin etiqueta"
+  - Chip de status (Activo/Usado/Expirado) con colores
+  - Fecha de expiracion formateada
+  - Para links usados: boton hacia el evento resultante
+- **FloatingActionButton** "Generar Enlace" → BottomSheet con:
+  - OutlinedTextField para label
+  - Slider para TTL (1-30 dias)
+  - Boton crear
+- **Acciones por item:**
+  - Compartir (Intent.ACTION_SEND)
+  - Copiar URL (ClipboardManager)
+  - Eliminar con confirmacion (AlertDialog)
+
+### Compartir
+
+```kotlin
+val shareIntent = Intent(Intent.ACTION_SEND).apply {
+    type = "text/plain"
+    putExtra(Intent.EXTRA_TEXT, link.url)
+    putExtra(Intent.EXTRA_SUBJECT, "Formulario de evento - ${user.businessName}")
+}
+context.startActivity(Intent.createChooser(shareIntent, "Compartir enlace"))
+```
+
+---
+
+## Navegacion
+
+Accesible desde:
+- Navigation drawer / bottom nav como item dedicado
+- O como accion en la seccion de Clientes
+
+---
+
+> [!tip] Navegacion
+> El formulario que llena el cliente es web-only ([[Módulo Formularios Compartibles|Web]]). Android solo gestiona la creacion de enlaces. Cuando el cliente envia, aparece un nuevo evento en [[Módulo Eventos]] y un nuevo cliente en [[Módulo Clientes]].

--- a/obsidian/Solennix/Backend/Backend MOC.md
+++ b/obsidian/Solennix/Backend/Backend MOC.md
@@ -26,6 +26,7 @@
 - [[Módulo Suscripciones]] — Stripe, RevenueCat, webhooks, sync bidireccional, billing
 - [[Módulos Auxiliares]] — Calendario (fechas bloqueadas), Búsqueda global, Uploads (imágenes), Dispositivos (push tokens)
 - [[Módulo Admin]] — Stats, gestión de usuarios, upgrades, suscripciones
+- [[Módulo Formularios Compartibles]] — Enlaces temporales para que clientes llenen datos de evento sin auth
 
 ## Infraestructura
 

--- a/obsidian/Solennix/Backend/Módulo Formularios Compartibles.md
+++ b/obsidian/Solennix/Backend/Módulo Formularios Compartibles.md
@@ -1,0 +1,226 @@
+# Módulo Formularios Compartibles
+
+#backend #formularios #módulo
+
+> [!abstract] Resumen
+> Permite a un organizador generar un enlace temporal y de un solo uso. Su cliente potencial abre el enlace en el navegador, llena datos del evento, selecciona productos del catálogo (sin ver precios) y envía. Esto crea un **evento borrador** + **cliente nuevo** para el organizador. El enlace expira al usarse o por TTL (7 días default).
+
+**Archivos principales:**
+- `internal/handlers/event_form_handler.go`
+- `internal/repository/event_form_link_repo.go`
+- `internal/database/migrations/038_add_event_form_links.up.sql`
+
+**Relacionado:** [[Backend MOC]] | [[Módulo Eventos]] | [[Módulo Clientes]] | [[Módulo Productos]] | [[Seguridad]]
+
+---
+
+## Arquitectura del Módulo
+
+```mermaid
+graph TB
+    subgraph "Authenticated Handlers"
+        GL[GenerateLink]
+        LL[ListLinks]
+        DL[DeleteLink]
+    end
+
+    subgraph "Public Handlers"
+        GF[GetFormData]
+        SF[SubmitForm]
+    end
+
+    subgraph "Repository"
+        EFLR[EventFormLinkRepo]
+    end
+
+    subgraph "Existing Repos"
+        PR[ProductRepo]
+        CR[ClientRepo]
+        ER[EventRepo]
+        UR[UserRepo]
+    end
+
+    subgraph "Database"
+        EFL[(event_form_links)]
+        C[(clients)]
+        E[(events)]
+        EP[(event_products)]
+        P[(products)]
+    end
+
+    GL --> EFLR
+    LL --> EFLR
+    DL --> EFLR
+
+    GF --> EFLR
+    GF --> PR
+    GF --> UR
+    SF --> EFLR
+    SF --> CR
+    SF --> ER
+    SF --> PR
+
+    EFLR --> EFL
+    CR --> C
+    ER --> E
+    ER --> EP
+    PR --> P
+```
+
+---
+
+## Tabla `event_form_links`
+
+```sql
+CREATE TABLE event_form_links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT NOT NULL UNIQUE,           -- 64 chars hex (crypto/rand 32 bytes)
+    label TEXT,                           -- etiqueta opcional del organizador
+    status TEXT NOT NULL DEFAULT 'active', -- 'active' | 'used' | 'expired'
+    submitted_event_id UUID REFERENCES events(id) ON DELETE SET NULL,
+    submitted_client_id UUID REFERENCES clients(id) ON DELETE SET NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Indices:** `token` (lookup publico), `user_id` (listado), `expires_at WHERE status='active'` (cleanup).
+
+---
+
+## Endpoints
+
+### Autenticados (requieren `mw.Auth`)
+
+| Method | Route | Handler | Descripcion |
+|--------|-------|---------|-------------|
+| `POST` | `/api/event-forms` | GenerateLink | Crear enlace (label, ttl_days 1-30) |
+| `GET` | `/api/event-forms` | ListLinks | Listar enlaces del organizador |
+| `DELETE` | `/api/event-forms/{id}` | DeleteLink | Revocar enlace |
+
+### Publicos (sin auth, rate-limited 10/min)
+
+| Method | Route | Handler | Descripcion |
+|--------|-------|---------|-------------|
+| `GET` | `/api/public/event-forms/{token}` | GetFormData | Branding + productos sin precios |
+| `POST` | `/api/public/event-forms/{token}` | SubmitForm | Crear cliente + evento borrador |
+
+---
+
+## Flujo de Generacion
+
+```mermaid
+sequenceDiagram
+    participant O as Organizador
+    participant API as Backend
+    participant DB as PostgreSQL
+
+    O->>API: POST /event-forms {label, ttl_days}
+    API->>API: crypto/rand 32 bytes → hex token
+    API->>DB: INSERT event_form_links
+    DB-->>API: link record
+    API-->>O: {id, token, url, expires_at}
+    O->>O: Comparte URL con cliente
+```
+
+## Flujo de Envio (Publico)
+
+```mermaid
+sequenceDiagram
+    participant C as Cliente
+    participant Web as Form Page
+    participant API as Backend
+    participant DB as PostgreSQL
+
+    C->>Web: Abre /form/{token}
+    Web->>API: GET /public/event-forms/{token}
+    API->>DB: SELECT WHERE token AND status='active' AND expires_at > NOW()
+    DB-->>API: link + user_id
+    API->>DB: SELECT products WHERE user_id (active only)
+    API->>DB: SELECT user (branding)
+    API-->>Web: {organizer, products (sin precios), expires_at}
+
+    C->>Web: Llena formulario y envia
+    Web->>API: POST /public/event-forms/{token}
+
+    Note over API,DB: Transaction
+    API->>DB: INSERT client
+    API->>DB: INSERT event (status='quoted')
+    API->>DB: INSERT event_products
+    API->>DB: UPDATE link SET status='used'
+    Note over API,DB: Commit
+
+    API-->>Web: 201 {success: true}
+    Web-->>C: Pagina de agradecimiento
+```
+
+---
+
+## Seguridad
+
+| Riesgo | Mitigacion |
+|--------|------------|
+| Enumeracion de tokens | `crypto/rand` 256 bits, no UUID predecible |
+| Exposicion de precios | DTO dedicado `PublicProduct` sin base_price/recipe |
+| Doble envio (race condition) | `MarkUsed` atomico con `WHERE status='active'`, 409 si 0 rows |
+| Spam de formularios | Rate limit 10 req/min en endpoints publicos |
+| CSRF en POST publico | Pasa sin validar — no hay `auth_token` cookie |
+| Links perpetuos | TTL max 30 dias + background job hourly para expirar |
+| Productos ajenos | `VerifyOwnership` antes de crear event_products |
+
+---
+
+## Modelo Go
+
+```go
+type EventFormLink struct {
+    ID                uuid.UUID  `json:"id"`
+    UserID            uuid.UUID  `json:"user_id"`
+    Token             string     `json:"token"`
+    Label             *string    `json:"label,omitempty"`
+    Status            string     `json:"status"`
+    SubmittedEventID  *uuid.UUID `json:"submitted_event_id,omitempty"`
+    SubmittedClientID *uuid.UUID `json:"submitted_client_id,omitempty"`
+    ExpiresAt         time.Time  `json:"expires_at"`
+    UsedAt            *time.Time `json:"used_at,omitempty"`
+    CreatedAt         time.Time  `json:"created_at"`
+    UpdatedAt         time.Time  `json:"updated_at"`
+}
+```
+
+## Repository
+
+| Metodo | Descripcion |
+|--------|-------------|
+| `Create` | Inserta link nuevo |
+| `GetByToken` | Busca por token, valida status='active' y no expirado |
+| `GetByUserID` | Lista links del organizador (management UI) |
+| `MarkUsed` | Atomico: status='used', used_at, event_id, client_id |
+| `Delete` | Revoca un link por id + user_id |
+| `ExpireStale` | Background: marca links expirados por TTL |
+
+---
+
+## Background Job
+
+Igual que el patron de `ExpireGiftedPlans` en `main.go`:
+
+```go
+go func() {
+    runExpiry := func() {
+        count, err := eventFormLinkRepo.ExpireStale(context.Background())
+        // log si count > 0
+    }
+    runExpiry()
+    ticker := time.NewTicker(1 * time.Hour)
+    for range ticker.C { runExpiry() }
+}()
+```
+
+---
+
+> [!tip] Navegacion
+> Este modulo conecta con [[Módulo Eventos]], [[Módulo Clientes]] y [[Módulo Productos]] para crear registros. Ver [[Seguridad]] para detalles de rate limiting y token management.

--- a/obsidian/Solennix/Backend/Seguridad.md
+++ b/obsidian/Solennix/Backend/Seguridad.md
@@ -59,6 +59,7 @@ graph TB
 | Uploads | 5 req/min | 1 minuto | Fixed window |
 | Search | 30 req/min | 1 minuto | Fixed window |
 | Admin | 30 req/min | 1 minuto | Fixed window |
+| Public Event Forms | 10 req/min | 1 minuto | Fixed window |
 
 > [!warning] Limitaciones
 > - **Fixed window**: Permite burst al inicio de cada ventana. Mejor: sliding window o token bucket.
@@ -143,8 +144,22 @@ graph TB
 | Request signing | Prevenir replay attacks | HMAC signing en headers |
 | API versioning | Breaking changes sin versión | `/api/v2/...` |
 
+## Formularios Compartibles — Seguridad
+
+Ver [[Módulo Formularios Compartibles]] para detalle completo.
+
+| Control | Implementacion |
+|---------|---------------|
+| Token no predecible | `crypto/rand` 32 bytes (256 bits), hex-encoded |
+| Precios ocultos | DTO `PublicProduct` sin base_price/recipe |
+| Doble envio | `MarkUsed` atomico con `WHERE status='active'` |
+| Spam | Rate limit 10/min en endpoints publicos |
+| CSRF | No aplica — sin `auth_token` cookie en requests publicos |
+| Links perpetuos | TTL max 30 dias + cleanup hourly |
+
 ## Relaciones
 
 - [[Middleware Stack]] — Implementación de cada middleware de seguridad
 - [[Autenticación]] — JWT, bcrypt, OAuth
+- [[Módulo Formularios Compartibles]] — Seguridad de enlaces publicos
 - [[Roadmap Backend]] — Plan de mejoras de seguridad

--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -860,6 +860,46 @@ Sistema de upload de imagenes para fotos de eventos, productos y logos de negoci
 
 ---
 
+### 15. Formularios Compartibles [Todas]
+
+> [!abstract] Resumen
+> El organizador genera un enlace temporal de un solo uso. Su cliente potencial abre el enlace en un navegador web (sin descargar app ni crear cuenta), llena datos de su evento, selecciona productos del catalogo (sin ver precios) y envia. Esto crea automaticamente un evento borrador + cliente nuevo para el organizador.
+
+#### Flujo
+
+1. Organizador crea enlace desde la app (iOS/Android) o web
+2. Comparte el enlace via WhatsApp/email/mensaje
+3. Cliente abre `/form/{token}` en su navegador
+4. Llena: nombre, telefono, email, fecha, tipo de evento, personas, ubicacion, notas
+5. Selecciona productos del catalogo del organizador (sin precios)
+6. Envia → se crea cliente + evento con status `quoted`
+7. El enlace se invalida (un solo uso)
+
+#### Seguridad
+
+| Control | Implementacion |
+|---------|---------------|
+| Token no predecible | `crypto/rand` 256 bits hex |
+| Precios ocultos | DTO dedicado sin base_price |
+| Doble envio | Atomico con `WHERE status='active'` |
+| Rate limit | 10 req/min en endpoints publicos |
+| TTL | 1-30 dias (default 7), cleanup hourly |
+
+#### Paridad
+
+| Funcion | iOS | Android | Web | Backend |
+|---------|-----|---------|-----|---------|
+| Crear enlace | 🔄 | 🔄 | ✅ | ✅ |
+| Listar enlaces | 🔄 | 🔄 | ✅ | ✅ |
+| Revocar enlace | 🔄 | 🔄 | ✅ | ✅ |
+| Compartir enlace | 🔄 | 🔄 | ✅ | ➖ |
+| Formulario publico | ➖ | ➖ | ✅ | ✅ |
+| Copiar al portapapeles | 🔄 | 🔄 | ✅ | ➖ |
+
+**Tier:** FREE (3 enlaces activos) / PRO (ilimitados)
+
+---
+
 ## P2 — Futuro
 
 > [!warning] Funcionalidades planificadas — no implementadas

--- a/obsidian/Solennix/Web/Módulo Formularios Compartibles.md
+++ b/obsidian/Solennix/Web/Módulo Formularios Compartibles.md
@@ -1,0 +1,152 @@
+# Módulo Formularios Compartibles
+
+#web #formularios #dominio
+
+> [!abstract] Resumen
+> Dos caras: (1) **Pagina publica** `/form/:token` donde el cliente potencial llena datos de su evento y selecciona productos sin ver precios, y (2) **UI de gestion** `/event-forms` donde el organizador crea, comparte y administra sus enlaces.
+
+---
+
+## Paginas
+
+| Pagina | Ruta | Auth | Descripcion |
+|--------|------|------|-------------|
+| **PublicEventFormPage** | `/form/:token` | No | Formulario publico branded del organizador |
+| **EventFormLinksPage** | `/event-forms` | Si | Gestion de enlaces (crear, copiar, revocar) |
+
+---
+
+## Pagina Publica (`/form/:token`)
+
+### Estructura
+
+```
+PublicEventFormPage.tsx
+├── PublicProductCard.tsx      — Card de producto (nombre, categoria, imagen, qty picker)
+├── PublicFormExpired.tsx      — Estado: link expirado/usado
+└── PublicFormSuccess.tsx      — Estado: envio exitoso (agradecimiento)
+```
+
+### Comportamiento
+
+1. Extrae `token` de URL params
+2. Fetch `GET /api/v1/public/event-forms/{token}` (fetch standalone, no el `api` client con auth)
+3. Token invalido → `PublicFormExpired`
+4. Token valido → formulario con branding del organizador:
+   - **Header**: logo, business_name, brand_color del organizador
+   - **Seccion 1**: Datos del cliente (nombre, telefono, email)
+   - **Seccion 2**: Datos del evento (fecha, tipo servicio, personas, ubicacion, notas)
+   - **Seccion 3**: Catalogo de productos (grid responsive, sin precios, qty picker)
+   - **Seccion 4**: Resumen y boton enviar
+5. Submit → `POST /api/v1/public/event-forms/{token}`
+6. Exito → `PublicFormSuccess`
+7. 409 (ya usado) → `PublicFormExpired`
+
+### Consideraciones UI
+
+- **Sin Layout wrapper** — no usa Sidebar/Header del app
+- **Responsive** — el cliente probablemente abre en mobile
+- **Branding** — usa `brand_color` del organizador como accent
+- **Validacion** — React Hook Form + Zod
+- **Sin precios** — productos muestran solo nombre, categoria, imagen
+- **Dark/Light** — respeta `prefers-color-scheme` del sistema
+
+### Datos que NO se exponen al cliente
+
+- `base_price` de productos
+- `recipe` de productos
+- `user_id` del organizador
+- Cualquier dato financiero
+
+---
+
+## Pagina de Gestion (`/event-forms`)
+
+### Funcionalidades
+
+- **Generar enlace** — Dialog con label opcional + selector TTL (1-30 dias, default 7)
+- **Lista de enlaces** — Tabla/cards con status badges:
+  - `Activo` (verde) — link disponible
+  - `Usado` (azul) — cliente ya envio
+  - `Expirado` (gris) — TTL vencido
+- **Copiar al portapapeles** — Click en URL → copia + toast
+- **Compartir** — Web Share API (mobile) o fallback a copiar
+- **Revocar** — Elimina link activo con confirmacion
+- **Ver resultado** — Links "usados" tienen link al evento/cliente creado
+
+### Componentes
+
+| Componente | Funcion |
+|-----------|---------|
+| `GenerateLinkDialog` | Modal para crear enlace nuevo |
+| `LinkStatusBadge` | Badge coloreado por status |
+| `LinkCard` / `LinkRow` | Item de la lista con acciones |
+
+---
+
+## Servicio API
+
+```
+services/eventFormService.ts
+```
+
+| Metodo | Endpoint | Descripcion |
+|--------|----------|-------------|
+| `generateLink(label?, ttlDays?)` | POST /event-forms | Crear enlace |
+| `listLinks()` | GET /event-forms | Listar enlaces del usuario |
+| `deleteLink(id)` | DELETE /event-forms/{id} | Revocar enlace |
+
+Para la pagina publica (fetch directo sin auth client):
+| Metodo | Endpoint | Descripcion |
+|--------|----------|-------------|
+| fetch | GET /public/event-forms/{token} | Datos del formulario |
+| fetch | POST /public/event-forms/{token} | Enviar formulario |
+
+---
+
+## Tipo
+
+```typescript
+interface EventFormLink {
+  id: string;
+  user_id: string;
+  token: string;
+  label?: string;
+  status: 'active' | 'used' | 'expired';
+  submitted_event_id?: string;
+  submitted_client_id?: string;
+  url: string;
+  expires_at: string;
+  used_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+---
+
+## React Query Hooks
+
+```
+hooks/queries/useEventFormQueries.ts
+```
+
+| Hook | Tipo | Descripcion |
+|------|------|-------------|
+| `useEventFormLinks()` | Query | Lista de links del usuario |
+| `useGenerateLink()` | Mutation | Crear enlace, invalida lista |
+| `useDeleteLink()` | Mutation | Revocar enlace, invalida lista |
+
+---
+
+## Navegacion
+
+- Ruta publica `/form/:token` — al nivel de `/login`, `/register` (sin ProtectedRoute/Layout)
+- Ruta protegida `/event-forms` — dentro de Layout, nuevo item en sidebar
+- Sidebar icon: `Link2` de lucide-react
+- Label sidebar: "Formularios"
+
+---
+
+> [!tip] Navegacion
+> Ver [[Módulo Eventos]] para el flujo completo de eventos. Los productos seleccionados en el form publico se crean como `EventProduct` records. El cliente creado aparece en [[Módulo Clientes]].

--- a/obsidian/Solennix/Web/Web MOC.md
+++ b/obsidian/Solennix/Web/Web MOC.md
@@ -24,6 +24,7 @@
 - [[Módulo Pagos]] — Registro de pagos, Stripe checkout, reportes
 - [[Módulo Calendario]] — Vista mensual, fechas bloqueadas
 - [[Módulo Admin]] — Dashboard admin, gestión de usuarios, suscripciones
+- [[Módulo Formularios Compartibles]] — Formulario publico para clientes + gestion de enlaces
 
 ## Infraestructura
 

--- a/obsidian/Solennix/iOS/Módulo Formularios Compartibles.md
+++ b/obsidian/Solennix/iOS/Módulo Formularios Compartibles.md
@@ -1,0 +1,106 @@
+# Módulo Formularios Compartibles
+
+#ios #formularios #módulo
+
+> [!abstract] Resumen
+> Permite al organizador crear enlaces compartibles desde la app iOS. El organizador genera un link, lo comparte via iMessage/WhatsApp/email, y su cliente potencial lo abre en un navegador web para llenar sus datos de evento y seleccionar productos. iOS solo gestiona la creacion y seguimiento de enlaces — el formulario en si es web.
+
+---
+
+## Modelo
+
+**Archivo:** `ios/Packages/SolennixCore/Sources/SolennixCore/Models/EventFormLink.swift`
+
+```swift
+public struct EventFormLink: Codable, Identifiable, Sendable {
+    public let id: String
+    public let userId: String
+    public let token: String
+    public var label: String?
+    public let status: String          // "active" | "used" | "expired"
+    public var submittedEventId: String?
+    public var submittedClientId: String?
+    public let url: String
+    public let expiresAt: String
+    public var usedAt: String?
+    public let createdAt: String
+    public let updatedAt: String
+}
+```
+
+---
+
+## Endpoints
+
+**Archivo:** `ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift`
+
+```swift
+// Event Form Links
+public static let eventFormLinks = "/event-forms"
+public static func eventFormLink(_ id: String) -> String { "/event-forms/\(id)" }
+```
+
+| Metodo | Endpoint | Descripcion |
+|--------|----------|-------------|
+| GET | `/event-forms` | Listar enlaces |
+| POST | `/event-forms` | Crear enlace |
+| DELETE | `/event-forms/{id}` | Revocar enlace |
+
+---
+
+## ViewModel
+
+**Archivo:** `ios/.../EventForms/EventFormLinksViewModel.swift`
+
+Patron: `@Observable` class (iOS 17+)
+
+| Metodo | Descripcion |
+|--------|-------------|
+| `loadLinks()` | GET /event-forms → actualiza lista |
+| `generateLink(label:ttlDays:)` | POST → agrega a lista + retorna URL |
+| `deleteLink(id:)` | DELETE → remueve de lista |
+
+---
+
+## Vista
+
+**Archivo:** `ios/.../EventForms/EventFormLinksView.swift`
+
+### UI
+
+- **NavigationStack** con titulo "Formularios"
+- **List** con cada link mostrando:
+  - Label o "Sin etiqueta"
+  - Status badge (Activo/Usado/Expirado)
+  - Fecha de expiracion
+  - Para links usados: link al evento resultante
+- **Toolbar button** "Generar Enlace" → sheet con:
+  - TextField para label (opcional)
+  - Stepper para TTL (1-30 dias)
+  - Boton crear
+- **Swipe actions:**
+  - Compartir (UIActivityViewController)
+  - Copiar URL
+  - Eliminar (solo activos)
+- **Context menu** con las mismas acciones
+
+### Compartir
+
+Usa `UIActivityViewController` / `ShareLink` (SwiftUI) para:
+- iMessage
+- WhatsApp
+- Email
+- Copiar link
+
+---
+
+## Navegacion
+
+Agregar como tab o seccion accesible desde:
+- Navigation sidebar (iPad) / tab o menu (iPhone)
+- O como boton en la vista de Clientes (contexto: "adquirir nuevo cliente")
+
+---
+
+> [!tip] Navegacion
+> El formulario que llena el cliente es web-only ([[Módulo Formularios Compartibles|Web]]). iOS solo gestiona la creacion de enlaces. Cuando el cliente envia el form, aparece un nuevo evento en [[Módulo Eventos]] y un nuevo cliente en [[Módulo Clientes]].

--- a/obsidian/Solennix/iOS/iOS MOC.md
+++ b/obsidian/Solennix/iOS/iOS MOC.md
@@ -45,6 +45,7 @@
 | Vista de calendario | [[Módulo Calendario]] |
 | Configuración y perfil | [[Módulo Settings]] |
 | Generación de PDFs | [[Sistema de PDFs]] |
+| Formularios compartibles | [[Módulo Formularios Compartibles]] |
 
 ## Calidad
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,6 +46,9 @@ const InventoryDetails = React.lazy(() => import("@/pages/Inventory/InventoryDet
 
 const CalendarView = React.lazy(() => import("@/pages/Calendar/CalendarView").then((m) => ({ default: m.CalendarView })));
 const QuickQuotePage = React.lazy(() => import("@/pages/QuickQuote/QuickQuotePage").then((m) => ({ default: m.QuickQuotePage })));
+const PublicEventFormPage = React.lazy(() => import("@/pages/PublicEventForm/PublicEventFormPage").then((m) => ({ default: m.PublicEventFormPage })));
+
+const EventFormLinksPage = React.lazy(() => import("@/pages/EventForms/EventFormLinksPage").then((m) => ({ default: m.EventFormLinksPage })));
 
 const AdminDashboard = React.lazy(() => import("@/pages/Admin/AdminDashboard").then((m) => ({ default: m.AdminDashboard })));
 const AdminUsers = React.lazy(() => import("@/pages/Admin/AdminUsers").then((m) => ({ default: m.AdminUsers })));
@@ -76,6 +79,7 @@ function App() {
               <Route path="/about" element={<About />} />
               <Route path="/privacy" element={<Privacy />} />
               <Route path="/terms" element={<Terms />} />
+              <Route path="/form/:token" element={<PublicEventFormPage />} />
 
               <Route
                 element={
@@ -110,6 +114,7 @@ function App() {
                 <Route path="/inventory/:id" element={<InventoryDetails />} />
                 <Route path="/inventory/:id/edit" element={<InventoryForm />} />
 
+                <Route path="/event-forms" element={<EventFormLinksPage />} />
                 <Route path="/settings" element={<Settings />} />
 
                 <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -16,7 +16,8 @@ import {
   Sun,
   Shield,
   ChevronsLeft,
-  ChevronsRight
+  ChevronsRight,
+  Link2
 } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/hooks/useTheme';
@@ -81,6 +82,7 @@ export const Layout: React.FC = () => {
     { name: 'Clientes', href: '/clients', icon: Users },
     { name: 'Productos', href: '/products', icon: Package },
     { name: 'Inventario', href: '/inventory', icon: Boxes },
+    { name: 'Formularios', href: '/event-forms', icon: Link2 },
     { name: 'Configuración', href: '/settings', icon: Settings },
     // Admin link — only visible to admins
     ...(user?.role === 'admin' ? [{ name: 'Admin', href: '/admin', icon: Shield }] : []),

--- a/web/src/hooks/queries/queryKeys.ts
+++ b/web/src/hooks/queries/queryKeys.ts
@@ -50,5 +50,8 @@ export const queryKeys = {
     users: ['admin', 'users'] as const,
     stats: ['admin', 'stats'] as const,
   },
+  eventFormLinks: {
+    all: ['eventFormLinks'] as const,
+  },
   planLimits: ['planLimits'] as const,
 } as const;

--- a/web/src/hooks/queries/useEventFormQueries.ts
+++ b/web/src/hooks/queries/useEventFormQueries.ts
@@ -1,0 +1,31 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { eventFormService } from '@/services/eventFormService'
+import { queryKeys } from './queryKeys'
+
+export function useEventFormLinks() {
+    return useQuery({
+        queryKey: queryKeys.eventFormLinks.all,
+        queryFn: () => eventFormService.listLinks(),
+    })
+}
+
+export function useGenerateLink() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: ({ label, ttlDays }: { label?: string; ttlDays?: number }) =>
+            eventFormService.generateLink(label, ttlDays),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.eventFormLinks.all })
+        },
+    })
+}
+
+export function useDeleteLink() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: (id: string) => eventFormService.deleteLink(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.eventFormLinks.all })
+        },
+    })
+}

--- a/web/src/pages/EventForms/EventFormLinksPage.tsx
+++ b/web/src/pages/EventForms/EventFormLinksPage.tsx
@@ -1,0 +1,314 @@
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Link2,
+  Plus,
+  Copy,
+  Share2,
+  Trash2,
+  ExternalLink,
+  Check,
+  Clock,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+  Calendar,
+} from "lucide-react";
+import {
+  useEventFormLinks,
+  useGenerateLink,
+  useDeleteLink,
+} from "@/hooks/queries/useEventFormQueries";
+import { useToast } from "@/hooks/useToast";
+import type { EventFormLink } from "@/types/entities";
+
+export const EventFormLinksPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+  const { data: links, isLoading } = useEventFormLinks();
+  const generateLink = useGenerateLink();
+  const deleteLink = useDeleteLink();
+
+  const [showDialog, setShowDialog] = useState(false);
+  const [label, setLabel] = useState("");
+  const [ttlDays, setTtlDays] = useState(7);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const handleGenerate = async () => {
+    try {
+      await generateLink.mutateAsync({
+        label: label.trim() || undefined,
+        ttlDays,
+      });
+      addToast("Enlace creado", "success");
+      setShowDialog(false);
+      setLabel("");
+      setTtlDays(7);
+    } catch {
+      addToast("Error al crear enlace", "error");
+    }
+  };
+
+  const handleCopy = async (url: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(id);
+      addToast("Enlace copiado", "success");
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch {
+      addToast("No se pudo copiar", "error");
+    }
+  };
+
+  const handleShare = async (url: string, label?: string) => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: "Formulario de evento",
+          text: label
+            ? `Formulario: ${label}`
+            : "Llena los datos de tu evento",
+          url,
+        });
+      } catch {
+        // User cancelled
+      }
+    } else {
+      handleCopy(url, "share");
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("¿Revocar este enlace? Ya no podrá ser utilizado.")) return;
+    try {
+      await deleteLink.mutateAsync(id);
+      addToast("Enlace revocado", "success");
+    } catch {
+      addToast("Error al revocar", "error");
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    return new Date(dateStr).toLocaleDateString("es-MX", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  const getStatusBadge = (link: EventFormLink) => {
+    switch (link.status) {
+      case "active":
+        return (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-success/10 text-success">
+            <Clock className="h-3 w-3" />
+            Activo
+          </span>
+        );
+      case "used":
+        return (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-info/10 text-info">
+            <CheckCircle2 className="h-3 w-3" />
+            Usado
+          </span>
+        );
+      case "expired":
+        return (
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-text-tertiary/10 text-text-tertiary">
+            <XCircle className="h-3 w-3" />
+            Expirado
+          </span>
+        );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-text tracking-tight">
+            Formularios
+          </h1>
+          <p className="text-sm text-text-secondary mt-1">
+            Genera enlaces para que tus clientes llenen datos de su evento
+          </p>
+        </div>
+        <button
+          onClick={() => setShowDialog(true)}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl premium-gradient text-white font-medium text-sm shadow-lg shadow-primary/20 hover:shadow-xl hover:shadow-primary/30 transition-all hover:scale-[1.02]"
+        >
+          <Plus className="h-4 w-4" />
+          Generar enlace
+        </button>
+      </div>
+
+      {/* Links list */}
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      ) : !links || links.length === 0 ? (
+        <div className="text-center py-16 bg-card rounded-2xl border border-border">
+          <Link2 className="h-12 w-12 text-text-tertiary mx-auto mb-4" />
+          <h3 className="text-lg font-semibold text-text mb-2">
+            Sin formularios
+          </h3>
+          <p className="text-sm text-text-secondary mb-6 max-w-sm mx-auto">
+            Genera un enlace compartible para que tus clientes potenciales
+            llenen los datos de su evento y seleccionen productos.
+          </p>
+          <button
+            onClick={() => setShowDialog(true)}
+            className="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl premium-gradient text-white font-medium text-sm"
+          >
+            <Plus className="h-4 w-4" />
+            Crear primer enlace
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {links.map((link) => (
+            <div
+              key={link.id}
+              className="bg-card rounded-xl border border-border p-4 flex flex-col sm:flex-row sm:items-center gap-3"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <p className="text-sm font-semibold text-text truncate">
+                    {link.label || "Sin etiqueta"}
+                  </p>
+                  {getStatusBadge(link)}
+                </div>
+
+                <div className="flex items-center gap-3 text-xs text-text-secondary">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="h-3 w-3" />
+                    Expira: {formatDate(link.expires_at)}
+                  </span>
+                  {link.used_at && (
+                    <span>Usado: {formatDate(link.used_at)}</span>
+                  )}
+                </div>
+
+                {link.status === "active" && (
+                  <p className="text-xs text-text-tertiary mt-1 truncate font-mono">
+                    {link.url}
+                  </p>
+                )}
+              </div>
+
+              <div className="flex items-center gap-2 shrink-0">
+                {link.status === "active" && (
+                  <>
+                    <button
+                      onClick={() => handleCopy(link.url, link.id)}
+                      className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border text-sm text-text-secondary hover:bg-surface-alt transition-colors"
+                      title="Copiar enlace"
+                    >
+                      {copiedId === link.id ? (
+                        <Check className="h-4 w-4 text-success" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                      <span className="hidden sm:inline">Copiar</span>
+                    </button>
+                    <button
+                      onClick={() => handleShare(link.url, link.label)}
+                      className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border text-sm text-text-secondary hover:bg-surface-alt transition-colors"
+                      title="Compartir"
+                    >
+                      <Share2 className="h-4 w-4" />
+                      <span className="hidden sm:inline">Compartir</span>
+                    </button>
+                    <button
+                      onClick={() => handleDelete(link.id)}
+                      className="inline-flex items-center px-3 py-2 rounded-lg border border-border text-sm text-error/70 hover:bg-error/5 hover:text-error transition-colors"
+                      title="Revocar"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </>
+                )}
+
+                {link.status === "used" && link.submitted_event_id && (
+                  <button
+                    onClick={() =>
+                      navigate(
+                        `/events/${link.submitted_event_id}/summary`
+                      )
+                    }
+                    className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border text-sm text-text-secondary hover:bg-surface-alt transition-colors"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    Ver evento
+                  </button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Generate Dialog (Modal) */}
+      {showDialog && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+          <div className="bg-card rounded-2xl border border-border p-6 w-full max-w-md space-y-4 shadow-xl">
+            <h2 className="text-lg font-bold text-text">Generar enlace</h2>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Etiqueta (opcional)
+              </label>
+              <input
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="Ej: Boda de María y Pedro"
+                className="w-full px-4 py-3 rounded-xl border border-border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Válido por: {ttlDays} día{ttlDays !== 1 ? "s" : ""}
+              </label>
+              <input
+                type="range"
+                min={1}
+                max={30}
+                value={ttlDays}
+                onChange={(e) => setTtlDays(Number(e.target.value))}
+                className="w-full accent-primary"
+              />
+              <div className="flex justify-between text-xs text-text-tertiary mt-1">
+                <span>1 día</span>
+                <span>30 días</span>
+              </div>
+            </div>
+
+            <div className="flex gap-3 pt-2">
+              <button
+                onClick={() => setShowDialog(false)}
+                className="flex-1 px-4 py-2.5 rounded-xl border border-border text-sm font-medium text-text hover:bg-surface-alt transition-colors"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handleGenerate}
+                disabled={generateLink.isPending}
+                className="flex-1 px-4 py-2.5 rounded-xl premium-gradient text-white text-sm font-medium disabled:opacity-60"
+              >
+                {generateLink.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin mx-auto" />
+                ) : (
+                  "Crear"
+                )}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/pages/PublicEventForm/PublicEventFormPage.tsx
+++ b/web/src/pages/PublicEventForm/PublicEventFormPage.tsx
@@ -1,0 +1,549 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Calendar,
+  MapPin,
+  Users,
+  FileText,
+  User,
+  Phone,
+  Mail,
+  Send,
+  Loader2,
+  Minus,
+  Plus,
+  Package,
+} from "lucide-react";
+import { PublicFormExpired } from "./components/PublicFormExpired";
+import { PublicFormSuccess } from "./components/PublicFormSuccess";
+import { PublicProductCard } from "./components/PublicProductCard";
+
+interface PublicProduct {
+  id: string;
+  name: string;
+  category: string;
+  image_url?: string;
+}
+
+interface Organizer {
+  business_name?: string;
+  logo_url?: string;
+  brand_color?: string;
+}
+
+interface FormData {
+  organizer: Organizer;
+  products: PublicProduct[];
+  link_id: string;
+  expires_at: string;
+}
+
+interface SelectedProduct {
+  product_id: string;
+  quantity: number;
+}
+
+const schema = z.object({
+  client_name: z.string().min(2, "El nombre es requerido"),
+  client_phone: z.string().min(7, "El teléfono es requerido"),
+  client_email: z.string().email("Email inválido").optional().or(z.literal("")),
+  event_date: z.string().min(1, "La fecha es requerida"),
+  service_type: z.string().min(1, "El tipo de evento es requerido"),
+  num_people: z.coerce.number().min(1, "Mínimo 1 persona"),
+  location: z.string().optional(),
+  city: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8080/api";
+
+export const PublicEventFormPage: React.FC = () => {
+  const { token } = useParams<{ token: string }>();
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [formData, setFormData] = useState<FormData | null>(null);
+  const [expired, setExpired] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [selectedProducts, setSelectedProducts] = useState<
+    Map<string, number>
+  >(new Map());
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      num_people: 50,
+    },
+  });
+
+  useEffect(() => {
+    if (!token) return;
+    fetchFormData();
+  }, [token]);
+
+  const fetchFormData = async () => {
+    try {
+      const res = await fetch(
+        `${API_BASE}/public/event-forms/${token}`
+      );
+      if (!res.ok) {
+        setExpired(true);
+        return;
+      }
+      const data: FormData = await res.json();
+      setFormData(data);
+    } catch {
+      setExpired(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleProduct = (productId: string) => {
+    setSelectedProducts((prev) => {
+      const next = new Map(prev);
+      if (next.has(productId)) {
+        next.delete(productId);
+      } else {
+        next.set(productId, 1);
+      }
+      return next;
+    });
+  };
+
+  const updateQuantity = (productId: string, delta: number) => {
+    setSelectedProducts((prev) => {
+      const next = new Map(prev);
+      const current = next.get(productId) || 1;
+      const newQty = Math.max(1, current + delta);
+      next.set(productId, newQty);
+      return next;
+    });
+  };
+
+  const setQuantity = (productId: string, qty: number) => {
+    setSelectedProducts((prev) => {
+      const next = new Map(prev);
+      next.set(productId, Math.max(1, qty));
+      return next;
+    });
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    if (!token) return;
+    setSubmitting(true);
+    setSubmitError(null);
+
+    const products: SelectedProduct[] = [];
+    selectedProducts.forEach((quantity, product_id) => {
+      products.push({ product_id, quantity });
+    });
+
+    try {
+      const res = await fetch(
+        `${API_BASE}/public/event-forms/${token}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...values,
+            client_email: values.client_email || undefined,
+            num_people: Number(values.num_people),
+            products,
+          }),
+        }
+      );
+
+      if (res.status === 410 || res.status === 409) {
+        setExpired(true);
+        return;
+      }
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        setSubmitError(
+          data?.error || "Hubo un error al enviar. Intenta de nuevo."
+        );
+        return;
+      }
+      setSuccess(true);
+    } catch {
+      setSubmitError("Error de conexión. Verifica tu internet e intenta de nuevo.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const brandColor = formData?.organizer.brand_color || "#C4A265";
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (expired) {
+    return <PublicFormExpired />;
+  }
+
+  if (success) {
+    return (
+      <PublicFormSuccess
+        organizerName={formData?.organizer.business_name}
+        brandColor={brandColor}
+      />
+    );
+  }
+
+  if (!formData) {
+    return <PublicFormExpired />;
+  }
+
+  // Group products by category
+  const categories = formData.products.reduce(
+    (acc, p) => {
+      const cat = p.category || "General";
+      if (!acc[cat]) acc[cat] = [];
+      acc[cat].push(p);
+      return acc;
+    },
+    {} as Record<string, PublicProduct[]>
+  );
+
+  return (
+    <div className="min-h-screen bg-bg">
+      {/* Header */}
+      <header
+        className="sticky top-0 z-10 border-b border-border backdrop-blur-md"
+        style={{ backgroundColor: `${brandColor}10` }}
+      >
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center gap-3">
+          {formData.organizer.logo_url && (
+            <img
+              src={formData.organizer.logo_url}
+              alt=""
+              className="h-10 w-10 rounded-full object-cover border-2"
+              style={{ borderColor: brandColor }}
+            />
+          )}
+          <div>
+            <h1 className="text-lg font-bold text-text">
+              {formData.organizer.business_name || "Formulario de Evento"}
+            </h1>
+            <p className="text-xs text-text-secondary">
+              Cuéntanos sobre tu evento
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="max-w-3xl mx-auto px-4 py-6 space-y-8"
+      >
+        {/* Error */}
+        {submitError && (
+          <div className="bg-error/5 border border-error/30 text-error rounded-xl p-4 text-sm">
+            {submitError}
+          </div>
+        )}
+
+        {/* Section: Client Info */}
+        <section className="bg-card rounded-2xl border border-border p-6 space-y-4">
+          <h2
+            className="text-base font-bold flex items-center gap-2"
+            style={{ color: brandColor }}
+          >
+            <User className="h-5 w-5" />
+            Tus datos
+          </h2>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Nombre *
+              </label>
+              <div className="relative">
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("client_name")}
+                  placeholder="Tu nombre completo"
+                  className={`w-full pl-10 pr-4 py-3 rounded-xl border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:border-transparent transition-colors ${
+                    errors.client_name
+                      ? "border-error/30"
+                      : "border-border"
+                  }`}
+                  style={
+                    errors.client_name
+                      ? undefined
+                      : { "--tw-ring-color": `${brandColor}40` } as React.CSSProperties
+                  }
+                />
+              </div>
+              {errors.client_name && (
+                <p className="mt-1 text-xs text-error">
+                  {errors.client_name.message}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Teléfono *
+              </label>
+              <div className="relative">
+                <Phone className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("client_phone")}
+                  type="tel"
+                  placeholder="Tu número de teléfono"
+                  className={`w-full pl-10 pr-4 py-3 rounded-xl border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:border-transparent transition-colors ${
+                    errors.client_phone
+                      ? "border-error/30"
+                      : "border-border"
+                  }`}
+                />
+              </div>
+              {errors.client_phone && (
+                <p className="mt-1 text-xs text-error">
+                  {errors.client_phone.message}
+                </p>
+              )}
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Email
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("client_email")}
+                  type="email"
+                  placeholder="tu@email.com (opcional)"
+                  className="w-full pl-10 pr-4 py-3 rounded-xl border border-border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors"
+                />
+              </div>
+              {errors.client_email && (
+                <p className="mt-1 text-xs text-error">
+                  {errors.client_email.message}
+                </p>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Section: Event Details */}
+        <section className="bg-card rounded-2xl border border-border p-6 space-y-4">
+          <h2
+            className="text-base font-bold flex items-center gap-2"
+            style={{ color: brandColor }}
+          >
+            <Calendar className="h-5 w-5" />
+            Detalles del evento
+          </h2>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Fecha del evento *
+              </label>
+              <div className="relative">
+                <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("event_date")}
+                  type="date"
+                  className={`w-full pl-10 pr-4 py-3 rounded-xl border text-sm bg-card text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors ${
+                    errors.event_date ? "border-error/30" : "border-border"
+                  }`}
+                />
+              </div>
+              {errors.event_date && (
+                <p className="mt-1 text-xs text-error">
+                  {errors.event_date.message}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Tipo de evento *
+              </label>
+              <div className="relative">
+                <FileText className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("service_type")}
+                  placeholder="Boda, XV Años, Corporativo..."
+                  className={`w-full pl-10 pr-4 py-3 rounded-xl border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors ${
+                    errors.service_type ? "border-error/30" : "border-border"
+                  }`}
+                />
+              </div>
+              {errors.service_type && (
+                <p className="mt-1 text-xs text-error">
+                  {errors.service_type.message}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Número de personas *
+              </label>
+              <div className="relative">
+                <Users className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("num_people")}
+                  type="number"
+                  min={1}
+                  placeholder="150"
+                  className={`w-full pl-10 pr-4 py-3 rounded-xl border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors ${
+                    errors.num_people ? "border-error/30" : "border-border"
+                  }`}
+                />
+              </div>
+              {errors.num_people && (
+                <p className="mt-1 text-xs text-error">
+                  {errors.num_people.message}
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Ubicación
+              </label>
+              <div className="relative">
+                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("location")}
+                  placeholder="Salón, jardín, dirección..."
+                  className="w-full pl-10 pr-4 py-3 rounded-xl border border-border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Ciudad
+              </label>
+              <div className="relative">
+                <MapPin className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary" />
+                <input
+                  {...register("city")}
+                  placeholder="Ciudad"
+                  className="w-full pl-10 pr-4 py-3 rounded-xl border border-border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors"
+                />
+              </div>
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-medium text-text mb-1.5">
+                Notas o comentarios
+              </label>
+              <textarea
+                {...register("notes")}
+                rows={3}
+                placeholder="Cuéntanos más sobre lo que tienes en mente..."
+                className="w-full px-4 py-3 rounded-xl border border-border text-sm bg-card text-text placeholder-text-tertiary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent transition-colors resize-none"
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Section: Products */}
+        {formData.products.length > 0 && (
+          <section className="bg-card rounded-2xl border border-border p-6 space-y-4">
+            <h2
+              className="text-base font-bold flex items-center gap-2"
+              style={{ color: brandColor }}
+            >
+              <Package className="h-5 w-5" />
+              Selecciona lo que necesitas
+            </h2>
+            <p className="text-sm text-text-secondary">
+              Selecciona los productos que te interesan e indica la cantidad.
+            </p>
+
+            {Object.entries(categories).map(([category, products]) => (
+              <div key={category} className="space-y-3">
+                <h3 className="text-sm font-semibold text-text-secondary uppercase tracking-wide">
+                  {category}
+                </h3>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  {products.map((product) => {
+                    const isSelected = selectedProducts.has(product.id);
+                    const quantity = selectedProducts.get(product.id) || 0;
+                    return (
+                      <PublicProductCard
+                        key={product.id}
+                        product={product}
+                        isSelected={isSelected}
+                        quantity={quantity}
+                        brandColor={brandColor}
+                        onToggle={() => toggleProduct(product.id)}
+                        onIncrement={() => updateQuantity(product.id, 1)}
+                        onDecrement={() => updateQuantity(product.id, -1)}
+                        onQuantityChange={(qty) =>
+                          setQuantity(product.id, qty)
+                        }
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* Summary */}
+        {selectedProducts.size > 0 && (
+          <div className="bg-surface-alt rounded-xl border border-border p-4">
+            <p className="text-sm font-medium text-text">
+              {selectedProducts.size} producto
+              {selectedProducts.size !== 1 ? "s" : ""} seleccionado
+              {selectedProducts.size !== 1 ? "s" : ""}
+            </p>
+          </div>
+        )}
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full flex items-center justify-center gap-2 text-white py-4 rounded-xl font-bold text-sm shadow-lg transition-all hover:scale-[1.01] disabled:opacity-60 disabled:cursor-not-allowed disabled:scale-100"
+          style={{
+            background: `linear-gradient(135deg, ${brandColor} 0%, ${brandColor}CC 100%)`,
+            boxShadow: `0 10px 25px -5px ${brandColor}40`,
+          }}
+        >
+          {submitting ? (
+            <>
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Enviando...
+            </>
+          ) : (
+            <>
+              <Send className="h-5 w-5" />
+              Enviar solicitud
+            </>
+          )}
+        </button>
+
+        <p className="text-center text-xs text-text-tertiary">
+          Tu información será enviada de forma segura al organizador.
+        </p>
+      </form>
+    </div>
+  );
+};

--- a/web/src/pages/PublicEventForm/components/PublicFormExpired.tsx
+++ b/web/src/pages/PublicEventForm/components/PublicFormExpired.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Clock, AlertCircle } from "lucide-react";
+
+export const PublicFormExpired: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-bg flex items-center justify-center p-4">
+      <div className="max-w-md w-full text-center space-y-6">
+        <div className="mx-auto w-16 h-16 rounded-2xl bg-warning/10 flex items-center justify-center">
+          <Clock className="h-8 w-8 text-warning" />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-text tracking-tight">
+            Enlace no disponible
+          </h1>
+          <p className="text-text-secondary text-sm leading-relaxed">
+            Este enlace ya fue utilizado o ha expirado. Contacta al organizador
+            para solicitar uno nuevo.
+          </p>
+        </div>
+
+        <div className="bg-surface-alt rounded-xl border border-border p-4 flex items-start gap-3">
+          <AlertCircle className="h-5 w-5 text-text-tertiary shrink-0 mt-0.5" />
+          <p className="text-xs text-text-secondary text-left">
+            Los enlaces de formulario son de un solo uso y tienen una fecha de
+            expiración para proteger tu seguridad.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/src/pages/PublicEventForm/components/PublicFormSuccess.tsx
+++ b/web/src/pages/PublicEventForm/components/PublicFormSuccess.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { CheckCircle2, PartyPopper } from "lucide-react";
+
+interface Props {
+  organizerName?: string;
+  brandColor: string;
+}
+
+export const PublicFormSuccess: React.FC<Props> = ({
+  organizerName,
+  brandColor,
+}) => {
+  return (
+    <div className="min-h-screen bg-bg flex items-center justify-center p-4">
+      <div className="max-w-md w-full text-center space-y-6">
+        <div
+          className="mx-auto w-16 h-16 rounded-2xl flex items-center justify-center"
+          style={{ backgroundColor: `${brandColor}15` }}
+        >
+          <CheckCircle2
+            className="h-8 w-8"
+            style={{ color: brandColor }}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold text-text tracking-tight">
+            ¡Solicitud enviada!
+          </h1>
+          <p className="text-text-secondary text-sm leading-relaxed">
+            {organizerName ? (
+              <>
+                <span className="font-medium text-text">{organizerName}</span>{" "}
+                ha recibido tu información y se pondrá en contacto contigo
+                pronto.
+              </>
+            ) : (
+              "El organizador ha recibido tu información y se pondrá en contacto contigo pronto."
+            )}
+          </p>
+        </div>
+
+        <div
+          className="rounded-xl p-4 flex items-center justify-center gap-2 text-sm"
+          style={{
+            backgroundColor: `${brandColor}10`,
+            color: brandColor,
+          }}
+        >
+          <PartyPopper className="h-5 w-5" />
+          <span className="font-medium">
+            Gracias por tu interés
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/src/pages/PublicEventForm/components/PublicProductCard.tsx
+++ b/web/src/pages/PublicEventForm/components/PublicProductCard.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { Check, Minus, Plus } from "lucide-react";
+
+interface PublicProduct {
+  id: string;
+  name: string;
+  category: string;
+  image_url?: string;
+}
+
+interface Props {
+  product: PublicProduct;
+  isSelected: boolean;
+  quantity: number;
+  brandColor: string;
+  onToggle: () => void;
+  onIncrement: () => void;
+  onDecrement: () => void;
+  onQuantityChange: (qty: number) => void;
+}
+
+export const PublicProductCard: React.FC<Props> = ({
+  product,
+  isSelected,
+  quantity,
+  brandColor,
+  onToggle,
+  onIncrement,
+  onDecrement,
+  onQuantityChange,
+}) => {
+  return (
+    <div
+      className={`rounded-xl border p-3 transition-all cursor-pointer ${
+        isSelected
+          ? "border-2 shadow-sm"
+          : "border-border bg-card hover:border-border-strong"
+      }`}
+      style={
+        isSelected
+          ? { borderColor: brandColor, backgroundColor: `${brandColor}08` }
+          : undefined
+      }
+      onClick={() => {
+        if (!isSelected) onToggle();
+      }}
+    >
+      <div className="flex gap-3">
+        {/* Image or placeholder */}
+        {product.image_url ? (
+          <img
+            src={product.image_url}
+            alt={product.name}
+            className="h-16 w-16 rounded-lg object-cover shrink-0"
+          />
+        ) : (
+          <div
+            className="h-16 w-16 rounded-lg shrink-0 flex items-center justify-center text-white text-lg font-bold"
+            style={{ backgroundColor: `${brandColor}30` }}
+          >
+            {product.name.charAt(0).toUpperCase()}
+          </div>
+        )}
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-text truncate">
+                {product.name}
+              </p>
+              <p className="text-xs text-text-secondary">{product.category}</p>
+            </div>
+
+            {/* Checkbox */}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onToggle();
+              }}
+              className={`shrink-0 h-6 w-6 rounded-md border-2 flex items-center justify-center transition-colors ${
+                isSelected ? "text-white" : "border-border"
+              }`}
+              style={
+                isSelected
+                  ? { backgroundColor: brandColor, borderColor: brandColor }
+                  : undefined
+              }
+            >
+              {isSelected && <Check className="h-4 w-4" />}
+            </button>
+          </div>
+
+          {/* Quantity picker */}
+          {isSelected && (
+            <div
+              className="flex items-center gap-2 mt-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <span className="text-xs text-text-secondary">Cantidad:</span>
+              <div className="flex items-center rounded-lg border border-border overflow-hidden">
+                <button
+                  type="button"
+                  onClick={onDecrement}
+                  className="px-2 py-1 hover:bg-surface-alt transition-colors text-text-secondary"
+                  disabled={quantity <= 1}
+                >
+                  <Minus className="h-3 w-3" />
+                </button>
+                <input
+                  type="number"
+                  min={1}
+                  value={quantity}
+                  onChange={(e) =>
+                    onQuantityChange(parseInt(e.target.value) || 1)
+                  }
+                  className="w-12 text-center text-sm bg-card text-text border-x border-border py-1 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={onIncrement}
+                  className="px-2 py-1 hover:bg-surface-alt transition-colors text-text-secondary"
+                >
+                  <Plus className="h-3 w-3" />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/src/services/eventFormService.ts
+++ b/web/src/services/eventFormService.ts
@@ -1,0 +1,16 @@
+import { api } from '@/lib/api'
+import type { EventFormLink } from '@/types/entities'
+
+export const eventFormService = {
+    async generateLink(label?: string, ttlDays?: number): Promise<EventFormLink> {
+        return api.post<EventFormLink>('/event-forms', { label, ttl_days: ttlDays })
+    },
+
+    async listLinks(): Promise<EventFormLink[]> {
+        return api.get<EventFormLink[]>('/event-forms')
+    },
+
+    async deleteLink(id: string): Promise<void> {
+        return api.delete(`/event-forms/${id}`)
+    },
+}

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -158,6 +158,22 @@ export type Payment = components['schemas']['Payment']
 export type PaymentInsert = Omit<Payment, 'id' | 'user_id' | 'created_at'>
 export type PaymentUpdate = Partial<PaymentInsert>
 
+// ===== Event Form Link =====
+export interface EventFormLink {
+    id: string
+    user_id: string
+    token: string
+    label?: string
+    status: 'active' | 'used' | 'expired'
+    submitted_event_id?: string
+    submitted_client_id?: string
+    url: string
+    expires_at: string
+    used_at?: string
+    created_at: string
+    updated_at: string
+}
+
 // ===== Pagination =====
 // Wrapper genérico — el spec declara PaginatedXxxResponse concretos por
 // entidad. El Web usa PaginatedResponse<T> genéricamente para reutilizar


### PR DESCRIPTION
Organizers can generate temporary, single-use links that prospective
clients open in a browser to fill out event details and select products
(without seeing prices). On submission, a draft event + new client record
are created for the organizer.

Backend:
- Migration 038: event_form_links table with token, status, TTL
- EventFormLink model, repository (with atomic MarkUsed for race safety)
- EventFormHandler with public (GetFormData, SubmitForm) and
  authenticated (GenerateLink, ListLinks, DeleteLink) endpoints
- Router: /api/public/event-forms/{token} (rate-limited 10/min)
  and /api/event-forms (authenticated)
- Background job to expire stale links hourly

Web:
- PublicEventFormPage at /form/:token — branded, responsive, no auth
- PublicProductCard, PublicFormExpired, PublicFormSuccess components
- EventFormLinksPage at /event-forms — link management UI with
  generate dialog, copy/share/revoke, status badges
- eventFormService + React Query hooks
- Sidebar nav item "Formularios" with Link2 icon

iOS:
- EventFormLink model (SolennixCore)
- Endpoints for /event-forms (SolennixNetwork)
- EventFormLinksViewModel + EventFormLinksView (SolennixFeatures)

Android:
- EventFormLink data class (core/model)
- Endpoint constants (core/network)

Docs:
- Obsidian: Módulo Formularios Compartibles for all 4 platforms
- Updated MOCs, Seguridad, PRD/02_FEATURES with parity table

Security: crypto/rand 256-bit tokens, PublicProduct DTO strips prices,
atomic double-submission prevention, 10/min rate limit on public endpoints

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_019jSwVbJhFdm9LF81Xd9LPx