### PR TITLE
feat(ios): align dashboard pending events with web + inline pay+complete CTAs

### DIFF
--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Common/Views/PaymentEntrySheet.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Common/Views/PaymentEntrySheet.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import SolennixDesign
+
+public struct PaymentEntrySheet: View {
+
+    public typealias PaymentMethodOption = (key: String, label: String)
+
+    @Binding var amount: String
+    @Binding var method: String
+    @Binding var notes: String
+    let title: String
+    let confirmLabel: String
+    let isSaving: Bool
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+    let methods: [PaymentMethodOption]
+
+    public init(
+        amount: Binding<String>,
+        method: Binding<String>,
+        notes: Binding<String>,
+        title: String = "Registrar Pago",
+        confirmLabel: String = "Guardar Pago",
+        isSaving: Bool = false,
+        methods: [PaymentMethodOption] = [
+            (key: "cash", label: "Efectivo"),
+            (key: "transfer", label: "Transferencia"),
+            (key: "card", label: "Tarjeta"),
+            (key: "check", label: "Cheque")
+        ],
+        onCancel: @escaping () -> Void,
+        onConfirm: @escaping () -> Void
+    ) {
+        self._amount = amount
+        self._method = method
+        self._notes = notes
+        self.title = title
+        self.confirmLabel = confirmLabel
+        self.isSaving = isSaving
+        self.methods = methods
+        self.onCancel = onCancel
+        self.onConfirm = onConfirm
+    }
+
+    public var body: some View {
+        NavigationStack {
+            VStack(spacing: Spacing.lg) {
+                Text(title)
+                    .font(.title3)
+                    .fontWeight(.bold)
+                    .foregroundStyle(SolennixColors.text)
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    Text("Monto")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+
+                    TextField("0.00", text: $amount)
+                        .keyboardType(.decimalPad)
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundStyle(SolennixColors.text)
+                        .padding(Spacing.md)
+                        .background(SolennixColors.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                }
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    Text("Metodo de pago")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+
+                    HStack(spacing: Spacing.sm) {
+                        ForEach(methods, id: \.key) { option in
+                            Button {
+                                method = option.key
+                            } label: {
+                                Text(option.label)
+                                    .font(.caption)
+                                    .fontWeight(.medium)
+                                    .foregroundStyle(method == option.key ? .white : SolennixColors.text)
+                                    .padding(.horizontal, Spacing.md)
+                                    .padding(.vertical, Spacing.sm)
+                                    .background(method == option.key ? SolennixColors.primary : SolennixColors.surface)
+                                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                            }
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: Spacing.xs) {
+                    Text("Notas (opcional)")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+
+                    TextField("Notas del pago", text: $notes)
+                        .font(.body)
+                        .foregroundStyle(SolennixColors.text)
+                        .padding(Spacing.md)
+                        .background(SolennixColors.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                }
+
+                Spacer()
+
+                PremiumButton(
+                    title: confirmLabel,
+                    isLoading: isSaving,
+                    isDisabled: amount.isEmpty
+                ) {
+                    onConfirm()
+                }
+            }
+            .padding(Spacing.lg)
+            .background(SolennixColors.background)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancelar") { onCancel() }
+                        .foregroundStyle(SolennixColors.primary)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Common/Views/PaymentEntrySheet.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Common/Views/PaymentEntrySheet.swift
@@ -66,7 +66,7 @@ public struct PaymentEntrySheet: View {
                 }
 
                 VStack(alignment: .leading, spacing: Spacing.xs) {
-                    Text("Metodo de pago")
+                    Text("Método de pago")
                         .font(.caption)
                         .foregroundStyle(SolennixColors.textSecondary)
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/PendingEventsViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/PendingEventsViewModel.swift
@@ -185,7 +185,15 @@ public final class PendingEventsViewModel {
             return
         }
 
-        let shouldAutoComplete = pendingEvent.reason == .overdueEvent && pendingEvent.hasPendingPayment
+        // Auto-complete only when the entered amount actually settles the
+        // pending balance (within an epsilon). Without this guard a partial
+        // payment of an "overdue with balance" event would mark it as
+        // completed while still leaving an outstanding balance.
+        let paymentCompletionEpsilon = 0.01
+        let shouldAutoComplete =
+            pendingEvent.reason == .overdueEvent
+            && pendingEvent.hasPendingPayment
+            && amount >= (pendingEvent.pendingAmount - paymentCompletionEpsilon)
 
         isSavingPayment = true
         updatingEventId = pendingEvent.event.id
@@ -206,12 +214,17 @@ public final class PendingEventsViewModel {
             let payment: Payment = try await apiClient.post(Endpoint.payments, body: AnyCodable(body))
 
             HapticsHelper.play(.success)
+            // `client_name` is required by NotificationManager (the receipt
+            // observer early-returns without it). We don't have client data
+            // on the dashboard VM, so fall back to "Cliente" — same default
+            // EventDetailViewModel.addPayment uses when client is nil.
             NotificationCenter.default.post(
                 name: .solennixPaymentRegistered,
                 object: nil,
                 userInfo: [
                     "payment_id": payment.id,
                     "event_id": pendingEvent.event.id,
+                    "client_name": "Cliente",
                     "amount": payment.amount
                 ]
             )
@@ -227,6 +240,10 @@ public final class PendingEventsViewModel {
                 }
             } else {
                 transientMessage = "Pago registrado correctamente"
+                // Reload to reflect the new balance: the affected pending
+                // event may now be fully paid (and should drop off the list)
+                // or simply show a smaller pendingAmount on the next open.
+                await loadPendingEvents()
             }
 
             if pendingEvents.isEmpty {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/PendingEventsViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/PendingEventsViewModel.swift
@@ -4,15 +4,27 @@ import SolennixNetwork
 
 // MARK: - Pending Event with Reason
 
+public enum PendingEventReason: String, Sendable {
+    case paymentDue        // confirmed in next 7 days, balance > 0
+    case overdueEvent      // past date still quoted/confirmed
+    case quoteUrgent       // quoted in next 14 days
+}
+
 public struct PendingEventWithReason: Identifiable {
     public let id: String
     public let event: Event
-    public let reason: String
+    public let reason: PendingEventReason
+    public let reasonLabel: String
+    public let pendingAmount: Double
 
-    public init(event: Event, reason: String) {
+    public var hasPendingPayment: Bool { pendingAmount > 0.01 }
+
+    public init(event: Event, reason: PendingEventReason, reasonLabel: String, pendingAmount: Double) {
         self.id = event.id
         self.event = event
         self.reason = reason
+        self.reasonLabel = reasonLabel
+        self.pendingAmount = pendingAmount
     }
 }
 
@@ -26,6 +38,14 @@ public final class PendingEventsViewModel {
     public var isLoading: Bool = true
     public var isPresented: Bool = false
     public var updatingEventId: String? = nil
+
+    // Payment sheet state
+    public var paymentSheetEvent: PendingEventWithReason? = nil
+    public var paymentAmount: String = ""
+    public var paymentMethod: String = "cash"
+    public var paymentNotes: String = ""
+    public var isSavingPayment: Bool = false
+    public var transientMessage: String? = nil
 
     public init(apiClient: APIClient) {
         self.apiClient = apiClient
@@ -41,6 +61,7 @@ public final class PendingEventsViewModel {
             let calendar = Calendar.current
             let startOfToday = calendar.startOfDay(for: Date())
             let sevenDaysFromNow = calendar.date(byAdding: .day, value: 7, to: startOfToday)!
+            let fourteenDaysFromNow = calendar.date(byAdding: .day, value: 14, to: startOfToday)!
 
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd"
@@ -55,20 +76,48 @@ public final class PendingEventsViewModel {
                 let totalPaid = allPayments
                     .filter { $0.eventId == event.id }
                     .reduce(0) { $0 + $1.amount }
-                let isFullyPaid = totalPaid >= event.totalAmount
+                let pendingAmount = max(event.totalAmount - totalPaid, 0)
+                let hasPending = pendingAmount > 0.01
 
-                // Upcoming within 7 days but not fully paid
-                if eventDate >= startOfToday && eventDate <= sevenDaysFromNow
-                    && !isFullyPaid
-                    && event.status != .completed && event.status != .cancelled
+                // 1) Confirmed in next 7 days with pending balance.
+                if event.status == .confirmed
+                    && eventDate >= startOfToday && eventDate <= sevenDaysFromNow
+                    && hasPending
                 {
-                    pending.append(PendingEventWithReason(event: event, reason: "Pago pendiente"))
+                    pending.append(
+                        PendingEventWithReason(
+                            event: event,
+                            reason: .paymentDue,
+                            reasonLabel: "Cobro por cerrar",
+                            pendingAmount: pendingAmount
+                        )
+                    )
                 }
-                // Past date but still quoted or confirmed
+                // 2) Past date still quoted/confirmed.
                 else if eventDate < startOfToday
                     && (event.status == .quoted || event.status == .confirmed)
                 {
-                    pending.append(PendingEventWithReason(event: event, reason: "Evento vencido"))
+                    pending.append(
+                        PendingEventWithReason(
+                            event: event,
+                            reason: .overdueEvent,
+                            reasonLabel: "Evento vencido",
+                            pendingAmount: pendingAmount
+                        )
+                    )
+                }
+                // 3) Quoted within 14 days (urgent quote, not yet confirmed).
+                else if event.status == .quoted
+                    && eventDate >= startOfToday && eventDate <= fourteenDaysFromNow
+                {
+                    pending.append(
+                        PendingEventWithReason(
+                            event: event,
+                            reason: .quoteUrgent,
+                            reasonLabel: "Cotización urgente",
+                            pendingAmount: pendingAmount
+                        )
+                    )
                 }
             }
 
@@ -93,9 +142,103 @@ public final class PendingEventsViewModel {
             if pendingEvents.isEmpty {
                 isPresented = false
             }
+            transientMessage = newStatus == .completed
+                ? "Evento marcado como completado"
+                : "Evento cancelado"
         } catch {
+            transientMessage = "Error al actualizar el estado"
             print("Error updating event status: \(error)")
         }
+        updatingEventId = nil
+    }
+
+    // MARK: - Payment flow
+
+    @MainActor
+    public func openPaymentSheet(for pendingEvent: PendingEventWithReason) {
+        paymentSheetEvent = pendingEvent
+        paymentAmount = pendingEvent.pendingAmount > 0
+            ? String(format: "%.2f", pendingEvent.pendingAmount)
+            : ""
+        paymentMethod = "cash"
+        paymentNotes = ""
+    }
+
+    @MainActor
+    public func dismissPaymentSheet() {
+        paymentSheetEvent = nil
+        paymentAmount = ""
+        paymentNotes = ""
+        paymentMethod = "cash"
+    }
+
+    @MainActor
+    public func consumeTransientMessage() {
+        transientMessage = nil
+    }
+
+    @MainActor
+    public func registerPayment() async {
+        guard let pendingEvent = paymentSheetEvent else { return }
+        guard let amount = Double(paymentAmount.replacingOccurrences(of: ",", with: ".")), amount > 0 else {
+            transientMessage = "Monto inválido"
+            return
+        }
+
+        let shouldAutoComplete = pendingEvent.reason == .overdueEvent && pendingEvent.hasPendingPayment
+
+        isSavingPayment = true
+        updatingEventId = pendingEvent.event.id
+
+        do {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd"
+            let today = dateFormatter.string(from: Date())
+
+            let body: [String: Any] = [
+                "event_id": pendingEvent.event.id,
+                "amount": amount,
+                "payment_date": today,
+                "payment_method": paymentMethod,
+                "notes": paymentNotes
+            ]
+
+            let payment: Payment = try await apiClient.post(Endpoint.payments, body: AnyCodable(body))
+
+            HapticsHelper.play(.success)
+            NotificationCenter.default.post(
+                name: .solennixPaymentRegistered,
+                object: nil,
+                userInfo: [
+                    "payment_id": payment.id,
+                    "event_id": pendingEvent.event.id,
+                    "amount": payment.amount
+                ]
+            )
+
+            if shouldAutoComplete {
+                do {
+                    let statusBody = ["status": EventStatus.completed.rawValue]
+                    let _: Event = try await apiClient.put(Endpoint.event(pendingEvent.event.id), body: statusBody)
+                    pendingEvents.removeAll { $0.event.id == pendingEvent.event.id }
+                    transientMessage = "Pago registrado y evento completado"
+                } catch {
+                    transientMessage = "Pago registrado. Marcá el evento como completado manualmente."
+                }
+            } else {
+                transientMessage = "Pago registrado correctamente"
+            }
+
+            if pendingEvents.isEmpty {
+                isPresented = false
+            }
+            dismissPaymentSheet()
+        } catch {
+            HapticsHelper.play(.error)
+            transientMessage = "Error al registrar el pago"
+        }
+
+        isSavingPayment = false
         updatingEventId = nil
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/PendingEventsModalView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/PendingEventsModalView.swift
@@ -27,7 +27,21 @@ public struct PendingEventsModalView: View {
         .task {
             await viewModel.loadPendingEvents()
         }
+        .sheet(item: $viewModel.paymentSheetEvent) { pendingEvent in
+            paymentSheet(for: pendingEvent)
+        }
+        .alert(
+            viewModel.transientMessage ?? "",
+            isPresented: Binding(
+                get: { viewModel.transientMessage != nil },
+                set: { if !$0 { viewModel.consumeTransientMessage() } }
+            )
+        ) {
+            Button("OK", role: .cancel) { viewModel.consumeTransientMessage() }
+        }
     }
+
+    // MARK: - Modal content
 
     private var modalContent: some View {
         VStack(spacing: 0) {
@@ -79,7 +93,7 @@ public struct PendingEventsModalView: View {
                 .padding(.horizontal, Spacing.lg)
                 .padding(.bottom, Spacing.lg)
             }
-            .frame(maxHeight: 300)
+            .frame(maxHeight: 360)
 
             Divider()
 
@@ -102,6 +116,8 @@ public struct PendingEventsModalView: View {
         .shadowLg()
     }
 
+    // MARK: - Event row
+
     private func eventRow(_ pendingEvent: PendingEventWithReason) -> some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack(alignment: .top) {
@@ -118,8 +134,7 @@ public struct PendingEventsModalView: View {
 
                 Spacer()
 
-                // Reason badge
-                Text(pendingEvent.reason)
+                Text(pendingEvent.reasonLabel)
                     .font(.caption2)
                     .fontWeight(.bold)
                     .foregroundStyle(SolennixColors.warning)
@@ -129,58 +144,177 @@ public struct PendingEventsModalView: View {
                     .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
             }
 
-            HStack(spacing: Spacing.sm) {
-                Button {
-                    Task {
-                        await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .completed)
-                    }
-                } label: {
-                    HStack(spacing: 4) {
-                        if viewModel.updatingEventId == pendingEvent.event.id {
-                            ProgressView()
-                                .controlSize(.small)
-                                .tint(.white)
-                        } else {
-                            Image(systemName: "checkmark.circle")
-                            Text("Completar")
-                        }
-                    }
-                    .font(.caption)
-                    .fontWeight(.bold)
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(SolennixColors.success)
-                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
-                }
-                .disabled(viewModel.updatingEventId != nil)
-
-                Button {
-                    Task {
-                        await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .cancelled)
-                    }
-                } label: {
-                    HStack(spacing: 4) {
-                        Image(systemName: "xmark.circle")
-                        Text("Cancelar")
-                    }
-                    .font(.caption)
-                    .fontWeight(.bold)
-                    .foregroundStyle(SolennixColors.error)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(SolennixColors.errorBg)
-                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: CornerRadius.sm)
-                            .strokeBorder(SolennixColors.error.opacity(0.2), lineWidth: 1)
-                    )
-                }
-                .disabled(viewModel.updatingEventId != nil)
-            }
+            actionButtons(for: pendingEvent)
         }
         .padding(Spacing.md)
         .background(SolennixColors.surface)
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+    }
+
+    @ViewBuilder
+    private func actionButtons(for pendingEvent: PendingEventWithReason) -> some View {
+        let isUpdating = viewModel.updatingEventId == pendingEvent.event.id
+        let disabled = viewModel.updatingEventId != nil
+
+        switch pendingEvent.reason {
+        case .paymentDue:
+            HStack(spacing: Spacing.sm) {
+                primaryButton(
+                    title: "Registrar pago",
+                    icon: "dollarsign.circle",
+                    isLoading: isUpdating,
+                    disabled: disabled
+                ) {
+                    viewModel.openPaymentSheet(for: pendingEvent)
+                }
+            }
+
+        case .overdueEvent:
+            VStack(spacing: Spacing.sm) {
+                if pendingEvent.hasPendingPayment {
+                    primaryButton(
+                        title: "Pagar y completar",
+                        icon: "dollarsign.circle",
+                        isLoading: isUpdating,
+                        disabled: disabled
+                    ) {
+                        viewModel.openPaymentSheet(for: pendingEvent)
+                    }
+                    HStack(spacing: Spacing.sm) {
+                        cancelButton(disabled: disabled) {
+                            Task {
+                                await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .cancelled)
+                            }
+                        }
+                        Button {
+                            Task {
+                                await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .completed)
+                            }
+                        } label: {
+                            Text("Solo completar")
+                                .font(.caption)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(SolennixColors.textSecondary)
+                                .underline()
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                        }
+                        .disabled(disabled)
+                    }
+                } else {
+                    HStack(spacing: Spacing.sm) {
+                        Button {
+                            Task {
+                                await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .completed)
+                            }
+                        } label: {
+                            HStack(spacing: 4) {
+                                if isUpdating {
+                                    ProgressView().controlSize(.small).tint(.white)
+                                } else {
+                                    Image(systemName: "checkmark.circle")
+                                    Text("Completar")
+                                }
+                            }
+                            .font(.caption)
+                            .fontWeight(.bold)
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .background(SolennixColors.success)
+                            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
+                        }
+                        .disabled(disabled)
+
+                        cancelButton(disabled: disabled) {
+                            Task {
+                                await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .cancelled)
+                            }
+                        }
+                    }
+                }
+            }
+
+        case .quoteUrgent:
+            HStack {
+                Spacer()
+                Text("Pendiente de confirmar")
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textSecondary)
+                Spacer()
+            }
+        }
+    }
+
+    // MARK: - Reusable button styles
+
+    private func primaryButton(
+        title: String,
+        icon: String,
+        isLoading: Bool,
+        disabled: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if isLoading {
+                    ProgressView().controlSize(.small).tint(.white)
+                } else {
+                    Image(systemName: icon)
+                    Text(title)
+                }
+            }
+            .font(.caption)
+            .fontWeight(.bold)
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(SolennixColors.primary)
+            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
+        }
+        .disabled(disabled)
+    }
+
+    private func cancelButton(disabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: "xmark.circle")
+                Text("Cancelar")
+            }
+            .font(.caption)
+            .fontWeight(.bold)
+            .foregroundStyle(SolennixColors.error)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(SolennixColors.errorBg)
+            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: CornerRadius.sm)
+                    .strokeBorder(SolennixColors.error.opacity(0.2), lineWidth: 1)
+            )
+        }
+        .disabled(disabled)
+    }
+
+    // MARK: - Payment sheet
+
+    private func paymentSheet(for pendingEvent: PendingEventWithReason) -> some View {
+        let confirmLabel = pendingEvent.reason == .overdueEvent && pendingEvent.hasPendingPayment
+            ? "Pagar y completar"
+            : "Guardar Pago"
+        let title = pendingEvent.reason == .overdueEvent && pendingEvent.hasPendingPayment
+            ? "Registrar pago y completar"
+            : "Registrar Pago"
+
+        return PaymentEntrySheet(
+            amount: $viewModel.paymentAmount,
+            method: $viewModel.paymentMethod,
+            notes: $viewModel.paymentNotes,
+            title: title,
+            confirmLabel: confirmLabel,
+            isSaving: viewModel.isSavingPayment,
+            onCancel: { viewModel.dismissPaymentSheet() },
+            onConfirm: { Task { await viewModel.registerPayment() } }
+        )
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventPaymentsDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventPaymentsDetailView.swift
@@ -225,88 +225,14 @@ public struct EventPaymentsDetailView: View {
     // MARK: - Payment Sheet
 
     private var paymentSheet: some View {
-        NavigationStack {
-            VStack(spacing: Spacing.lg) {
-                Text("Registrar Pago")
-                    .font(.title3)
-                    .fontWeight(.bold)
-                    .foregroundStyle(SolennixColors.text)
-
-                VStack(alignment: .leading, spacing: Spacing.xs) {
-                    Text("Monto")
-                        .font(.caption)
-                        .foregroundStyle(SolennixColors.textSecondary)
-
-                    TextField("0.00", text: $viewModel.paymentAmount)
-                        .keyboardType(.decimalPad)
-                        .font(.title2)
-                        .fontWeight(.bold)
-                        .foregroundStyle(SolennixColors.text)
-                        .padding(Spacing.md)
-                        .background(SolennixColors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
-                }
-
-                VStack(alignment: .leading, spacing: Spacing.xs) {
-                    Text("Metodo de pago")
-                        .font(.caption)
-                        .foregroundStyle(SolennixColors.textSecondary)
-
-                    HStack(spacing: Spacing.sm) {
-                        ForEach(paymentMethods, id: \.key) { method in
-                            Button {
-                                viewModel.paymentMethod = method.key
-                            } label: {
-                                Text(method.label)
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                    .foregroundStyle(
-                                        viewModel.paymentMethod == method.key ? .white : SolennixColors.text
-                                    )
-                                    .padding(.horizontal, Spacing.md)
-                                    .padding(.vertical, Spacing.sm)
-                                    .background(
-                                        viewModel.paymentMethod == method.key ? SolennixColors.primary : SolennixColors.surface
-                                    )
-                                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
-                            }
-                        }
-                    }
-                }
-
-                VStack(alignment: .leading, spacing: Spacing.xs) {
-                    Text("Notas (opcional)")
-                        .font(.caption)
-                        .foregroundStyle(SolennixColors.textSecondary)
-
-                    TextField("Notas del pago", text: $viewModel.paymentNotes)
-                        .font(.body)
-                        .foregroundStyle(SolennixColors.text)
-                        .padding(Spacing.md)
-                        .background(SolennixColors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
-                }
-
-                Spacer()
-
-                PremiumButton(
-                    title: "Guardar Pago",
-                    isLoading: viewModel.isSavingPayment,
-                    isDisabled: viewModel.paymentAmount.isEmpty
-                ) {
-                    Task { await viewModel.addPayment(eventId: eventId) }
-                }
-            }
-            .padding(Spacing.lg)
-            .background(SolennixColors.background)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancelar") { viewModel.showPaymentSheet = false }
-                        .foregroundStyle(SolennixColors.primary)
-                }
-            }
-        }
-        .presentationDetents([.medium, .large])
+        PaymentEntrySheet(
+            amount: $viewModel.paymentAmount,
+            method: $viewModel.paymentMethod,
+            notes: $viewModel.paymentNotes,
+            isSaving: viewModel.isSavingPayment,
+            onCancel: { viewModel.showPaymentSheet = false },
+            onConfirm: { Task { await viewModel.addPayment(eventId: eventId) } }
+        )
     }
 
     // MARK: - Helpers
@@ -324,9 +250,5 @@ public struct EventPaymentsDetailView: View {
         case "cheque": return "Cheque"
         default: return method.capitalized
         }
-    }
-
-    private var paymentMethods: [(key: String, label: String)] {
-        [("cash", "Efectivo"), ("transfer", "Transferencia"), ("card", "Tarjeta"), ("check", "Cheque")]
     }
 }


