### PR TITLE
docs(prd): pending-events parity and inline pay+complete CTAs

### DIFF
--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -443,15 +443,23 @@ Cada producto puede tener una receta que vincula items del inventario como ingre
 
 #### Alertas de Atencion (widget)
 
-Muestra eventos que necesitan accion inmediata del organizador. Si no hay alertas, la seccion no se muestra.
+Muestra eventos que necesitan accion inmediata del organizador. Si no hay alertas, la seccion no se muestra. Las tres plataformas comparten las mismas categorias y reglas de deteccion (paridad cross-platform).
 
-| Tipo de alerta | Criterio                                                                 |
-| -------------- | ------------------------------------------------------------------------ |
-| Pago pendiente | Eventos confirmados con fecha dentro de 7 dias, no completamente pagados |
-| Evento vencido | Eventos con fecha pasada en estado "cotizado" o "confirmado"             |
-| Sin confirmar  | Eventos cotizados con fecha dentro de 14 dias sin confirmacion           |
+| Tipo de alerta       | Criterio                                                                 |
+| -------------------- | ------------------------------------------------------------------------ |
+| Cobro por cerrar     | Eventos confirmados con fecha dentro de 7 dias, no completamente pagados |
+| Evento vencido       | Eventos con fecha pasada en estado "cotizado" o "confirmado"             |
+| Cotizacion urgente   | Eventos cotizados con fecha dentro de 14 dias sin confirmacion           |
 
-Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente. Tap → detalle del evento.
+Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente cuando aplica. Las acciones inline se ofrecen segun la categoria:
+
+| Categoria          | Acciones inline                                                                                                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cobro por cerrar   | "Registrar pago" (abre form con saldo pendiente pre-llenado)                                                                                                                                                         |
+| Evento vencido     | Si tiene saldo: "Pagar y completar" (atajo: registra pago + marca completado en una sola accion), "Cancelar", "Solo completar". Si no tiene saldo: "Completar", "Cancelar". El saldo se pre-llena en el form de pago |
+| Cotizacion urgente | Solo navegacion al detalle (no requiere accion rapida)                                                                                                                                                               |
+
+**"Pagar y completar"** ejecuta dos llamadas secuenciales: `POST /payments` para crear el pago y, si tuvo exito, `PUT /events/{id}` con `status: completed`. Si falla la segunda llamada, se muestra un mensaje de recuperacion para que el organizador complete el evento manualmente desde el detalle.
 
 #### Quick Actions (2 botones)
 
@@ -478,9 +486,14 @@ Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente. T
 
 **Vistas por plataforma:**
 
-- **[iOS]**: `DashboardView`, `KPICardView`, `EventStatusChart`, `AttentionEventsCard` (nuevo)
-- **[Android]**: `DashboardScreen`, `PendingEventsBanner` (expandido con criterio "sin confirmar")
-- **[Web]**: `Dashboard`, `AttentionEventsCard` (nuevo)
+- **[iOS]**: `DashboardView`, `KPICardView`, `EventStatusChart`, `PendingEventsModalView` (modal bloqueante con CTAs por categoria), `PaymentEntrySheet` (sheet reusable para registrar pago)
+- **[Android]**: `DashboardScreen`, `PendingEventItem` (banner inline en LazyColumn con CTAs por categoria), `PaymentModal` (extraido a `core:designsystem` para reuso)
+- **[Web]**: `Dashboard`, `DashboardAttentionSection` (seccion inline con CTAs por categoria), `PaymentFormFields` (form reusable consumido por modal del dashboard y detalle de evento)
+
+**Endpoints usados por las acciones inline:**
+
+- `PUT /api/events/{id}` con `{ status }` — para "Completar" / "Cancelar" / "Solo completar".
+- `POST /api/payments` + `PUT /api/events/{id}` (secuenciales) — para "Pagar y completar".
 
 **Endpoint:** `GET /api/events/upcoming` — retorna eventos proximos y pendientes.
 

--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -459,7 +459,7 @@ Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente cu
 | Evento vencido     | Si tiene saldo: "Pagar y completar" (atajo: registra pago + marca completado en una sola accion), "Cancelar", "Solo completar". Si no tiene saldo: "Completar", "Cancelar". El saldo se pre-llena en el form de pago |
 | Cotizacion urgente | Solo navegacion al detalle (no requiere accion rapida)                                                                                                                                                               |
 
