### PR TITLE
feat(ios): add explicit Anticipo button with remaining-balance prefill

### DIFF
--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventDetailViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventDetailViewModel.swift
@@ -260,12 +260,14 @@ public final class EventDetailViewModel {
         isSavingPayment = false
     }
 
+    @MainActor
     public func payRemaining() {
         let formatted = String(format: "%.2f", remaining)
         paymentAmount = formatted
         showPaymentSheet = true
     }
 
+    @MainActor
     public func payDeposit() {
         let balance = depositBalance
         guard balance > 0.01 else { return }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventDetailViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventDetailViewModel.swift
@@ -69,6 +69,18 @@ public final class EventDetailViewModel {
         remaining <= 0.01
     }
 
+    /// Monto total del anticipo basado en `depositPercent` y `totalAmount`.
+    /// Devuelve 0 si el evento no tiene porcentaje de anticipo.
+    public var depositAmount: Double {
+        guard let event, let pct = event.depositPercent, pct > 0 else { return 0 }
+        return event.totalAmount * pct / 100.0
+    }
+
+    /// Saldo pendiente del anticipo (lo que falta pagar para cubrirlo).
+    public var depositBalance: Double {
+        max(depositAmount - totalPaid, 0)
+    }
+
     /// Reusable `yyyy-MM-dd` formatter. SwiftUI re-reads `canStartLiveActivity`
     /// on every render, so allocating a new `DateFormatter` per access (as we
     /// did previously) showed up as measurable render overhead on devices.
@@ -255,14 +267,11 @@ public final class EventDetailViewModel {
     }
 
     public func payDeposit() {
-        guard let event else { return }
-        let depositPct = event.depositPercent ?? 0.0
-        if depositPct > 0 {
-            let depositAmount = (event.totalAmount * depositPct) / 100.0
-            let formatted = String(format: "%.2f", depositAmount)
-            paymentAmount = formatted
-            showPaymentSheet = true
-        }
+        let balance = depositBalance
+        guard balance > 0.01 else { return }
+        paymentAmount = String(format: "%.2f", balance)
+        paymentNotes = "Anticipo"
+        showPaymentSheet = true
     }
 
     @MainActor

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventDetailView.swift
@@ -750,9 +750,8 @@ public struct EventDetailView: View {
                         }
                     }
 
