### PR TITLE
Persist product names in event products entity

### DIFF
--- a/PRD/11_CURRENT_STATUS.md
+++ b/PRD/11_CURRENT_STATUS.md
@@ -1,6 +1,6 @@
 # Current Status — Solennix
 
-**Last Updated:** 2026-04-12  
+**Last Updated:** 2026-04-15  
 **Status:** Core authentication complete across all platforms. Ready for next phase.
 
 ---
@@ -61,6 +61,10 @@ All authentication flows work identically across platforms.
 ## Known Issues
 
 None. All sign-in methods fully functional.
+
+### Resolved
+
+- **Android — Contract product names (2026-04-15):** El template de contrato renderizaba `"<cantidad> Producto"` en `[Servicios del evento]` porque la entidad Room `CachedEventProduct` no persistía la columna `product_name` devuelta por el backend. Fix: añadida columna + migración 5→6, y la UI ahora consume `EventProduct.productName` directo (eliminado el workaround `productNames` map en `EventDetailViewModel`).
 
 ---
 

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/SolennixDatabase.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/SolennixDatabase.kt
@@ -35,7 +35,7 @@ const val DATABASE_NAME = "solennix-database"
         CachedEventProduct::class,
         CachedEventExtra::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(JsonConverters::class)
@@ -56,7 +56,14 @@ abstract class SolennixDatabase : RoomDatabase() {
             }
         }
 
