### PR TITLE
fix(deploy): orphan-container cleanup + docker-compose hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,8 @@ jobs:
             git fetch origin main
             git checkout main
             git reset --hard origin/main
+            echo "→ Cleaning up orphan containers from previous compose versions"
+            docker rm -f solennix-frontend solennix-backend solennix-db 2>/dev/null || true
             echo "→ Rebuilding containers"
             if docker compose version >/dev/null 2>&1; then
               docker compose pull || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "${BACKEND_PORT:-8080}:8080"
+      - "127.0.0.1:${BACKEND_PORT:-8080}:8080"
     volumes:
       - uploads_data:/root/uploads
 
@@ -40,7 +40,7 @@ services:
     container_name: solennix-frontend
     restart: always
     ports:
-      - "${FRONTEND_PORT:-3000}:80"
+      - "127.0.0.1:${FRONTEND_PORT:-3000}:80"
 
   db:
     image: postgres:15-alpine
@@ -48,10 +48,10 @@ services:
     restart: always
     environment:
       POSTGRES_USER: ${DB_USER:-solennix_user}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-solennix_password}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD must be set}
       POSTGRES_DB: ${DB_NAME:-solennix}
-    ports:
-      - "5433:5432"
+    expose:
+      - "5432"
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
@@ -62,4 +62,8 @@ services:
 
 volumes:
   db_data:
+    external: true
+    name: solennix_db_data
   uploads_data:
+    external: true
+    name: solennix_uploads_data


### PR DESCRIPTION
## Contexto

El deploy del 2026-04-18 ([run 24613912426](https://github.com/tiagofur/eventosapp/actions/runs/24613912426/job/71972863006)) falló con:

```
Conflict. The container name "/solennix-frontend" is already in use by container "d9f4b3eba21a..."
```

El backend quedó caído ~4h hasta recuperarlo manualmente. Causa raíz: containers huérfanos (creados con un `project name` distinto antes de añadir `name: solennix` al compose) que `--remove-orphans` no detecta.

Aprovecho el mismo PR para cerrar issues de seguridad del compose detectados en la revisión.

## Cambios

### Commit 1 — `ci: remove orphan containers before compose up`
- Agrega `docker rm -f solennix-frontend solennix-backend solennix-db` antes del `compose up` en [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
- Idempotente (`|| true`), causa <2s de downtime por deploy.

### Commit 2 — `ops: harden docker-compose security`
En [docker-compose.yml](docker-compose.yml):
- **Loopback ports**: `backend` y `frontend` ahora bindean a `127.0.0.1` — Plesk proxy corre en el mismo host, no necesitan exposición pública.
- **DB sin puerto público**: removido `5433:5432`, reemplazado por `expose: 5432`. Postgres queda accesible sólo desde la red interna de Docker.
- **DB_PASSWORD obligatoria**: cambio de `${DB_PASSWORD:-solennix_password}` a `${DB_PASSWORD:?DB_PASSWORD must be set}`. Sin default inseguro.
- **Volumes external**: `db_data` y `uploads_data` marcados como `external: true` con nombres explícitos. Preserva datos de producción y silencia warnings.

## Pre-requisitos verificados
- `.env` del VPS tiene `DB_PASSWORD` seteado (sino el `compose up` fallaría tras 2.3).
- Plesk proxy corre en el mismo host (sino el bind a `127.0.0.1` rompería tráfico externo).
- Volumes `solennix_db_data` y `solennix_uploads_data` ya existen en el VPS.

## Test plan
- [ ] CI Pipeline pasa
- [ ] Tras merge: el step "Cleaning up orphan containers" ejecuta sin error
- [ ] `docker compose up` levanta los 3 containers (backend, frontend, db) sin conflicto
- [ ] Backend responde en `https://api.solennix.com/api/health` (vía Plesk proxy → 127.0.0.1:8080)
- [ ] Frontend carga en `https://solennix.com` (vía Plesk proxy → 127.0.0.1:3000)
- [ ] Postgres NO responde en `74.208.234.244:5433` desde fuera (debe rechazar conexión)