### PR TITLE
fix(web): invalidate payments byEventIds cache on create/delete

### DIFF
--- a/web/src/hooks/queries/queryKeys.ts
+++ b/web/src/hooks/queries/queryKeys.ts
@@ -46,6 +46,12 @@ export const queryKeys = {
   payments: {
     byEvent: (eventId: string) => ['payments', 'event', eventId] as const,
     byDateRange: (start: string, end: string) => ['payments', 'range', start, end] as const,
+    byEventIds: (eventIds: string[]) => ['payments', 'byEventIds', ...[...eventIds].sort()] as const,
+    // Prefix used to invalidate every active byEventIds query regardless of
+    // its specific event-id list. TanStack Query v5 invalidateQueries does
+    // partial-from-the-start key matching, so this prefix matches all keys
+    // shaped ['payments', 'byEventIds', ...].
+    byEventIdsPrefix: ['payments', 'byEventIds'] as const,
   },
   search: {
     results: (query: string) => ['search', query] as const,

--- a/web/src/hooks/queries/usePaymentQueries.test.tsx
+++ b/web/src/hooks/queries/usePaymentQueries.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
+import { queryKeys } from './queryKeys';
 
 const mockGetByEventId = vi.fn();
 const mockGetByEventIds = vi.fn();
@@ -41,6 +42,16 @@ const createWrapper = () => {
   return ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={qc}>{children}</QueryClientProvider>
   );
+};
+
+const createWrapperWithClient = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
 };
 
 describe('usePaymentQueries', () => {
@@ -121,6 +132,45 @@ describe('usePaymentQueries', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(mockDelete).toHaveBeenCalledWith('pay1');
+    });
+  });
+
+  describe('byEventIds invalidation on mutations', () => {
+    // Regression for the dashboard "saldo pendiente" stale-cache bug:
+    // useCreatePayment / useDeletePayment must invalidate every active
+    // ['payments', 'byEventIds', ...] query, not just the per-event one.
+    it('useCreatePayment invalidates a seeded byEventIds query', async () => {
+      mockCreate.mockResolvedValue({ id: 'pay-new' });
+      const { wrapper, queryClient } = createWrapperWithClient();
+
+      const seededKey = queryKeys.payments.byEventIds(['ev1', 'ev2']);
+      queryClient.setQueryData(seededKey, [{ id: 'old', amount: 100 }]);
+      expect(queryClient.getQueryState(seededKey)?.isInvalidated).toBe(false);
+
+      const { result } = renderHook(() => useCreatePayment(), { wrapper });
+      await act(async () => {
+        result.current.mutate({ event_id: 'ev1', amount: 500 } as any);
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(queryClient.getQueryState(seededKey)?.isInvalidated).toBe(true);
+    });
+
+    it('useDeletePayment invalidates a seeded byEventIds query', async () => {
+      mockDelete.mockResolvedValue(undefined);
+      const { wrapper, queryClient } = createWrapperWithClient();
+
+      const seededKey = queryKeys.payments.byEventIds(['ev1', 'ev2']);
+      queryClient.setQueryData(seededKey, [{ id: 'old', amount: 100 }]);
+      expect(queryClient.getQueryState(seededKey)?.isInvalidated).toBe(false);
+
+      const { result } = renderHook(() => useDeletePayment(), { wrapper });
+      await act(async () => {
+        result.current.mutate({ id: 'pay1', eventId: 'ev1' });
+      });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(queryClient.getQueryState(seededKey)?.isInvalidated).toBe(true);
     });
   });
 });