-**"Pagar y completar"** ejecuta dos llamadas secuenciales: `POST /payments` para crear el pago y, si tuvo exito, `PUT /events/{id}` con `status: completed`. Si falla la segunda llamada, se muestra un mensaje de recuperacion para que el organizador complete el evento manualmente desde el detalle.
+**"Pagar y completar"** ejecuta dos llamadas secuenciales: `POST /api/payments` para crear el pago y, si tuvo exito, `PUT /api/events/{id}` con `{"status": "completed"}`. El auto-complete solo dispara cuando el monto ingresado cubre el saldo pendiente (`amount >= pendingAmount - 0.01`) — un pago parcial no marca el evento como completado. Si falla la segunda llamada, se muestra un mensaje de recuperacion para que el organizador complete el evento manualmente desde el detalle.
 
 #### Quick Actions (2 botones)
 
@@ -488,7 +488,7 @@ Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente cu
 
 - **[iOS]**: `DashboardView`, `KPICardView`, `EventStatusChart`, `PendingEventsModalView` (modal bloqueante con CTAs por categoria), `PaymentEntrySheet` (sheet reusable para registrar pago)
 - **[Android]**: `DashboardScreen`, `PendingEventItem` (banner inline en LazyColumn con CTAs por categoria), `PaymentModal` (extraido a `core:designsystem` para reuso)
-- **[Web]**: `Dashboard`, `DashboardAttentionSection` (seccion inline con CTAs por categoria), `PaymentFormFields` (form reusable consumido por modal del dashboard y detalle de evento)
+- **[Web]**: `Dashboard`, `DashboardAttentionSection` (seccion inline con las 3 categorias y navegacion al detalle del evento). Las acciones rapidas inline (Registrar pago / Completar / Cancelar / Pagar y completar / Solo completar) estan **pendientes de re-implementacion** — la version inicial fue reverted por bugs financieros (ver tarea cross-platform "Bug 5: auto-complete sin verificar monto" para el contexto). Mientras tanto, las acciones se ejecutan desde el detalle del evento.
 
 **Endpoints usados por las acciones inline:**
 

--- a/obsidian/Solennix/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md
+++ b/obsidian/Solennix/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md
@@ -347,7 +347,7 @@ graph TD
 | `Settings`   | Perfil, ajustes de negocio, plantilla de contrato, precios, legal                       |
 | `Search`     | Busqueda global multi-entidad                                                           |
 | `Onboarding` | Flujo de primera vez con TipKit                                                         |
-| `Common`     | PlanLimitsManager, Sentry, Spotlight, Haptics, LiveActivity, StoreReview                |
+| `Common`     | PlanLimitsManager, Sentry, Spotlight, Haptics, LiveActivity, StoreReview, `PaymentEntrySheet` (sheet reusable de registro de pago, consumido por dashboard y detalle de evento) |
 
 Regla funcional de stock bajo (iOS): `minimumStock > 0 && currentStock < minimumStock`.
 

--- a/obsidian/Solennix/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md
+++ b/obsidian/Solennix/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md
@@ -389,7 +389,7 @@ Implementa el tema visual de Solennix basado en Material 3:
 - **`SolennixColorScheme`**: Esquema de colores personalizado con soporte para light/dark
 - **Contraste dinámico**: componentes interactivos (FAB, badges seleccionados) usan `MaterialTheme.colorScheme.onPrimary` para evitar hardcodes de blanco en dark mode
 - **Tokens**: `Color.kt`, `Typography.kt`, `Shape.kt`, `Spacing.kt`, `Elevation.kt`, `Gradient.kt`