### PR DESCRIPTION
## Summary

- Lift `PendingEventsViewModel` detection to **three categories** matching web: `paymentDue` (confirmed in next 7 days with balance), `overdueEvent` (past date still quoted/confirmed), `quoteUrgent` (quoted within 14 days). `PendingEventWithReason` now exposes a typed reason enum, a localized `reasonLabel`, and `pendingAmount`.
- Add `registerPayment()` on the ViewModel — `POST /payments`, post `.solennixPaymentRegistered`, and when the event is overdue with a balance, also `PUT /events/{id}` with `status: completed`. Partial failure surfaces a recovery message via `transientMessage` (alert).
- Extend `PendingEventsModalView` with action buttons per category, respecting HIG (primary action with primary color, vertical stack when 3 actions to avoid cramping on small screens).
- Extract `PaymentEntrySheet` to `Common/Views/` and have both `EventPaymentsDetailView` and `PendingEventsModalView` consume the same sheet with custom `title` and `confirmLabel`. Keeps `.medium/.large` detents and method chips.

## Test plan

- [x] `xcodebuild -project Solennix.xcodeproj -scheme Solennix -sdk iphonesimulator build` — `** BUILD SUCCEEDED **`
- [ ] Manual UI on simulator: open Dashboard with overdue events → tap "Pagar y completar" → sheet pre-fills saldo → confirm → payment appears + event marked completed → modal updates / dismisses
- [ ] Manual UI: tap "Solo completar" / "Cancelar" / "Completar" → single PUT fired, row removed
- [ ] Manual UI: with offline simulator between the two calls, the recovery alert text appears and the payment is still saved