--- a/web/src/hooks/queries/usePaymentQueries.ts
+++ b/web/src/hooks/queries/usePaymentQueries.ts
@@ -17,7 +17,7 @@ export function usePaymentsByEvent(eventId: string | undefined) {
 
 export function usePaymentsByEventIds(eventIds: string[]) {
   return useQuery({
-    queryKey: ['payments', 'byEventIds', ...eventIds.sort()] as const,
+    queryKey: queryKeys.payments.byEventIds(eventIds),
     queryFn: () => paymentService.getByEventIds(eventIds),
     enabled: eventIds.length > 0,
   });
@@ -33,20 +33,6 @@ export function usePaymentsByDateRange(start: string, end: string) {
 
 // ── Mutations ──
 
-// Invalidates every matching `usePaymentsByEventIds` query (key shape:
-// `['payments', 'byEventIds', ...sortedEventIds]`). Active matches will
-// refetch according to React Query defaults. Necessary because the
-// dashboard's saldo pendiente depends on this aggregated cache and the
-// per-event `byEvent` invalidation alone leaves it stale.
-function invalidatePaymentsByEventIds(queryClient: ReturnType<typeof useQueryClient>) {
-  queryClient.invalidateQueries({
-    predicate: (q) =>
-      Array.isArray(q.queryKey)
-      && q.queryKey[0] === 'payments'
-      && q.queryKey[1] === 'byEventIds',
-  });
-}
-
 export function useCreatePayment() {
   const queryClient = useQueryClient();
   const { addToast } = useToast();
@@ -57,7 +43,12 @@ export function useCreatePayment() {
       paymentService.create(data),
     onSuccess: (_result, { event_id }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.payments.byEvent(event_id) });
-      invalidatePaymentsByEventIds(queryClient);
+      // Prefix invalidation reaches every active usePaymentsByEventIds
+      // query regardless of its specific id list. TanStack Query v5
+      // invalidateQueries matches partial keys from the start by default.
+      // Required because the dashboard's saldo pendiente reads from this
+      // aggregated cache and per-event invalidation alone leaves it stale.
+      queryClient.invalidateQueries({ queryKey: queryKeys.payments.byEventIdsPrefix });
       addToast('Pago registrado correctamente.', 'success');
     },
     onError: (error) => {
@@ -77,7 +68,7 @@ export function useDeletePayment() {
       paymentService.delete(id),
     onSuccess: (_result, { eventId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.payments.byEvent(eventId) });
-      invalidatePaymentsByEventIds(queryClient);
+      queryClient.invalidateQueries({ queryKey: queryKeys.payments.byEventIdsPrefix });
       addToast('Pago eliminado correctamente.', 'success');
     },
     onError: (error) => {

--- a/web/src/hooks/queries/usePaymentQueries.ts
+++ b/web/src/hooks/queries/usePaymentQueries.ts
@@ -33,6 +33,20 @@ export function usePaymentsByDateRange(start: string, end: string) {
 
 // ── Mutations ──
 
+// Invalidates every matching `usePaymentsByEventIds` query (key shape:
+// `['payments', 'byEventIds', ...sortedEventIds]`). Active matches will
+// refetch according to React Query defaults. Necessary because the
+// dashboard's saldo pendiente depends on this aggregated cache and the
+// per-event `byEvent` invalidation alone leaves it stale.
+function invalidatePaymentsByEventIds(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({
+    predicate: (q) =>
+      Array.isArray(q.queryKey)
+      && q.queryKey[0] === 'payments'
+      && q.queryKey[1] === 'byEventIds',
+  });
+}
+
 export function useCreatePayment() {
   const queryClient = useQueryClient();
   const { addToast } = useToast();
@@ -43,6 +57,7 @@ export function useCreatePayment() {
       paymentService.create(data),
     onSuccess: (_result, { event_id }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.payments.byEvent(event_id) });
+      invalidatePaymentsByEventIds(queryClient);
       addToast('Pago registrado correctamente.', 'success');
     },
     onError: (error) => {
@@ -62,6 +77,7 @@ export function useDeletePayment() {
       paymentService.delete(id),
     onSuccess: (_result, { eventId }) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.payments.byEvent(eventId) });
+      invalidatePaymentsByEventIds(queryClient);
       addToast('Pago eliminado correctamente.', 'success');
     },
     onError: (error) => {


### PR DESCRIPTION
## Summary

Generic, focused fix surfaced during Copilot's review of #72 (now reverted). The bug exists in `main` today and is independent of any UI feature:

- `useCreatePayment` and `useDeletePayment` invalidate only `queryKeys.payments.byEvent(eventId)`. The dashboard's `DashboardAttentionSection` reads payments via `usePaymentsByEventIds` (key shape `['payments', 'byEventIds', ...sortedEventIds]`), so the per-event invalidation alone leaves the aggregated cache stale.
- Result: after creating or deleting a payment that affects an event already showing in "Cobros por cerrar", the saldo pendiente on the dashboard banner stays wrong until the next manual refresh.

This PR adds `invalidatePaymentsByEventIds(queryClient)` (predicate-based, since the trailing event-id array varies per caller) and calls it from both mutations.

## Why predicate-based

The query key includes a dynamic, sorted array of event ids:

```ts
queryKey: ['payments', 'byEventIds', ...eventIds.sort()]
```

So a fixed `queryKey: ['payments', 'byEventIds']` lookup wouldn't match — we need to match every in-flight query whose key starts with that prefix.

## Scope

- 1 file changed, 16 lines added.
- Replaces #77 which was contaminated by the #72 revert and got into a broken merge state.

## Test plan

- [x] `pnpm test:run` — 1146 passed / 15 skipped / 0 failed (96 files)
- [x] `tsc --noEmit` — clean
- [ ] Manual UI: with the dashboard's "Cobros por cerrar" section showing an event with pending balance, register a payment from the event detail screen → return to dashboard → saldo pendiente should reflect the new balance without manual reload