-- **Componentes reutilizables**: `SolennixTextField`, `Avatar`, `StatusBadge`, `KPICard`, `ConfirmDialog`, `EmptyState`, `PremiumButton`, `SkeletonLoading`, `ToastOverlay`, `UpgradeBanner`
+- **Componentes reutilizables**: `SolennixTextField`, `Avatar`, `StatusBadge`, `KPICard`, `ConfirmDialog`, `EmptyState`, `PremiumButton`, `SkeletonLoading`, `ToastOverlay`, `UpgradeBanner`, `PaymentModal` (`ModalBottomSheet` reusable de registro de pago, consumido por dashboard y detalle de evento — params `title` y `confirmLabel`)
 - **Utilidades**: `HapticFeedback` para feedback táctil
 
 **Calibración de contraste (Fase 3 A11y):** `Color.kt` endurece `secondaryText`, `tertiaryText` y `tabBarInactive` en light/dark para mantener legibilidad AA sobre `background`, `surface` y `card`. `EmptyState` también elevó el contraste del ícono base para evitar estados vacíos visualmente lavados.

--- a/obsidian/Solennix/PRD/08_TECHNICAL_ARCHITECTURE_WEB.md
+++ b/obsidian/Solennix/PRD/08_TECHNICAL_ARCHITECTURE_WEB.md
@@ -200,7 +200,7 @@ web/src/
 │   ├── QuickActionsFAB.tsx           # FAB de acciones rapidas solo para smartphones (<768px)
 │   ├── UpgradeBanner.tsx             # Banner de upgrade a plan PRO
 │   ├── OnboardingChecklist.tsx       # Checklist de onboarding para nuevos usuarios
-│   ├── PendingEventsModal.tsx        # Modal de eventos pendientes de confirmacion
+│   ├── PaymentFormFields.tsx         # Form de pago reusable (monto, fecha, metodo, notas) consumido por Payments.tsx y Dashboard.tsx (modal de "Pagar y completar")
 │   ├── SetupRequired.tsx             # Pantalla de configuracion inicial requerida
 │   └── ContractTemplateEditor.tsx    # Editor de plantillas de contrato
 │

--- a/obsidian/Solennix/PRD/08_TECHNICAL_ARCHITECTURE_WEB.md
+++ b/obsidian/Solennix/PRD/08_TECHNICAL_ARCHITECTURE_WEB.md
@@ -200,7 +200,7 @@ web/src/
 │   ├── QuickActionsFAB.tsx           # FAB de acciones rapidas solo para smartphones (<768px)
 │   ├── UpgradeBanner.tsx             # Banner de upgrade a plan PRO
 │   ├── OnboardingChecklist.tsx       # Checklist de onboarding para nuevos usuarios
-│   ├── PaymentFormFields.tsx         # Form de pago reusable (monto, fecha, metodo, notas) consumido por Payments.tsx y Dashboard.tsx (modal de "Pagar y completar")
+│   ├── PendingEventsModal.tsx        # Modal de eventos pendientes de confirmacion (orfano post-refactor de marzo 2026; pendiente decidir reemplazo definitivo tras revert PR #76)
 │   ├── SetupRequired.tsx             # Pantalla de configuracion inicial requerida
 │   └── ContractTemplateEditor.tsx    # Editor de plantillas de contrato
 │

--- a/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
+++ b/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
@@ -338,7 +338,7 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 
 - ✅ Dashboard (KPIs, resumen)
   - ✅ Alertas de Atencion (DashboardAttentionSection) — 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente
-  - ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" (modal con `PaymentFormFields` reusable, autocompleta evento vencido con saldo)
+  - ⏸️ Acciones inline en alertas: planeadas (Completar / Cancelar / "Pagar y completar" / "Solo completar"), pero **revertidas** tras la primera entrega (PR #72 reverted via PR #76) por un bug financiero compartido con mobile (auto-complete sin verificar monto). Mientras tanto, las acciones se ejecutan desde el detalle del evento. La invalidacion de cache `byEventIds` que surgio del review **sí** quedo en main (PR #78). Re-implementacion del feature inline pendiente.
 - ✅ Busqueda global
 - ✅ Calendario con vista de eventos
 - ✅ Lista de eventos (EventList) con filtros: Todos, Proximos, Pasados, Borradores
@@ -473,7 +473,7 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 - ✅ Grafico de estado de eventos (EventStatusChart)
 - ✅ Grafico de comparativa financiera (FinancialComparisonChart)
 - ✅ Alertas de Atencion (PendingEventsModalView) — 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente
-- ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" (form de pago en sheet, autocompleta evento vencido con saldo). Sheet reusable `PaymentEntrySheet` en `Common/Views/`
+- ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" / "Solo completar" (en evento vencido con saldo se muestran las 3 ultimas; "Pagar y completar" auto-completa el evento solo si el monto cubre el saldo). Sheet reusable `PaymentEntrySheet` en `Common/Views/`
 - ✅ Quick Actions — 2 botones: Nuevo Evento + Nuevo Cliente
 - ✅ Alertas de Stock Bajo — regla: `minimumStock > 0 && currentStock < minimumStock` (caso 0/0 sin alerta)
 - ✅ Proximos Eventos con dropdown de estado
@@ -643,7 +643,7 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 - ✅ Dashboard principal (DashboardScreen)
 - ✅ Tarjetas KPI — 8 KPIs
 - ✅ Alertas de Atencion (PendingEventItem en banner) — 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente
-- ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" (Material `Button` por categoria, `ModalBottomSheet` para registrar pago, autocompleta evento vencido con saldo). `PaymentModal` extraido a `core:designsystem` para reuso entre dashboard y detalle de evento
+- ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" / "Solo completar" (Material `Button` por categoria, `ModalBottomSheet` para registrar pago; en evento vencido con saldo se muestran las 3 ultimas y "Pagar y completar" solo auto-completa cuando el monto cubre el saldo). `PaymentModal` extraido a `core:designsystem` para reuso entre dashboard y detalle de evento
 - ✅ Quick Actions — 2 botones: Nuevo Evento + Nuevo Cliente
 - ✅ Grafico de estado de eventos + Comparativa financiera
 - ✅ Alertas de Inventario
@@ -869,7 +869,7 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 | Header (saludo + fecha)       | ✅  | ✅      | ✅  | ➖      | Todas las plataformas tienen saludo + fecha                                              |
 | KPI cards (8)                 | ✅  | ✅      | ✅  | ✅      | Labels consistentes. Web: "Cobrado (mes)" vs mobile: "Cobrado" (menor)                   |
 | Alertas de Atencion           | ✅  | ✅      | ✅  | ✅      | 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente |
-| Acciones inline en alertas    | ✅  | ✅      | ✅  | ➖      | Completar / Cancelar / Pagar y completar (form de pago en modal/sheet/banner). Form/sheet reusable: web `PaymentFormFields`, android `PaymentModal` (core:designsystem), iOS `PaymentEntrySheet` (Common/Views) |
+| Acciones inline en alertas    | ⏸️  | ✅      | ✅  | ➖      | Completar / Cancelar / "Pagar y completar" / "Solo completar" (esta ultima solo en evento vencido con saldo). Form/sheet reusable: android `PaymentModal` (core:designsystem), iOS `PaymentEntrySheet` (Common/Views). **Web: revertido tras PR #76** por bug financiero (auto-complete sin verificar monto); pendiente re-implementacion. La invalidacion de cache `byEventIds` que surgio del review se mergeo aparte (PR #78). |
 | Quick Actions (2)             | ✅  | ✅      | ✅  | ➖      | Nuevo Evento + Nuevo Cliente en las 3 plataformas                                        |
 | Chart: Distribucion estados   | ✅  | ✅      | ✅  | ➖      |                                                                                          |
 | Chart: Comparacion financiera | ✅  | ✅      | ✅  | ➖      |                                                                                          |

--- a/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
+++ b/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
@@ -337,6 +337,8 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 ### Paginas Protegidas
 
 - ✅ Dashboard (KPIs, resumen)
+  - ✅ Alertas de Atencion (DashboardAttentionSection) — 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente
+  - ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" (modal con `PaymentFormFields` reusable, autocompleta evento vencido con saldo)
 - ✅ Busqueda global
 - ✅ Calendario con vista de eventos
 - ✅ Lista de eventos (EventList) con filtros: Todos, Proximos, Pasados, Borradores
@@ -470,7 +472,8 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 - ✅ Tarjetas KPI — 8 KPIs (KPICardView)
 - ✅ Grafico de estado de eventos (EventStatusChart)
 - ✅ Grafico de comparativa financiera (FinancialComparisonChart)
-- ✅ Alertas de Atencion (AttentionEventsCard) — 3 tipos: vencido, pago pendiente, sin confirmar
+- ✅ Alertas de Atencion (PendingEventsModalView) — 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente
+- ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" (form de pago en sheet, autocompleta evento vencido con saldo). Sheet reusable `PaymentEntrySheet` en `Common/Views/`
 - ✅ Quick Actions — 2 botones: Nuevo Evento + Nuevo Cliente
 - ✅ Alertas de Stock Bajo — regla: `minimumStock > 0 && currentStock < minimumStock` (caso 0/0 sin alerta)
 - ✅ Proximos Eventos con dropdown de estado
@@ -639,7 +642,8 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 
 - ✅ Dashboard principal (DashboardScreen)
 - ✅ Tarjetas KPI — 8 KPIs
-- ✅ Alertas de Atencion (PendingEventsBanner) — 3 tipos: vencido, pago pendiente, sin confirmar
+- ✅ Alertas de Atencion (PendingEventItem en banner) — 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente
+- ✅ Acciones inline en alertas (2026-04): Completar / Cancelar / "Pagar y completar" (Material `Button` por categoria, `ModalBottomSheet` para registrar pago, autocompleta evento vencido con saldo). `PaymentModal` extraido a `core:designsystem` para reuso entre dashboard y detalle de evento
 - ✅ Quick Actions — 2 botones: Nuevo Evento + Nuevo Cliente
 - ✅ Grafico de estado de eventos + Comparativa financiera
 - ✅ Alertas de Inventario
@@ -864,7 +868,8 @@ Commits del slice en rama `super-plan`: `0fd6aac`, `42124d0`, `2c23dd6`, `af85e4
 | Dashboard principal           | ✅  | ✅      | ✅  | ✅      |                                                                                          |
 | Header (saludo + fecha)       | ✅  | ✅      | ✅  | ➖      | Todas las plataformas tienen saludo + fecha                                              |
 | KPI cards (8)                 | ✅  | ✅      | ✅  | ✅      | Labels consistentes. Web: "Cobrado (mes)" vs mobile: "Cobrado" (menor)                   |
-| Alertas de Atencion           | ✅  | ✅      | ✅  | ✅      | 3 tipos: vencido, pago pendiente, sin confirmar. Implementado en las 3 plataformas       |
+| Alertas de Atencion           | ✅  | ✅      | ✅  | ✅      | 3 categorias paridad cross-platform: cobro por cerrar, evento vencido, cotizacion urgente |
+| Acciones inline en alertas    | ✅  | ✅      | ✅  | ➖      | Completar / Cancelar / Pagar y completar (form de pago en modal/sheet/banner). Form/sheet reusable: web `PaymentFormFields`, android `PaymentModal` (core:designsystem), iOS `PaymentEntrySheet` (Common/Views) |
 | Quick Actions (2)             | ✅  | ✅      | ✅  | ➖      | Nuevo Evento + Nuevo Cliente en las 3 plataformas                                        |
 | Chart: Distribucion estados   | ✅  | ✅      | ✅  | ➖      |                                                                                          |
 | Chart: Comparacion financiera | ✅  | ✅      | ✅  | ➖      |                                                                                          |


### PR DESCRIPTION
## Summary

- Update `02_FEATURES.md` "Alertas de Atencion" section: rename categories to match the unified terms (Cobro por cerrar / Evento vencido / Cotizacion urgente), document inline action CTAs per category, and the `POST /payments` + `PUT /events/{id}` sequence used by "Pagar y completar".
- Update `11_CURRENT_STATUS.md` per platform with the new actions and reusable component names.
- Update architecture docs:
  - `05_TECHNICAL_ARCHITECTURE_IOS.md` → `Common/Views/PaymentEntrySheet`
  - `06_TECHNICAL_ARCHITECTURE_ANDROID.md` → `core:designsystem` `PaymentModal`
  - `08_TECHNICAL_ARCHITECTURE_WEB.md` → `components/PaymentFormFields.tsx` (replaces orphan `PendingEventsModal.tsx`)

## Merge order

This branch references components introduced by the three feature branches. Land them first, then merge this:

- #72 feat(web)
- #73 feat(android)
- #74 feat(ios)
- this PR

## Test plan

- [ ] Render preview in Obsidian / GitHub markdown to confirm tables align
- [ ] After the 3 feature PRs merge, re-grep the docs for any stale `Pago pendiente` / `Sin confirmar` references missed in this pass