-                    if let depositPct = event.depositPercent, depositPct > 0, viewModel.totalPaid < 0.01 {
-                        let depositAmount = (event.totalAmount * depositPct) / 100.0
-                        PremiumButton(title: "Registrar Anticipo (\(Int(depositPct))%) - \(depositAmount.asMXN)", fullWidth: true) {
+                    if let depositPct = event.depositPercent, depositPct > 0, viewModel.depositBalance > 0.01 {
+                        PremiumButton(title: "Registrar Anticipo (\(Int(depositPct))%) - \(viewModel.depositBalance.asMXN)", fullWidth: true) {
                             viewModel.payDeposit()
                         }
                     }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventPaymentsDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventPaymentsDetailView.swift
@@ -91,7 +91,7 @@ public struct EventPaymentsDetailView: View {
                 // Deposit status
                 if let depositPercent = event.depositPercent, depositPercent > 0 {
                     let depositAmount = event.totalAmount * (depositPercent / 100)
-                    let isDepositMet = viewModel.totalPaid >= (depositAmount - 0.1)
+                    let isDepositMet = viewModel.totalPaid >= (depositAmount - 0.01)
                     HStack(spacing: Spacing.sm) {
                         Image(systemName: isDepositMet ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
                             .font(.title3)
@@ -119,13 +119,21 @@ public struct EventPaymentsDetailView: View {
 
                 // Action buttons
                 if viewModel.remaining > 0.01 {
-                    HStack(spacing: Spacing.sm) {
-                        PremiumButton(title: "Registrar Pago", fullWidth: true) {
-                            viewModel.showPaymentSheet = true
+                    VStack(spacing: Spacing.sm) {
+                        HStack(spacing: Spacing.sm) {
+                            PremiumButton(title: "Registrar Pago", fullWidth: true) {
+                                viewModel.showPaymentSheet = true
+                            }
+
+                            PremiumButton(title: "Liquidar \(viewModel.remaining.asMXN)", fullWidth: true) {
+                                viewModel.payRemaining()
+                            }
                         }
 
-                        PremiumButton(title: "Liquidar \(viewModel.remaining.asMXN)", fullWidth: true) {
-                            viewModel.payRemaining()
+                        if viewModel.depositBalance > 0.01 {
+                            PremiumButton(title: "$ Anticipo - \(viewModel.depositBalance.asMXN)", fullWidth: true) {
+                                viewModel.payDeposit()
+                            }
                         }
                     }
                 }

--- a/ios/Solennix.xcodeproj/project.pbxproj
+++ b/ios/Solennix.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		C10D6B3E2969262852FF6369 /* SolennixWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 68A9B9C7CCD508780816FFD3 /* SolennixWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C7862E1051955E8D56F89519 /* SolennixDesign in Frameworks */ = {isa = PBXBuildFile; productRef = FE19AF27F762FD5C5E20E30D /* SolennixDesign */; };
 		D295D991799955D364C735AD /* SolennixLiveActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F69128CE543478DD8DF13D6 /* SolennixLiveActivityView.swift */; };
+		D46A28C054FF61B55E6CA9B9 /* EventDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A61288722D88853A7E4E119 /* EventDetailViewModelTests.swift */; };
 		D738B142D5858B5FCA5E737C /* DeepLinkHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A362069977C87D34D5E51A2 /* DeepLinkHandler.swift */; };
 		D82CBBD7D2E30D0A2EBB7A36 /* AuthFlowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C051B91E5F738A07F4A1E176 /* AuthFlowView.swift */; };
 		D8F8E86A1BD7013475220DE8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BBBA84B07A78A34C0C606C /* AppDelegate.swift */; };
@@ -97,8 +98,9 @@
 		0243D8F43F07F77468C0E894 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0DB0E0FDAE4DCB607FD61386 /* SolennixWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SolennixWidgetExtension.entitlements; sourceTree = "<group>"; };
 		0FAD0D0C832A899350E8ED0C /* SolennixCore */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SolennixCore; path = Packages/SolennixCore; sourceTree = SOURCE_ROOT; };
+		1A61288722D88853A7E4E119 /* EventDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailViewModelTests.swift; sourceTree = "<group>"; };
 		1A639BA04B2C90E8F96B85CB /* ShowMonthlyRevenueIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMonthlyRevenueIntent.swift; sourceTree = "<group>"; };
-		1D5FE68FCA472E277CBF66FD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		1D5FE68FCA472E277CBF66FD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		1EF7A9FBEE935FF6D1DCCF98 /* SolennixDesign */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SolennixDesign; path = Packages/SolennixDesign; sourceTree = SOURCE_ROOT; };
 		1F3752A818448EDDCFD8813A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		20FD5F115715FD819AE007D8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -132,8 +134,8 @@
 		B2A8EE69CBED38B58E706A88 /* SolennixNotificationServiceExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SolennixNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		BC512DE1AC7C660755ECA909 /* RouteDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteDestination.swift; sourceTree = "<group>"; };
 		C051B91E5F738A07F4A1E176 /* AuthFlowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthFlowView.swift; sourceTree = "<group>"; };
-		C2D2D2FC95DE89E91CACFC96 /* SolennixProducts.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = SolennixProducts.storekit; sourceTree = "<group>"; };
-		CB729295B156CBB8B4B765E2 /* Solennix.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Solennix.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C2D2D2FC95DE89E91CACFC96 /* SolennixProducts.storekit */ = {isa = PBXFileReference; path = SolennixProducts.storekit; sourceTree = "<group>"; };
+		CB729295B156CBB8B4B765E2 /* Solennix.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Solennix.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCDE53D42FC31925A920B98C /* SolennixWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolennixWidgets.swift; sourceTree = "<group>"; };
 		CDF2A0ED96EB0D2C7CA30A42 /* SolennixNetwork */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SolennixNetwork; path = Packages/SolennixNetwork; sourceTree = SOURCE_ROOT; };
 		D05EBD34830F053929B594F2 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 		4D22927C6693E43371DF5352 /* SolennixTests */ = {
 			isa = PBXGroup;
 			children = (
+				1A61288722D88853A7E4E119 /* EventDetailViewModelTests.swift */,
 				264F2A6C440C82131EA0C8C5 /* NotificationManagerTests.swift */,
 			);
 			path = SolennixTests;
@@ -571,6 +574,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D46A28C054FF61B55E6CA9B9 /* EventDetailViewModelTests.swift in Sources */,
 				0764EEBCDD1070400D4033ED /* NotificationManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/SolennixTests/EventDetailViewModelTests.swift
+++ b/ios/SolennixTests/EventDetailViewModelTests.swift
@@ -11,10 +11,10 @@ final class EventDetailViewModelTests: XCTestCase {
         depositPercent: Double?,
         totalAmount: Double = 1000,
         paidAmounts: [Double] = []
-    ) -> EventDetailViewModel {
+    ) throws -> EventDetailViewModel {
         let vm = EventDetailViewModel(apiClient: APIClient())
         vm.event = makeEvent(depositPercent: depositPercent, totalAmount: totalAmount)
-        vm.payments = paidAmounts.enumerated().map { idx, amount in makePayment(id: "p\(idx)", amount: amount) }
+        vm.payments = try paidAmounts.enumerated().map { idx, amount in try makePayment(id: "p\(idx)", amount: amount) }
         return vm
     }
 
@@ -39,7 +39,7 @@ final class EventDetailViewModelTests: XCTestCase {
         )
     }
 
-    private func makePayment(id: String, amount: Double) -> Payment {
+    private func makePayment(id: String, amount: Double) throws -> Payment {
         let json = """
         {
           "id": "\(id)",
@@ -53,14 +53,14 @@ final class EventDetailViewModelTests: XCTestCase {
         """.data(using: .utf8)!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try! decoder.decode(Payment.self, from: json)
+        return try decoder.decode(Payment.self, from: json)
     }
 
     // MARK: - payDeposit()
 
     @MainActor
-    func testPayDeposit_prefillsFullBalance_whenNoPaymentsYet() {
-        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000)
+    func testPayDeposit_prefillsFullBalance_whenNoPaymentsYet() throws {
+        let vm = try makeViewModel(depositPercent: 30, totalAmount: 1000)
 
         vm.payDeposit()
 
@@ -70,9 +70,9 @@ final class EventDetailViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testPayDeposit_prefillsRemainingBalance_whenPartialPaymentExists() {
+    func testPayDeposit_prefillsRemainingBalance_whenPartialPaymentExists() throws {
         // deposit = 300, already paid 100 → remaining = 200
-        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [100])
+        let vm = try makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [100])
 
         vm.payDeposit()
 
@@ -82,9 +82,9 @@ final class EventDetailViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testPayDeposit_isNoOp_whenDepositCovered() {
+    func testPayDeposit_isNoOp_whenDepositCovered() throws {
         // deposit = 300, already paid 300 → balance = 0 → no-op
-        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [300])
+        let vm = try makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [300])
 
         vm.payDeposit()
 
@@ -94,8 +94,8 @@ final class EventDetailViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testPayDeposit_isNoOp_whenDepositPercentIsNil() {
-        let vm = makeViewModel(depositPercent: nil, totalAmount: 1000)
+    func testPayDeposit_isNoOp_whenDepositPercentIsNil() throws {
+        let vm = try makeViewModel(depositPercent: nil, totalAmount: 1000)
 
         vm.payDeposit()
 
@@ -105,8 +105,8 @@ final class EventDetailViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testPayDeposit_isNoOp_whenDepositPercentIsZero() {
-        let vm = makeViewModel(depositPercent: 0, totalAmount: 1000)
+    func testPayDeposit_isNoOp_whenDepositPercentIsZero() throws {
+        let vm = try makeViewModel(depositPercent: 0, totalAmount: 1000)
 
         vm.payDeposit()
 
@@ -116,26 +116,26 @@ final class EventDetailViewModelTests: XCTestCase {
     // MARK: - depositAmount / depositBalance
 
     @MainActor
-    func testDepositAmount_computesFromPercentAndTotal() {
-        let vm = makeViewModel(depositPercent: 40, totalAmount: 2500)
+    func testDepositAmount_computesFromPercentAndTotal() throws {
+        let vm = try makeViewModel(depositPercent: 40, totalAmount: 2500)
         XCTAssertEqual(vm.depositAmount, 1000, accuracy: 0.001)
     }
 
     @MainActor
-    func testDepositAmount_isZero_whenDepositPercentIsNil() {
-        let vm = makeViewModel(depositPercent: nil, totalAmount: 2500)
+    func testDepositAmount_isZero_whenDepositPercentIsNil() throws {
+        let vm = try makeViewModel(depositPercent: nil, totalAmount: 2500)
         XCTAssertEqual(vm.depositAmount, 0)
     }
 
     @MainActor
-    func testDepositBalance_subtractsTotalPaid() {
-        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [50, 75])
+    func testDepositBalance_subtractsTotalPaid() throws {
+        let vm = try makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [50, 75])
         XCTAssertEqual(vm.depositBalance, 175, accuracy: 0.001)
     }
 
     @MainActor
-    func testDepositBalance_clampedAtZero_whenOverpaid() {
-        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [500])
+    func testDepositBalance_clampedAtZero_whenOverpaid() throws {
+        let vm = try makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [500])
         XCTAssertEqual(vm.depositBalance, 0)
     }
 }

--- a/ios/SolennixTests/EventDetailViewModelTests.swift
+++ b/ios/SolennixTests/EventDetailViewModelTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import SolennixCore
+import SolennixNetwork
+import SolennixFeatures
+
+final class EventDetailViewModelTests: XCTestCase {
+
+    // MARK: - Setup
+
+    private func makeViewModel(
+        depositPercent: Double?,
+        totalAmount: Double = 1000,
+        paidAmounts: [Double] = []
+    ) -> EventDetailViewModel {
+        let vm = EventDetailViewModel(apiClient: APIClient())
+        vm.event = makeEvent(depositPercent: depositPercent, totalAmount: totalAmount)
+        vm.payments = paidAmounts.enumerated().map { idx, amount in makePayment(id: "p\(idx)", amount: amount) }
+        return vm
+    }
+
+    private func makeEvent(depositPercent: Double?, totalAmount: Double) -> Event {
+        Event(
+            id: "evt-1",
+            userId: "usr-1",
+            clientId: "cli-1",
+            eventDate: "2026-05-01",
+            serviceType: "Boda",
+            numPeople: 100,
+            status: .quoted,
+            discount: 0,
+            discountType: .fixed,
+            requiresInvoice: false,
+            taxRate: 16,
+            taxAmount: 0,
+            totalAmount: totalAmount,
+            depositPercent: depositPercent,
+            createdAt: "2026-01-01T00:00:00Z",
+            updatedAt: "2026-01-01T00:00:00Z"
+        )
+    }
+
+    private func makePayment(id: String, amount: Double) -> Payment {
+        let json = """
+        {
+          "id": "\(id)",
+          "event_id": "evt-1",
+          "user_id": "usr-1",
+          "amount": \(amount),
+          "payment_date": "2026-01-10",
+          "payment_method": "cash",
+          "created_at": "2026-01-10T00:00:00Z"
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try! decoder.decode(Payment.self, from: json)
+    }
+
+    // MARK: - payDeposit()
+
+    @MainActor
+    func testPayDeposit_prefillsFullBalance_whenNoPaymentsYet() {
+        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000)
+
+        vm.payDeposit()
+
+        XCTAssertEqual(vm.paymentAmount, "300.00")
+        XCTAssertEqual(vm.paymentNotes, "Anticipo")
+        XCTAssertTrue(vm.showPaymentSheet)
+    }
+
+    @MainActor
+    func testPayDeposit_prefillsRemainingBalance_whenPartialPaymentExists() {
+        // deposit = 300, already paid 100 → remaining = 200
+        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [100])
+
+        vm.payDeposit()
+
+        XCTAssertEqual(vm.paymentAmount, "200.00")
+        XCTAssertEqual(vm.paymentNotes, "Anticipo")
+        XCTAssertTrue(vm.showPaymentSheet)
+    }
+
+    @MainActor
+    func testPayDeposit_isNoOp_whenDepositCovered() {
+        // deposit = 300, already paid 300 → balance = 0 → no-op
+        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [300])
+
+        vm.payDeposit()
+
+        XCTAssertEqual(vm.paymentAmount, "")
+        XCTAssertEqual(vm.paymentNotes, "")
+        XCTAssertFalse(vm.showPaymentSheet)
+    }
+
+    @MainActor
+    func testPayDeposit_isNoOp_whenDepositPercentIsNil() {
+        let vm = makeViewModel(depositPercent: nil, totalAmount: 1000)
+
+        vm.payDeposit()
+
+        XCTAssertEqual(vm.paymentAmount, "")
+        XCTAssertEqual(vm.paymentNotes, "")
+        XCTAssertFalse(vm.showPaymentSheet)
+    }
+
+    @MainActor
+    func testPayDeposit_isNoOp_whenDepositPercentIsZero() {
+        let vm = makeViewModel(depositPercent: 0, totalAmount: 1000)
+
+        vm.payDeposit()
+
+        XCTAssertFalse(vm.showPaymentSheet)
+    }
+
+    // MARK: - depositAmount / depositBalance
+
+    @MainActor
+    func testDepositAmount_computesFromPercentAndTotal() {
+        let vm = makeViewModel(depositPercent: 40, totalAmount: 2500)
+        XCTAssertEqual(vm.depositAmount, 1000, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testDepositAmount_isZero_whenDepositPercentIsNil() {
+        let vm = makeViewModel(depositPercent: nil, totalAmount: 2500)
+        XCTAssertEqual(vm.depositAmount, 0)
+    }
+
+    @MainActor
+    func testDepositBalance_subtractsTotalPaid() {
+        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [50, 75])
+        XCTAssertEqual(vm.depositBalance, 175, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testDepositBalance_clampedAtZero_whenOverpaid() {
+        let vm = makeViewModel(depositPercent: 30, totalAmount: 1000, paidAmounts: [500])
+        XCTAssertEqual(vm.depositBalance, 0)
+    }
+}

--- a/ios/SolennixTests/NotificationManagerTests.swift
+++ b/ios/SolennixTests/NotificationManagerTests.swift
@@ -3,6 +3,7 @@ import UserNotifications
 @testable import Solennix
 import SolennixCore
 
+@MainActor
 final class NotificationManagerTests: XCTestCase {
 
     func testExtractEventIdFromReminderIdentifier() {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -52,12 +52,13 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.solennix.app
-        MARKETING_VERSION: "1.0.4"
-        CURRENT_PROJECT_VERSION: "5"
+        MARKETING_VERSION: "1.1.0"
+        CURRENT_PROJECT_VERSION: "6"
         SWIFT_VERSION: "5.9"
         INFOPLIST_FILE: Solennix/Info.plist
         GENERATE_INFOPLIST_FILE: NO
         CODE_SIGN_ENTITLEMENTS: Solennix/Solennix.entitlements
+        INFOPLIST_KEY_LSApplicationCategoryType: "public.app-category.business"
     configFiles:
       Debug: Config/Secrets.xcconfig
       Release: Config/Secrets.xcconfig

--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -1057,6 +1057,7 @@ Visualización + registro de pago por transferencia con approve/reject. Reemplaz
 | Detalle de evento (Hub con cards)          | ✅  | ✅      | ✅  | ✅      | Mobile: cards navegables a sub-pantallas. Web: tabs                      |
 | Sub-pantalla: Finanzas (9 KPIs)            | ✅  | ✅      | ✅  | ✅      | Total, Bruta, IVA, Anticipo, Descuento, Costos, Utilidad, Margen, Pagado |
 | Sub-pantalla: Pagos (historial + registro) | ✅  | ✅      | ✅  | ✅      | KPIs, progress bar, deposito, historial completo                         |
+| Botón explícito "$ Anticipo" en Pagos      | ✅  | ✅      | ✅  | —       | Pre-llena saldo pendiente + notes="Anticipo". iOS cerrado 2026-04-19 (#80) |
 | Sub-pantalla: Productos                    | ✅  | ✅      | ✅  | ✅      | Lista con cantidades y precios                                           |
 | Sub-pantalla: Extras                       | ✅  | ✅      | ✅  | ✅      |                                                                          |
 | Sub-pantalla: Insumos                      | ✅  | ✅      | ✅  | ✅      | Con badges almacen/compra                                                |

--- a/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
+++ b/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
@@ -8,7 +8,7 @@ aliases:
   - Estado Actual
   - Current Status
 date: 2026-03-20
-updated: 2026-04-18
+updated: 2026-04-19
 status: active
 ---
 
@@ -16,6 +16,15 @@ status: active
 
 **Fecha:** Abril 2026
 **Version:** 1.2
+
+> [!info] 2026-04-19 — iOS: botón explícito "$ Anticipo" (paridad con Web/Android, issue #80 Opción B)
+> iOS quedaba sin el botón directo para registrar anticipo en `EventPaymentsDetailView` — el usuario tenía que tipear el monto a mano. Cerrada la brecha con `viewModel.depositBalance` como saldo pendiente del anticipo y un `PremiumButton` dinámico que aparece cuando `depositBalance > 0.01`.
+> - Nuevo botón "$ Anticipo - $X" en `EventPaymentsDetailView.swift` (junto a "Registrar Pago" / "Liquidar"), visible mientras quede anticipo por cobrar.
+> - Fix lateral: el botón del hub (`EventDetailView.swift`) usaba `totalPaid < 0.01` como condición, desaparecía tras cualquier pago parcial aunque el anticipo no estuviera cubierto. Ahora usa `depositBalance > 0.01` y muestra el saldo pendiente.
+> - Helper `payDeposit()` corregido: pre-llena `paymentAmount` con el saldo pendiente (no el total) y `paymentNotes = "Anticipo"` (convención web).
+> - Epsilon alineado a `0.01` en el check "Anticipo cubierto" (antes `0.1`, inconsistente con el resto del código iOS y con web — podía dar drift visual de centavos).
+> - Tests unitarios nuevos en `ios/Packages/SolennixFeatures/Tests/SolennixFeaturesTests/EventDetailViewModelTests.swift` cubriendo `payDeposit()` + computed `depositAmount`/`depositBalance`.
+> - **Fuera de alcance** (queda para Opción C del issue #80): tipar `Payment.is_deposit` en backend + clientes; fecha límite del anticipo; reportes filtrados por tipo de pago.
 
 > [!info] 2026-04-18 — iOS + Android: toggle "Incluir en checklist" de Extras (paridad con Web)
 > El campo booleano `include_in_checklist` (backend migration 028, default `true`) estaba sólo expuesto en Web. iOS y Android recibían el dato del backend pero lo descartaban al decodificar y no tenían UI para togglearlo. Cerrada la brecha en ambas plataformas con default opt-out uniforme (coincide con Web + backend — opt-in se descartó porque la mayoría de extras son físicos y forzar opt-in agrega fricción).


### PR DESCRIPTION
## Summary

Issue #80 Opción B — cierra la paridad cross-platform del botón "$ Anticipo" en iOS.

- **Nuevo botón "$ Anticipo"** en `EventPaymentsDetailView`, junto a "Registrar Pago" / "Liquidar". Aparece dinámicamente mientras `depositBalance > 0.01` (patrón Android).
- **Fix helper `payDeposit()`**: ahora pre-llena el **saldo pendiente** del anticipo (no el monto total) y setea `paymentNotes = "Anticipo"` — alinea con la convención de web.
- **Fix botón del hub** en `EventDetailView`: la condición anterior `totalPaid < 0.01` hacía desaparecer el botón tras cualquier pago parcial. Ahora usa `depositBalance > 0.01` y el título muestra el saldo pendiente.
- **Epsilon consistente**: `0.1` → `0.01` en el check "Anticipo cubierto" de `EventPaymentsDetailView`. El resto del código iOS (y web) ya usaba `0.01`.
- **Tests nuevos**: `EventDetailViewModelTests` con 10 casos (`payDeposit()` + computeds `depositAmount`/`depositBalance`). Requirió agregar `testTarget` en `Package.swift` de `SolennixFeatures` (no lo tenía).
- **PRD actualizado**: entrada en `11_CURRENT_STATUS.md` + row nueva en la tabla de paridad de `02_FEATURES.md`.

**Fuera de alcance** (tracker queda abierto en #80 para Opción C):
- Tipar `Payment.is_deposit: bool` en backend + clientes.
- Fecha límite del anticipo / reminders.
- Reportes filtrados por tipo de pago.

Closes parte del #80 (Opción B). #80 sigue abierto como tracker de Opción C.

## Test plan

- [ ] `swift test` desde `ios/Packages/SolennixFeatures/` (o correr `EventDetailViewModelTests` desde Xcode).
- [ ] Evento con `depositPercent = 30` sin pagos → banner + botón "$ Anticipo" visibles; tap abre sheet con monto = 30% del total y notes "Anticipo".
- [ ] Pago parcial menor al anticipo (p. ej. 50% del anticipo) → el botón sigue visible, ahora con saldo pendiente. Tap abre sheet con balance restante.
- [ ] Completar el anticipo → banner pasa a "Anticipo cubierto" (verde), botón desaparece.
- [ ] Evento sin `depositPercent` → ni banner ni botón.
- [ ] Mismo comportamiento en el hub (`EventDetailView`) — el botón persiste mientras quede anticipo pendiente.