-        private val ALL_MIGRATIONS = arrayOf(MIGRATION_4_5)
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                Log.d(TAG, "Running migration 5 -> 6: add product_name to event_products")
+                db.execSQL("ALTER TABLE event_products ADD COLUMN product_name TEXT")
+            }
+        }
+
+        private val ALL_MIGRATIONS = arrayOf(MIGRATION_4_5, MIGRATION_5_6)
 
         @Volatile
         private var INSTANCE: SolennixDatabase? = null

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/entity/CachedEventProduct.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/entity/CachedEventProduct.kt
@@ -14,7 +14,8 @@ data class CachedEventProduct(
     @ColumnInfo(name = "unit_price") val unitPrice: Double,
     val discount: Double,
     @ColumnInfo(name = "total_price") val totalPrice: Double?,
-    @ColumnInfo(name = "created_at") val createdAt: String
+    @ColumnInfo(name = "created_at") val createdAt: String,
+    @ColumnInfo(name = "product_name") val productName: String? = null
 )
 
 fun CachedEventProduct.asExternalModel() = EventProduct(
@@ -25,7 +26,8 @@ fun CachedEventProduct.asExternalModel() = EventProduct(
     unitPrice = unitPrice,
     discount = discount,
     totalPrice = totalPrice,
-    createdAt = createdAt
+    createdAt = createdAt,
+    productName = productName
 )
 
 fun EventProduct.asEntity() = CachedEventProduct(
@@ -36,5 +38,6 @@ fun EventProduct.asEntity() = CachedEventProduct(
     unitPrice = unitPrice,
     discount = discount,
     totalPrice = totalPrice,
-    createdAt = createdAt
+    createdAt = createdAt,
+    productName = productName
 )

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailScreen.kt
@@ -604,8 +604,7 @@ private fun EventInfoRow(
 
 @Composable
 private fun ProductsSection(
-    products: List<EventProduct>,
-    productNames: Map<String, String>
+    products: List<EventProduct>
 ) {
     var expanded by remember { mutableStateOf(true) }
     val subtotal = products.sumOf { it.totalPrice ?: (it.quantity * it.unitPrice) }
@@ -648,7 +647,7 @@ private fun ProductsSection(
                 Column {
                     Spacer(modifier = Modifier.height(12.dp))
                     products.forEach { product ->
-                        val name = productNames[product.productId] ?: "Producto"
+                        val name = product.productName ?: "Producto"
                         val total = product.totalPrice ?: (product.quantity * product.unitPrice)
                         ProductRow(
                             name = name,

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailSubScreens.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailSubScreens.kt
@@ -463,7 +463,7 @@ fun EventProductsScreen(
                 }
 
                 products.forEach { product ->
-                    val name = uiState.productNames[product.productId] ?: "Producto"
+                    val name = product.productName ?: "Producto"
                     val total = product.totalPrice ?: (product.quantity * product.unitPrice)
                     Card(
                         modifier = Modifier.fillMaxWidth(),
@@ -1111,7 +1111,7 @@ private fun renderContractTemplate(
     val today = java.text.SimpleDateFormat("d 'de' MMMM, yyyy", java.util.Locale("es", "MX")).format(java.util.Date())
 
     val servicesList = if (products.isNotEmpty()) {
-        products.joinToString(", ") { "${it.quantity} ${it.productName ?: "Producto"}" }
+        products.joinToString(", ") { "${it.quantity.formatQuantity()} ${it.productName ?: "Producto"}" }
     } else null
 
     val tokens: List<Pair<String, String?>> = listOf(

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventDetailViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventDetailViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.viewModelScope
 import com.creapolis.solennix.core.data.repository.ClientRepository
 import com.creapolis.solennix.core.data.repository.EventRepository
 import com.creapolis.solennix.core.data.repository.PaymentRepository
-import com.creapolis.solennix.core.data.repository.ProductRepository
 import com.creapolis.solennix.core.data.util.ImageCompressor
 import com.creapolis.solennix.core.model.Client
 import com.creapolis.solennix.core.model.Event
@@ -37,7 +36,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -52,7 +50,6 @@ data class EventDetailUiState(
     val supplies: List<EventSupply> = emptyList(),
     val payments: List<Payment> = emptyList(),
     val photos: List<EventPhoto> = emptyList(),
-    val productNames: Map<String, String> = emptyMap(),
     val totalPaid: Double = 0.0,
     val currentUser: User? = null,
     val isLoading: Boolean = false,
@@ -66,7 +63,6 @@ class EventDetailViewModel @Inject constructor(
     private val eventRepository: EventRepository,
     private val clientRepository: ClientRepository,
     private val paymentRepository: PaymentRepository,
-    private val productRepository: ProductRepository,
     private val apiService: ApiService,
     private val authManager: AuthManager,
     private val eventDayNotificationManager: EventDayNotificationManager,
@@ -81,7 +77,6 @@ class EventDetailViewModel @Inject constructor(
     private val _client = MutableStateFlow<Client?>(null)
     private val _equipment = MutableStateFlow<List<EventEquipment>>(emptyList())
     private val _supplies = MutableStateFlow<List<EventSupply>>(emptyList())
-    private val _productNames = MutableStateFlow<Map<String, String>>(emptyMap())
     private val _photos = MutableStateFlow<List<EventPhoto>>(emptyList())
     private val _isPhotosLoading = MutableStateFlow(false)
     private val _isPhotoUploading = MutableStateFlow(false)
@@ -98,8 +93,7 @@ class EventDetailViewModel @Inject constructor(
         _isPhotosLoading,
         _isPhotoUploading,
         _equipment,
-        _supplies,
-        _productNames
+        _supplies
     ) { values ->
         val event = values[0] as Event?
         val client = values[1] as Client?
@@ -119,8 +113,6 @@ class EventDetailViewModel @Inject constructor(
         val equipment = values[10] as List<EventEquipment>
         @Suppress("UNCHECKED_CAST")
         val supplies = values[11] as List<EventSupply>
-        @Suppress("UNCHECKED_CAST")
-        val productNames = values[12] as Map<String, String>
 
         EventDetailUiState(
             event = event,
@@ -131,7 +123,6 @@ class EventDetailViewModel @Inject constructor(
             supplies = supplies,
             payments = payments,
             photos = photos,
-            productNames = productNames,
             totalPaid = payments.sumOf { it.amount },
             currentUser = authManager.currentUser.value,
             isLoading = isLoading,
@@ -183,9 +174,6 @@ class EventDetailViewModel @Inject constructor(
                 // Load equipment and supplies from API
                 loadEquipmentAndSupplies()
 
-                // Load product names for display
-                loadProductNames()
-
                 // Auto-mostrar notificacion persistente si el evento es hoy y confirmado
                 checkAndShowEventDayNotification(event, _client.value)
 
@@ -212,22 +200,6 @@ class EventDetailViewModel @Inject constructor(
         } catch (e: Exception) {
             // Non-fatal, supplies may not exist for this event
             _supplies.value = emptyList()
-        }
-    }
-
-    private suspend fun loadProductNames() {
-        try {
-            val namesMap = mutableMapOf<String, String>()
-            val products = eventRepository.getEventProducts(eventId).first()
-            for (product in products) {
-                val p = productRepository.getProduct(product.productId)
-                if (p != null) {
-                    namesMap[product.productId] = p.name
-                }
-            }
-            _productNames.value = namesMap
-        } catch (e: Exception) {
-            // Non-fatal
         }
     }
 


### PR DESCRIPTION
## Summary
Refactored product name handling in event contracts by persisting `product_name` directly in the `CachedEventProduct` database entity, eliminating the need for a separate lookup mechanism in the ViewModel.

## Key Changes
- **Database Migration:** Added `MIGRATION_5_6` to introduce `product_name` column to `event_products` table
- **Entity Update:** Added `productName` field to `CachedEventProduct` with corresponding mapper functions
- **ViewModel Cleanup:** 
  - Removed `ProductRepository` dependency and `loadProductNames()` method
  - Removed `_productNames` state flow and `productNames` from `EventDetailUiState`
  - Simplified `combine` flow by removing product name aggregation logic
- **UI Updates:**
  - `ProductsSection()` now reads `product.productName` directly instead of looking up from `productNames` map
  - `EventProductsScreen()` updated to use `product.productName` 
  - Contract template rendering now uses `product.productName` with proper quantity formatting
- **Documentation:** Updated status document to reflect the fix

## Implementation Details
The product name is now sourced from the backend response and persisted at the database layer, making it immediately available in the domain model without requiring additional repository queries. This simplifies the ViewModel logic and ensures the contract template always has access to product names for rendering.

https://claude.ai/code/session_01PAwdiRaWp6nqaAPwqrzQvM