### PR TITLE
feat: Personal Ola 1 — shifts, RSVP status and staff availability

### DIFF
--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/StaffRepository.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/StaffRepository.kt
@@ -11,6 +11,7 @@ import com.creapolis.solennix.core.database.entity.asExternalModel
 import com.creapolis.solennix.core.model.EventStaff
 import com.creapolis.solennix.core.model.PaginatedResponse
 import com.creapolis.solennix.core.model.Staff
+import com.creapolis.solennix.core.model.StaffAvailability
 import com.creapolis.solennix.core.network.ApiService
 import com.creapolis.solennix.core.network.Endpoints
 import com.creapolis.solennix.core.network.SolennixException
@@ -48,6 +49,17 @@ interface StaffRepository {
      * No-op silencioso si el GET falla (la UI cae al cache).
      */
     suspend fun syncEventStaff(eventId: String): List<EventStaff>
+
+    /**
+     * `GET /api/staff/availability` — sólo devuelve colaboradores CON asignaciones
+     * en la ventana consultada. Si se pasa [date] se consulta ese día; si se pasan
+     * [start]/[end] se consulta el rango.
+     */
+    suspend fun getStaffAvailability(
+        date: String? = null,
+        start: String? = null,
+        end: String? = null
+    ): List<StaffAvailability>
 }
 
 @Singleton
@@ -126,5 +138,18 @@ class OfflineFirstStaffRepository @Inject constructor(
         val remote: List<EventStaff> = apiService.get(Endpoints.eventStaff(eventId))
         staffDao.replaceEventStaff(eventId, remote.map { it.asEntity() })
         return remote
+    }
+
+    override suspend fun getStaffAvailability(
+        date: String?,
+        start: String?,
+        end: String?
+    ): List<StaffAvailability> {
+        val params = buildMap {
+            if (!date.isNullOrBlank()) put("date", date)
+            if (!start.isNullOrBlank()) put("start", start)
+            if (!end.isNullOrBlank()) put("end", end)
+        }
+        return apiService.get(Endpoints.STAFF_AVAILABILITY, params)
     }
 }

--- a/android/core/database/schemas/com.creapolis.solennix.core.database.SolennixDatabase/9.json
+++ b/android/core/database/schemas/com.creapolis.solennix.core.database.SolennixDatabase/9.json
@@ -1,0 +1,807 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "d4af080b5662661cb951dbeae0feaf22",
+    "entities": [
+      {
+        "tableName": "clients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT NOT NULL, `phone` TEXT NOT NULL, `email` TEXT, `address` TEXT, `city` TEXT, `notes` TEXT, `photo_url` TEXT, `total_events` INTEGER, `total_spent` REAL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `sync_status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalEvents",
+            "columnName": "total_events",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalSpent",
+            "columnName": "total_spent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `client_id` TEXT NOT NULL, `event_date` TEXT NOT NULL, `start_time` TEXT, `end_time` TEXT, `service_type` TEXT NOT NULL, `num_people` INTEGER NOT NULL, `status` TEXT NOT NULL, `discount` REAL NOT NULL, `discount_type` TEXT NOT NULL, `requires_invoice` INTEGER NOT NULL, `tax_rate` REAL NOT NULL, `tax_amount` REAL NOT NULL, `total_amount` REAL NOT NULL, `location` TEXT, `city` TEXT, `deposit_percent` REAL, `cancellation_days` REAL, `refund_percent` REAL, `notes` TEXT, `photos` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `sync_status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientId",
+            "columnName": "client_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventDate",
+            "columnName": "event_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "serviceType",
+            "columnName": "service_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeople",
+            "columnName": "num_people",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discount",
+            "columnName": "discount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discountType",
+            "columnName": "discount_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiresInvoice",
+            "columnName": "requires_invoice",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taxRate",
+            "columnName": "tax_rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taxAmount",
+            "columnName": "tax_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "depositPercent",
+            "columnName": "deposit_percent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cancellationDays",
+            "columnName": "cancellation_days",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "refundPercent",
+            "columnName": "refund_percent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photos",
+            "columnName": "photos",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "products",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT NOT NULL, `category` TEXT NOT NULL, `base_price` REAL NOT NULL, `recipe` TEXT, `image_url` TEXT, `is_active` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "basePrice",
+            "columnName": "base_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipe",
+            "columnName": "recipe",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "inventory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `ingredient_name` TEXT NOT NULL, `current_stock` REAL NOT NULL, `minimum_stock` REAL NOT NULL, `unit` TEXT NOT NULL, `unit_cost` REAL, `last_updated` TEXT NOT NULL, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredient_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStock",
+            "columnName": "current_stock",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minimumStock",
+            "columnName": "minimum_stock",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitCost",
+            "columnName": "unit_cost",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "payments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `eventId` TEXT NOT NULL, `userId` TEXT NOT NULL, `amount` REAL NOT NULL, `paymentDate` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `notes` TEXT, `createdAt` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentDate",
+            "columnName": "paymentDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "paymentMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "event_products",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `event_id` TEXT NOT NULL, `product_id` TEXT NOT NULL, `quantity` REAL NOT NULL, `unit_price` REAL NOT NULL, `discount` REAL NOT NULL, `total_price` REAL, `created_at` TEXT NOT NULL, `product_name` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "product_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discount",
+            "columnName": "discount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPrice",
+            "columnName": "total_price",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "event_extras",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `event_id` TEXT NOT NULL, `description` TEXT NOT NULL, `cost` REAL NOT NULL, `price` REAL NOT NULL, `exclude_utility` INTEGER NOT NULL, `include_in_checklist` INTEGER NOT NULL DEFAULT 1, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeUtility",
+            "columnName": "exclude_utility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeInChecklist",
+            "columnName": "include_in_checklist",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cached_staff",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT NOT NULL, `role_label` TEXT, `phone` TEXT, `email` TEXT, `notes` TEXT, `notification_email_opt_in` INTEGER NOT NULL, `invited_user_id` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `sync_status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roleLabel",
+            "columnName": "role_label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationEmailOptIn",
+            "columnName": "notification_email_opt_in",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invitedUserId",
+            "columnName": "invited_user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cached_event_staff",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `event_id` TEXT NOT NULL, `staff_id` TEXT NOT NULL, `fee_amount` REAL, `role_override` TEXT, `notes` TEXT, `notification_sent_at` TEXT, `notification_last_result` TEXT, `created_at` TEXT NOT NULL, `staff_name` TEXT, `staff_role_label` TEXT, `staff_phone` TEXT, `staff_email` TEXT, `shift_start` TEXT, `shift_end` TEXT, `status` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staffId",
+            "columnName": "staff_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feeAmount",
+            "columnName": "fee_amount",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "roleOverride",
+            "columnName": "role_override",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationSentAt",
+            "columnName": "notification_sent_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationLastResult",
+            "columnName": "notification_last_result",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staffName",
+            "columnName": "staff_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "staffRoleLabel",
+            "columnName": "staff_role_label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "staffPhone",
+            "columnName": "staff_phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "staffEmail",
+            "columnName": "staff_email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shiftStart",
+            "columnName": "shift_start",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shiftEnd",
+            "columnName": "shift_end",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd4af080b5662661cb951dbeae0feaf22')"
+    ]
+  }
+}

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/SolennixDatabase.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/SolennixDatabase.kt
@@ -40,7 +40,7 @@ const val DATABASE_NAME = "solennix-database"
         CachedStaff::class,
         CachedEventStaff::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = true
 )
 @TypeConverters(JsonConverters::class)
@@ -142,7 +142,23 @@ abstract class SolennixDatabase : RoomDatabase() {
             }
         }
 
-        val ALL_MIGRATIONS = arrayOf(MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8)
+        /**
+         * v9 — Ola 1 (operational layer) del módulo Personal.
+         *
+         * Agrega `shift_start`, `shift_end` y `status` a `cached_event_staff`
+         * para espejar el backend. Nullable — filas existentes quedan sin turno
+         * y sin status (la UI asume `confirmed` cuando `status` es null).
+         */
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                Log.d(TAG, "Running migration 8 -> 9: add shift_start/shift_end/status to cached_event_staff")
+                db.execSQL("ALTER TABLE cached_event_staff ADD COLUMN shift_start TEXT")
+                db.execSQL("ALTER TABLE cached_event_staff ADD COLUMN shift_end TEXT")
+                db.execSQL("ALTER TABLE cached_event_staff ADD COLUMN status TEXT")
+            }
+        }
+
+        val ALL_MIGRATIONS = arrayOf(MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
 
         /**
          * Manual singleton for use in contexts without Hilt (e.g., Glance widgets).

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/entity/CachedStaff.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/entity/CachedStaff.kt
@@ -71,7 +71,11 @@ data class CachedEventStaff(
     @ColumnInfo(name = "staff_name") val staffName: String?,
     @ColumnInfo(name = "staff_role_label") val staffRoleLabel: String?,
     @ColumnInfo(name = "staff_phone") val staffPhone: String?,
-    @ColumnInfo(name = "staff_email") val staffEmail: String?
+    @ColumnInfo(name = "staff_email") val staffEmail: String?,
+    // Ola 1 (operational layer)
+    @ColumnInfo(name = "shift_start") val shiftStart: String? = null,
+    @ColumnInfo(name = "shift_end") val shiftEnd: String? = null,
+    val status: String? = null
 )
 
 fun CachedEventStaff.asExternalModel() = EventStaff(
@@ -87,7 +91,10 @@ fun CachedEventStaff.asExternalModel() = EventStaff(
     staffName = staffName,
     staffRoleLabel = staffRoleLabel,
     staffPhone = staffPhone,
-    staffEmail = staffEmail
+    staffEmail = staffEmail,
+    shiftStart = shiftStart,
+    shiftEnd = shiftEnd,
+    status = status
 )
 
 fun EventStaff.asEntity() = CachedEventStaff(
@@ -103,5 +110,8 @@ fun EventStaff.asEntity() = CachedEventStaff(
     staffName = staffName,
     staffRoleLabel = staffRoleLabel,
     staffPhone = staffPhone,
-    staffEmail = staffEmail
+    staffEmail = staffEmail,
+    shiftStart = shiftStart,
+    shiftEnd = shiftEnd,
+    status = status
 )

--- a/android/core/model/src/main/java/com/creapolis/solennix/core/model/EventStaff.kt
+++ b/android/core/model/src/main/java/com/creapolis/solennix/core/model/EventStaff.kt
@@ -12,6 +12,12 @@ import kotlinx.serialization.Serializable
  *
  * `notificationSentAt` / `notificationLastResult` se poblarán en Phase 2
  * cuando el email de asignación sea real. En Phase 1 son null.
+ *
+ * Ola 1 (operational layer) añade `shiftStart`, `shiftEnd` y `status`:
+ *   - `shiftStart` / `shiftEnd`: ISO8601 UTC, opcionales. Pueden cruzar medianoche.
+ *   - `status`: enum (`pending|confirmed|declined|cancelled`). Opcional en payloads
+ *     (nil = preservar valor existente en upsert). En lecturas del backend siempre
+ *     viene poblado, pero se mantiene nullable por compatibilidad con caches viejos.
  */
 @Serializable
 data class EventStaff(
@@ -29,18 +35,53 @@ data class EventStaff(
     @SerialName("staff_name") val staffName: String? = null,
     @SerialName("staff_role_label") val staffRoleLabel: String? = null,
     @SerialName("staff_phone") val staffPhone: String? = null,
-    @SerialName("staff_email") val staffEmail: String? = null
+    @SerialName("staff_email") val staffEmail: String? = null,
+
+    // Ola 1
+    @SerialName("shift_start") val shiftStart: String? = null,
+    @SerialName("shift_end") val shiftEnd: String? = null,
+    val status: String? = null
 )
 
 /**
  * Payload que se manda dentro de `PUT /api/events/{id}/items` en la lista
  * `staff`. No incluye id/event_id/created_at/notification_* — el backend
  * los maneja.
+ *
+ * Los campos de Ola 1 (`shiftStart`, `shiftEnd`, `status`) son opcionales:
+ * si se mandan como `null` el backend preserva el valor existente en upsert.
  */
 @Serializable
 data class EventStaffAssignmentPayload(
     @SerialName("staff_id") val staffId: String,
     @SerialName("fee_amount") val feeAmount: Double? = null,
     @SerialName("role_override") val roleOverride: String? = null,
-    val notes: String? = null
+    val notes: String? = null,
+    @SerialName("shift_start") val shiftStart: String? = null,
+    @SerialName("shift_end") val shiftEnd: String? = null,
+    val status: String? = null
 )
+
+/**
+ * Estado de una asignación a evento. El backend persiste el valor crudo
+ * (`pending|confirmed|declined|cancelled`); este enum lo normaliza para el
+ * cliente — valores desconocidos caen a [CONFIRMED] para mantener paridad
+ * con el default del servidor.
+ */
+enum class AssignmentStatus(val raw: String) {
+    PENDING("pending"),
+    CONFIRMED("confirmed"),
+    DECLINED("declined"),
+    CANCELLED("cancelled");
+
+    companion object {
+        fun fromString(value: String?): AssignmentStatus =
+            when (value?.lowercase()) {
+                "pending" -> PENDING
+                "confirmed" -> CONFIRMED
+                "declined" -> DECLINED
+                "cancelled" -> CANCELLED
+                else -> CONFIRMED
+            }
+    }
+}

--- a/android/core/model/src/main/java/com/creapolis/solennix/core/model/StaffAvailability.kt
+++ b/android/core/model/src/main/java/com/creapolis/solennix/core/model/StaffAvailability.kt
@@ -1,0 +1,26 @@
+package com.creapolis.solennix.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Respuesta de `GET /api/staff/availability?date=YYYY-MM-DD` o
+ * `?start=YYYY-MM-DD&end=YYYY-MM-DD`. Sólo se devuelven colaboradores CON
+ * asignaciones en la ventana consultada — si un staff no aparece, está libre.
+ */
+@Serializable
+data class StaffAvailability(
+    @SerialName("staff_id") val staffId: String,
+    @SerialName("staff_name") val staffName: String,
+    val assignments: List<StaffAvailabilityAssignment> = emptyList()
+)
+
+@Serializable
+data class StaffAvailabilityAssignment(
+    @SerialName("event_id") val eventId: String,
+    @SerialName("event_name") val eventName: String,
+    @SerialName("event_date") val eventDate: String,
+    @SerialName("shift_start") val shiftStart: String? = null,
+    @SerialName("shift_end") val shiftEnd: String? = null,
+    val status: String
+)

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
@@ -19,6 +19,7 @@ object Endpoints {
 
     // Staff (Personal / Colaboradores)
     const val STAFF = "staff"
+    const val STAFF_AVAILABILITY = "staff/availability"
     fun staff(id: String) = "staff/$id"
     fun eventStaff(eventId: String) = "events/$eventId/staff"
 

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailSubScreens.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailSubScreens.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -22,6 +23,7 @@ import com.creapolis.solennix.core.designsystem.component.PremiumButton
 import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
 import com.creapolis.solennix.core.designsystem.component.StatusBadge
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.AssignmentStatus
 import com.creapolis.solennix.core.model.DiscountType
 import com.creapolis.solennix.core.model.SupplySource
 import com.creapolis.solennix.core.model.extensions.asMXN
@@ -1325,6 +1327,22 @@ fun EventStaffScreen(
                                 }
                             }
 
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                AssignmentStatusBadge(assignment.status)
+                                val window = formatShiftWindow(assignment.shiftStart, assignment.shiftEnd)
+                                if (window != null) {
+                                    Text(
+                                        window,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = SolennixTheme.colors.secondaryText
+                                    )
+                                }
+                            }
+
                             val contact = listOfNotNull(
                                 assignment.staffPhone?.takeIf { it.isNotBlank() },
                                 assignment.staffEmail?.takeIf { it.isNotBlank() }
@@ -1351,5 +1369,52 @@ fun EventStaffScreen(
                 }
             }
         }
+    }
+}
+
+// ==================== Assignment status helpers ====================
+
+@Composable
+private fun AssignmentStatusBadge(rawStatus: String?) {
+    val status = AssignmentStatus.fromString(rawStatus)
+    val (label, color) = when (status) {
+        AssignmentStatus.PENDING -> "Sin confirmar" to Color(0xFFB7791F)
+        AssignmentStatus.CONFIRMED -> "Confirmado" to Color(0xFF2F855A)
+        AssignmentStatus.DECLINED -> "Rechazó" to Color(0xFFC53030)
+        AssignmentStatus.CANCELLED -> "Cancelado" to Color(0xFF718096)
+    }
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = color.copy(alpha = 0.15f)
+    ) {
+        Text(
+            label,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+/**
+ * Formatea el turno como `HH:mm – HH:mm` en hora local. Devuelve null si
+ * ambos extremos son null. Si solo uno está seteado, muestra ese extremo.
+ */
+private fun formatShiftWindow(shiftStartIso: String?, shiftEndIso: String?): String? {
+    if (shiftStartIso.isNullOrBlank() && shiftEndIso.isNullOrBlank()) return null
+    val zone = java.time.ZoneId.systemDefault()
+    val fmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+    val start = shiftStartIso?.let {
+        runCatching { java.time.Instant.parse(it).atZone(zone).toLocalTime().format(fmt) }.getOrNull()
+    }
+    val end = shiftEndIso?.let {
+        runCatching { java.time.Instant.parse(it).atZone(zone).toLocalTime().format(fmt) }.getOrNull()
+    }
+    return when {
+        start != null && end != null -> "$start – $end"
+        start != null -> "Desde $start"
+        end != null -> "Hasta $end"
+        else -> null
     }
 }

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventFormScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventFormScreen.kt
@@ -1946,9 +1946,16 @@ private fun StaffAssignmentPanel(viewModel: EventFormViewModel) {
             viewModel.selectedStaff.forEach { assignment ->
                 StaffAssignmentCard(
                     assignment = assignment,
+                    defaultStart = viewModel.startTime,
+                    defaultEnd = viewModel.endTime,
                     onFeeChange = { viewModel.updateStaffFee(assignment.staffId, it) },
                     onRoleChange = { viewModel.updateStaffRoleOverride(assignment.staffId, it) },
                     onNotesChange = { viewModel.updateStaffNotes(assignment.staffId, it) },
+                    onShiftChange = { start, end ->
+                        viewModel.updateStaffShift(assignment.staffId, start, end)
+                    },
+                    onShiftClear = { viewModel.clearStaffShift(assignment.staffId) },
+                    onStatusChange = { viewModel.updateStaffStatus(assignment.staffId, it) },
                     onRemove = { viewModel.removeStaffAssignment(assignment.staffId) }
                 )
                 Spacer(modifier = Modifier.height(8.dp))
@@ -1973,17 +1980,54 @@ private fun StaffAssignmentPanel(viewModel: EventFormViewModel) {
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun StaffAssignmentCard(
     assignment: SelectedStaffAssignment,
+    defaultStart: String,
+    defaultEnd: String,
     onFeeChange: (Double?) -> Unit,
     onRoleChange: (String) -> Unit,
     onNotesChange: (String) -> Unit,
+    onShiftChange: (java.time.LocalTime?, java.time.LocalTime?) -> Unit,
+    onShiftClear: () -> Unit,
+    onStatusChange: (AssignmentStatus) -> Unit,
     onRemove: () -> Unit
 ) {
     var feeText by remember(assignment.staffId) {
         mutableStateOf(assignment.feeAmount?.let { "%.2f".format(it) } ?: "")
     }
+
+    val currentStatus = remember(assignment.status) {
+        AssignmentStatus.fromString(assignment.status)
+    }
+    var shiftExpanded by remember(assignment.staffId) {
+        mutableStateOf(!assignment.shiftStart.isNullOrBlank() || !assignment.shiftEnd.isNullOrBlank())
+    }
+    val zone = java.time.ZoneId.systemDefault()
+    val startLocalTime = remember(assignment.shiftStart) {
+        assignment.shiftStart?.let {
+            try {
+                java.time.Instant.parse(it).atZone(zone).toLocalTime()
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+    val endLocalTime = remember(assignment.shiftEnd) {
+        assignment.shiftEnd?.let {
+            try {
+                java.time.Instant.parse(it).atZone(zone).toLocalTime()
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+    val defaultStartLocal = remember(defaultStart) { parseHHmmOrNull(defaultStart) }
+    val defaultEndLocal = remember(defaultEnd) { parseHHmmOrNull(defaultEnd) }
+
+    var showStartPicker by remember { mutableStateOf(false) }
+    var showEndPicker by remember { mutableStateOf(false) }
 
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -2017,6 +2061,28 @@ private fun StaffAssignmentCard(
             }
 
             Spacer(modifier = Modifier.height(8.dp))
+
+            // Status chips — sin confirmar / confirmado / rechazó / cancelado.
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                AssignmentStatus.values().forEach { opt ->
+                    FilterChip(
+                        selected = opt == currentStatus,
+                        onClick = { onStatusChange(opt) },
+                        label = { Text(opt.uiLabel()) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            selectedContainerColor = opt.uiColor().copy(alpha = 0.18f),
+                            selectedLabelColor = opt.uiColor()
+                        )
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
 
             AdaptiveFormRow(
                 left = {
@@ -2053,8 +2119,130 @@ private fun StaffAssignmentCard(
                 modifier = Modifier.fillMaxWidth(),
                 maxLines = 3
             )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Sección expandible del turno — oculta por default.
+            TextButton(
+                onClick = { shiftExpanded = !shiftExpanded },
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                Icon(
+                    if (shiftExpanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = null
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    if (shiftExpanded) "Horario del turno" else "Agregar horario (opcional)",
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+
+            if (shiftExpanded) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedButton(
+                        onClick = { showStartPicker = true },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(Icons.Default.Schedule, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            startLocalTime?.let { formatTime(it) } ?: "Entrada"
+                        )
+                    }
+                    OutlinedButton(
+                        onClick = { showEndPicker = true },
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(Icons.Default.Schedule, contentDescription = null, modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            endLocalTime?.let { formatTime(it) } ?: "Salida"
+                        )
+                    }
+                    if (startLocalTime != null || endLocalTime != null) {
+                        IconButton(onClick = onShiftClear) {
+                            Icon(
+                                Icons.Default.Clear,
+                                contentDescription = "Limpiar turno",
+                                tint = SolennixTheme.colors.secondaryText
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (showStartPicker) {
+                val pickerState = rememberTimePickerState(
+                    initialHour = (startLocalTime ?: defaultStartLocal)?.hour ?: 14,
+                    initialMinute = (startLocalTime ?: defaultStartLocal)?.minute ?: 0,
+                    is24Hour = true
+                )
+                AlertDialog(
+                    onDismissRequest = { showStartPicker = false },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            val picked = java.time.LocalTime.of(pickerState.hour, pickerState.minute)
+                            onShiftChange(picked, endLocalTime)
+                            showStartPicker = false
+                        }) { Text("Listo") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showStartPicker = false }) { Text("Cancelar") }
+                    },
+                    text = { TimePicker(state = pickerState) }
+                )
+            }
+            if (showEndPicker) {
+                val pickerState = rememberTimePickerState(
+                    initialHour = (endLocalTime ?: defaultEndLocal)?.hour ?: 20,
+                    initialMinute = (endLocalTime ?: defaultEndLocal)?.minute ?: 0,
+                    is24Hour = true
+                )
+                AlertDialog(
+                    onDismissRequest = { showEndPicker = false },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            val picked = java.time.LocalTime.of(pickerState.hour, pickerState.minute)
+                            onShiftChange(startLocalTime, picked)
+                            showEndPicker = false
+                        }) { Text("Listo") }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showEndPicker = false }) { Text("Cancelar") }
+                    },
+                    text = { TimePicker(state = pickerState) }
+                )
+            }
         }
     }
+}
+
+private fun parseHHmmOrNull(hhmm: String): java.time.LocalTime? = try {
+    java.time.LocalTime.parse(hhmm)
+} catch (_: Exception) {
+    null
+}
+
+private fun formatTime(time: java.time.LocalTime): String =
+    time.format(java.time.format.DateTimeFormatter.ofPattern("HH:mm"))
+
+private fun AssignmentStatus.uiLabel(): String = when (this) {
+    AssignmentStatus.PENDING -> "Sin confirmar"
+    AssignmentStatus.CONFIRMED -> "Confirmado"
+    AssignmentStatus.DECLINED -> "Rechazó"
+    AssignmentStatus.CANCELLED -> "Cancelado"
+}
+
+private fun AssignmentStatus.uiColor(): Color = when (this) {
+    AssignmentStatus.PENDING -> Color(0xFFB7791F)      // amber
+    AssignmentStatus.CONFIRMED -> Color(0xFF2F855A)    // green
+    AssignmentStatus.DECLINED -> Color(0xFFC53030)     // red muted
+    AssignmentStatus.CANCELLED -> Color(0xFF718096)    // gray
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -2065,6 +2253,7 @@ private fun StaffPickerSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val availableStaff by viewModel.availableStaff.collectAsStateWithLifecycle()
+    val availability by viewModel.staffAvailability.collectAsStateWithLifecycle()
     var query by remember { mutableStateOf("") }
 
     val selectedIds = remember(viewModel.selectedStaff.size) {
@@ -2156,6 +2345,21 @@ private fun StaffPickerSheet(
                                             subtitle,
                                             style = MaterialTheme.typography.bodySmall,
                                             color = SolennixTheme.colors.secondaryText
+                                        )
+                                    }
+                                }
+                                if (availability[staff.id]?.isNotEmpty() == true) {
+                                    Surface(
+                                        shape = MaterialTheme.shapes.small,
+                                        color = Color(0xFFB7791F).copy(alpha = 0.15f),
+                                        modifier = Modifier.padding(end = 8.dp)
+                                    ) {
+                                        Text(
+                                            "Ocupado ese día",
+                                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = Color(0xFFB7791F),
+                                            fontWeight = FontWeight.Medium
                                         )
                                     }
                                 }

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventFormViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventFormViewModel.kt
@@ -167,6 +167,19 @@ class EventFormViewModel @Inject constructor(
     private val _availableStaff = MutableStateFlow<List<Staff>>(emptyList())
     val availableStaff: StateFlow<List<Staff>> = _availableStaff.asStateFlow()
 
+    /**
+     * Mapa `staff_id → List<StaffAvailabilityAssignment>` para la fecha del evento.
+     * Permite O(1) lookup de ocupación en el picker. Se recarga cuando cambia
+     * [eventDate] o cuando el catálogo de staff se hidrata. Excluye el evento
+     * actual cuando se está editando (un colaborador ya asignado al mismo evento
+     * no está "ocupado" para esta vista).
+     */
+    private val _staffAvailability =
+        MutableStateFlow<Map<String, List<StaffAvailabilityAssignment>>>(emptyMap())
+    val staffAvailability: StateFlow<Map<String, List<StaffAvailabilityAssignment>>> =
+        _staffAvailability.asStateFlow()
+    private var availabilityJob: Job? = null
+
     // Step 6: Location & Details (moved to GeneralInfo in UI)
     var location by mutableStateOf("")
     var city by mutableStateOf("")
@@ -312,6 +325,8 @@ class EventFormViewModel @Inject constructor(
         } else {
             null
         }
+        // Refresca la señal de ocupación de colaboradores para la nueva fecha.
+        fetchStaffAvailability()
     }
 
     private fun loadUnavailableDates() {
@@ -361,6 +376,7 @@ class EventFormViewModel @Inject constructor(
             }
         }
         loadUnavailableDates()
+        fetchStaffAvailability()
     }
 
     private fun loadFromQuickQuote() {
@@ -609,7 +625,10 @@ class EventFormViewModel @Inject constructor(
                                 roleOverride = assignment.roleOverride ?: "",
                                 notes = assignment.notes ?: "",
                                 staffName = assignment.staffName,
-                                staffRoleLabel = assignment.staffRoleLabel
+                                staffRoleLabel = assignment.staffRoleLabel,
+                                shiftStart = assignment.shiftStart,
+                                shiftEnd = assignment.shiftEnd,
+                                status = assignment.status
                             )
                         )
                     }
@@ -939,9 +958,79 @@ class EventFormViewModel @Inject constructor(
                 roleOverride = "",
                 notes = "",
                 staffName = staff.name,
-                staffRoleLabel = staff.roleLabel
+                staffRoleLabel = staff.roleLabel,
+                // Defaulting a null: el backend aplica `confirmed` si no viene status.
+                shiftStart = null,
+                shiftEnd = null,
+                status = AssignmentStatus.CONFIRMED.raw
             )
         )
+    }
+
+    /**
+     * Setea el turno del colaborador para la fecha actual del evento. [startLocal]
+     * y [endLocal] son `LocalTime`; se combinan con [eventDate] y se convierten
+     * a ISO8601 UTC. Si [endLocal] es menor a [startLocal], se asume que el turno
+     * cruza medianoche y se corre un día.
+     */
+    fun updateStaffShift(
+        staffId: String,
+        startLocal: java.time.LocalTime?,
+        endLocal: java.time.LocalTime?
+    ) {
+        val index = selectedStaff.indexOfFirst { it.staffId == staffId }
+        if (index < 0) return
+        val zone = java.time.ZoneId.systemDefault()
+        val startIso = startLocal?.let { t ->
+            eventDate.atTime(t).atZone(zone).toInstant().toString()
+        }
+        val endIso = endLocal?.let { t ->
+            val baseDate =
+                if (startLocal != null && t.isBefore(startLocal)) eventDate.plusDays(1)
+                else eventDate
+            baseDate.atTime(t).atZone(zone).toInstant().toString()
+        }
+        selectedStaff[index] = selectedStaff[index].copy(
+            shiftStart = startIso,
+            shiftEnd = endIso
+        )
+    }
+
+    /** Limpia el turno registrado para la asignación. */
+    fun clearStaffShift(staffId: String) {
+        val index = selectedStaff.indexOfFirst { it.staffId == staffId }
+        if (index < 0) return
+        selectedStaff[index] = selectedStaff[index].copy(shiftStart = null, shiftEnd = null)
+    }
+
+    fun updateStaffStatus(staffId: String, status: AssignmentStatus) {
+        val index = selectedStaff.indexOfFirst { it.staffId == staffId }
+        if (index < 0) return
+        selectedStaff[index] = selectedStaff[index].copy(status = status.raw)
+    }
+
+    /**
+     * Dispara `GET /api/staff/availability?date=X` para [eventDate]. El resultado
+     * se publica en [staffAvailability]. No-op si el fetch falla — la UI no
+     * debe bloquear la asignación por no tener la señal de ocupación.
+     */
+    fun fetchStaffAvailability() {
+        availabilityJob?.cancel()
+        availabilityJob = viewModelScope.launch {
+            try {
+                val list = staffRepository.getStaffAvailability(date = eventDate.toString())
+                // Al editar, filtrar asignaciones del evento actual para no
+                // marcar como "ocupado" a alguien que ya está en este mismo
+                // evento.
+                val currentId = eventId
+                val map = list.associate { avail ->
+                    avail.staffId to avail.assignments.filter { it.eventId != currentId }
+                }.filterValues { it.isNotEmpty() }
+                _staffAvailability.value = map
+            } catch (_: Exception) {
+                // Silencioso: la UI puede vivir sin la señal.
+            }
+        }
     }
 
     fun removeStaffAssignment(staffId: String) {
@@ -1112,7 +1201,10 @@ class EventFormViewModel @Inject constructor(
                             staffId = it.staffId,
                             feeAmount = it.feeAmount,
                             roleOverride = it.roleOverride.takeIf { s -> s.isNotBlank() },
-                            notes = it.notes.takeIf { s -> s.isNotBlank() }
+                            notes = it.notes.takeIf { s -> s.isNotBlank() },
+                            shiftStart = it.shiftStart,
+                            shiftEnd = it.shiftEnd,
+                            status = it.status
                         )
                     }
                 )
@@ -1138,6 +1230,10 @@ data class SelectedStaffAssignment(
     val roleOverride: String,
     val notes: String,
     val staffName: String?,
-    val staffRoleLabel: String?
+    val staffRoleLabel: String?,
+    // Ola 1 — shift times en ISO8601 UTC. Null = sin turno registrado.
+    val shiftStart: String? = null,
+    val shiftEnd: String? = null,
+    val status: String? = null
 )
 

--- a/backend/internal/database/migrations/043_add_event_staff_shift_status.down.sql
+++ b/backend/internal/database/migrations/043_add_event_staff_shift_status.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE event_staff
+    DROP CONSTRAINT IF EXISTS event_staff_shift_window_valid;
+
+ALTER TABLE event_staff
+    DROP COLUMN IF EXISTS status,
+    DROP COLUMN IF EXISTS shift_end,
+    DROP COLUMN IF EXISTS shift_start;

--- a/backend/internal/database/migrations/043_add_event_staff_shift_status.up.sql
+++ b/backend/internal/database/migrations/043_add_event_staff_shift_status.up.sql
@@ -1,0 +1,21 @@
+-- Ola 1 of Personal expansion: operational layer on event_staff.
+-- Adds shift window (for waiter teams / late-night gigs that may cross midnight)
+-- and an assignment status so the organizer can track pending/confirmed/declined
+-- without losing historical rows.
+--
+-- All columns are additive and defaulted so existing rows remain valid:
+--   shift_start / shift_end NULL  = no shift defined (current behavior preserved)
+--   status = 'confirmed'          = current behavior preserved (no pending step)
+--
+-- TIMESTAMPTZ (not TIME) because shifts may span midnight. The UI converts to
+-- local time on display; backend stores UTC.
+ALTER TABLE event_staff
+    ADD COLUMN shift_start TIMESTAMPTZ,
+    ADD COLUMN shift_end TIMESTAMPTZ,
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'confirmed'
+        CHECK (status IN ('pending', 'confirmed', 'declined', 'cancelled'));
+
+-- Sanity: if both are set, end must be after start.
+ALTER TABLE event_staff
+    ADD CONSTRAINT event_staff_shift_window_valid
+    CHECK (shift_start IS NULL OR shift_end IS NULL OR shift_end > shift_start);

--- a/backend/internal/handlers/interfaces.go
+++ b/backend/internal/handlers/interfaces.go
@@ -83,6 +83,7 @@ type StaffRepository interface {
 	Delete(ctx context.Context, id, userID uuid.UUID) error
 	CountByUserID(ctx context.Context, userID uuid.UUID) (int, error)
 	Search(ctx context.Context, userID uuid.UUID, query string) ([]models.Staff, error)
+	GetAvailability(ctx context.Context, userID uuid.UUID, start, end string) ([]repository.StaffAvailability, error)
 }
 
 // ProductRepository defines product repo operations.

--- a/backend/internal/handlers/mocks_test.go
+++ b/backend/internal/handlers/mocks_test.go
@@ -406,6 +406,14 @@ func (m *MockStaffRepo) Search(ctx context.Context, userID uuid.UUID, query stri
 	return args.Get(0).([]models.Staff), args.Error(1)
 }
 
+func (m *MockStaffRepo) GetAvailability(ctx context.Context, userID uuid.UUID, start, end string) ([]repository.StaffAvailability, error) {
+	args := m.Called(ctx, userID, start, end)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]repository.StaffAvailability), args.Error(1)
+}
+
 // ---------------------------------------------------------------------------
 // MockProductRepo — implements ProductRepository
 // ---------------------------------------------------------------------------

--- a/backend/internal/handlers/staff_handler.go
+++ b/backend/internal/handlers/staff_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -149,4 +150,44 @@ func (h *StaffHandler) DeleteStaff(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetStaffAvailability returns staff with assignments inside a date window.
+// Staff without assignments in the window are omitted (considered free).
+//
+// GET /api/staff/availability?date=YYYY-MM-DD          (single day)
+// GET /api/staff/availability?start=YYYY-MM-DD&end=... (range, inclusive)
+func (h *StaffHandler) GetStaffAvailability(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+
+	start := r.URL.Query().Get("start")
+	end := r.URL.Query().Get("end")
+	if date := r.URL.Query().Get("date"); date != "" {
+		start, end = date, date
+	}
+
+	if start == "" || end == "" {
+		writeError(w, http.StatusBadRequest, "date or (start,end) is required")
+		return
+	}
+	if _, err := time.Parse("2006-01-02", start); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid start date, expected YYYY-MM-DD")
+		return
+	}
+	if _, err := time.Parse("2006-01-02", end); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid end date, expected YYYY-MM-DD")
+		return
+	}
+	if end < start {
+		writeError(w, http.StatusBadRequest, "end must be on or after start")
+		return
+	}
+
+	items, err := h.staffRepo.GetAvailability(r.Context(), userID, start, end)
+	if err != nil {
+		slog.Error("staff availability failed", "error", err, "user_id", userID)
+		writeError(w, http.StatusInternalServerError, "Failed to fetch availability")
+		return
+	}
+	writeJSON(w, http.StatusOK, items)
 }

--- a/backend/internal/handlers/validation.go
+++ b/backend/internal/handlers/validation.go
@@ -414,6 +414,21 @@ func ValidateEventStaff(es *models.EventStaff) error {
 			return err
 		}
 	}
+	if es.ShiftStart != nil && es.ShiftEnd != nil && !es.ShiftEnd.After(*es.ShiftStart) {
+		return ValidationError{Field: "shift_end", Message: "must be after shift_start"}
+	}
+	// Status is optional. Nil = keep current (UPSERT uses COALESCE). Empty string
+	// from an older client is treated the same as nil for preservation semantics.
+	if es.Status != nil && *es.Status != "" {
+		switch *es.Status {
+		case models.AssignmentStatusPending,
+			models.AssignmentStatusConfirmed,
+			models.AssignmentStatusDeclined,
+			models.AssignmentStatusCancelled:
+		default:
+			return ValidationError{Field: "status", Message: "must be one of: pending, confirmed, declined, cancelled"}
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -335,9 +335,18 @@ type Staff struct {
 	UpdatedAt              time.Time  `json:"updated_at"`
 }
 
+// AssignmentStatus values for EventStaff.Status.
+const (
+	AssignmentStatusPending   = "pending"
+	AssignmentStatusConfirmed = "confirmed"
+	AssignmentStatusDeclined  = "declined"
+	AssignmentStatusCancelled = "cancelled"
+)
+
 // EventStaff is the assignment of a Staff row to an Event. Fee is per-assignment
 // because the same person may charge differently per event. NotificationSentAt
 // and NotificationLastResult are Phase 2 tracking columns (dedup + outcome).
+// ShiftStart/End and Status are Ola 1 operational fields (shift window + RSVP).
 type EventStaff struct {
 	ID                     uuid.UUID  `json:"id"`
 	EventID                uuid.UUID  `json:"event_id"`
@@ -345,6 +354,12 @@ type EventStaff struct {
 	FeeAmount              *float64   `json:"fee_amount,omitempty"`
 	RoleOverride           *string    `json:"role_override,omitempty"`
 	Notes                  *string    `json:"notes,omitempty"`
+	ShiftStart             *time.Time `json:"shift_start,omitempty"`
+	ShiftEnd               *time.Time `json:"shift_end,omitempty"`
+	// Status is a pointer so an omitted field in the payload is distinguishable
+	// from an empty string. UPSERT uses COALESCE to preserve the stored status
+	// when clients (e.g. older app versions) don't send the field at all.
+	Status *string `json:"status,omitempty"`
 	NotificationSentAt     *time.Time `json:"notification_sent_at,omitempty"`
 	NotificationLastResult *string    `json:"notification_last_result,omitempty"`
 	CreatedAt              time.Time  `json:"created_at"`

--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -463,14 +463,26 @@ func (r *EventRepo) UpdateEventItems(ctx context.Context, eventID uuid.UUID,
 			}
 		}
 		for _, st := range *staff {
+			// status nil or empty string = preserve existing (UPSERT COALESCE keeps
+			// stored value on update; new rows fall back to 'confirmed'). This keeps
+			// older clients that don't know about `status` from clobbering RSVP state.
+			var status *string
+			if st.Status != nil && *st.Status != "" {
+				status = st.Status
+			}
 			_, err := tx.Exec(ctx,
-				`INSERT INTO event_staff (event_id, staff_id, fee_amount, role_override, notes)
-				VALUES ($1, $2, $3, $4, $5)
+				`INSERT INTO event_staff (event_id, staff_id, fee_amount, role_override, notes,
+					shift_start, shift_end, status)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, 'confirmed'))
 				ON CONFLICT (event_id, staff_id) DO UPDATE SET
 					fee_amount = EXCLUDED.fee_amount,
 					role_override = EXCLUDED.role_override,
-					notes = EXCLUDED.notes`,
-				eventID, st.StaffID, st.FeeAmount, st.RoleOverride, st.Notes)
+					notes = EXCLUDED.notes,
+					shift_start = EXCLUDED.shift_start,
+					shift_end = EXCLUDED.shift_end,
+					status = COALESCE($8, event_staff.status)`,
+				eventID, st.StaffID, st.FeeAmount, st.RoleOverride, st.Notes,
+				st.ShiftStart, st.ShiftEnd, status)
 			if err != nil {
 				return err
 			}
@@ -549,7 +561,8 @@ func (r *EventRepo) MarkStaffNotificationResult(ctx context.Context, eventStaffI
 // from the staff catalog (name, role_label, phone, email) for display convenience.
 func (r *EventRepo) GetStaff(ctx context.Context, eventID uuid.UUID) ([]models.EventStaff, error) {
 	query := `SELECT es.id, es.event_id, es.staff_id, es.fee_amount, es.role_override,
-		es.notes, es.notification_sent_at, es.notification_last_result, es.created_at,
+		es.notes, es.shift_start, es.shift_end, es.status,
+		es.notification_sent_at, es.notification_last_result, es.created_at,
 		s.name, s.role_label, s.phone, s.email
 		FROM event_staff es
 		LEFT JOIN staff s ON es.staff_id = s.id
@@ -564,11 +577,15 @@ func (r *EventRepo) GetStaff(ctx context.Context, eventID uuid.UUID) ([]models.E
 	items := make([]models.EventStaff, 0)
 	for rows.Next() {
 		var es models.EventStaff
+		var status string
 		if err := rows.Scan(&es.ID, &es.EventID, &es.StaffID, &es.FeeAmount,
-			&es.RoleOverride, &es.Notes, &es.NotificationSentAt, &es.NotificationLastResult,
+			&es.RoleOverride, &es.Notes, &es.ShiftStart, &es.ShiftEnd, &status,
+			&es.NotificationSentAt, &es.NotificationLastResult,
 			&es.CreatedAt, &es.StaffName, &es.StaffRoleLabel, &es.StaffPhone, &es.StaffEmail); err != nil {
 			return nil, err
 		}
+		statusCopy := status
+		es.Status = &statusCopy
 		items = append(items, es)
 	}
 	if err := rows.Err(); err != nil {

--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -463,9 +463,14 @@ func (r *EventRepo) UpdateEventItems(ctx context.Context, eventID uuid.UUID,
 			}
 		}
 		for _, st := range *staff {
-			// status nil or empty string = preserve existing (UPSERT COALESCE keeps
-			// stored value on update; new rows fall back to 'confirmed'). This keeps
-			// older clients that don't know about `status` from clobbering RSVP state.
+			// Preserve-on-nil semantics for fields that legacy clients may not
+			// send at all. Without this, an older app version saving an event
+			// would clobber shift windows and RSVP state set by newer clients.
+			//
+			// Tradeoff: a client can no longer clear a previously-set shift by
+			// sending null alone — the UI must DELETE+re-add the assignment to
+			// clear a shift. Same reasoning as `status`. If explicit clearing
+			// becomes a real user need, add a `clear_shift` flag to the payload.
 			var status *string
 			if st.Status != nil && *st.Status != "" {
 				status = st.Status
@@ -478,8 +483,8 @@ func (r *EventRepo) UpdateEventItems(ctx context.Context, eventID uuid.UUID,
 					fee_amount = EXCLUDED.fee_amount,
 					role_override = EXCLUDED.role_override,
 					notes = EXCLUDED.notes,
-					shift_start = EXCLUDED.shift_start,
-					shift_end = EXCLUDED.shift_end,
+					shift_start = COALESCE(EXCLUDED.shift_start, event_staff.shift_start),
+					shift_end = COALESCE(EXCLUDED.shift_end, event_staff.shift_end),
 					status = COALESCE($8, event_staff.status)`,
 				eventID, st.StaffID, st.FeeAmount, st.RoleOverride, st.Notes,
 				st.ShiftStart, st.ShiftEnd, status)

--- a/backend/internal/repository/staff_repo.go
+++ b/backend/internal/repository/staff_repo.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -161,4 +162,99 @@ func (r *StaffRepo) Search(ctx context.Context, userID uuid.UUID, query string) 
 		return nil, fmt.Errorf("error iterating staff search: %w", err)
 	}
 	return result, nil
+}
+
+// StaffAvailabilityAssignment is a single assignment for a staff member inside a
+// date window, used to surface "who is busy" in the event form.
+type StaffAvailabilityAssignment struct {
+	EventID    uuid.UUID  `json:"event_id"`
+	EventName  string     `json:"event_name"`
+	EventDate  string     `json:"event_date"`
+	ShiftStart *string    `json:"shift_start,omitempty"`
+	ShiftEnd   *string    `json:"shift_end,omitempty"`
+	Status     string     `json:"status"`
+}
+
+// StaffAvailability groups assignments per staff inside a date window.
+// Staff without assignments in the window are NOT included (they are free).
+type StaffAvailability struct {
+	StaffID     uuid.UUID                     `json:"staff_id"`
+	StaffName   string                        `json:"staff_name"`
+	Assignments []StaffAvailabilityAssignment `json:"assignments"`
+}
+
+// GetAvailability returns busy staff for the user in [start, end] inclusive.
+// Dates are YYYY-MM-DD strings matching events.event_date. Only staff with at
+// least one assignment in the window are returned; the UI infers "free" from
+// absence.
+func (r *StaffRepo) GetAvailability(ctx context.Context, userID uuid.UUID, start, end string) ([]StaffAvailability, error) {
+	query := `
+		SELECT s.id, s.name, e.id, e.name, e.event_date,
+			es.shift_start, es.shift_end, es.status
+		FROM event_staff es
+		JOIN staff s ON s.id = es.staff_id
+		JOIN events e ON e.id = es.event_id
+		WHERE s.user_id = $1
+			AND e.event_date BETWEEN $2::date AND $3::date
+			AND es.status IN ('pending', 'confirmed')
+		ORDER BY s.name, e.event_date`
+
+	rows, err := r.pool.Query(ctx, query, userID, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("query staff availability: %w", err)
+	}
+	defer rows.Close()
+
+	byStaff := make(map[uuid.UUID]*StaffAvailability)
+	order := make([]uuid.UUID, 0)
+	for rows.Next() {
+		var (
+			staffID    uuid.UUID
+			staffName  string
+			eventID    uuid.UUID
+			eventName  string
+			eventDate  time.Time
+			shiftStart *time.Time
+			shiftEnd   *time.Time
+			status     string
+		)
+		if err := rows.Scan(&staffID, &staffName, &eventID, &eventName, &eventDate,
+			&shiftStart, &shiftEnd, &status); err != nil {
+			return nil, err
+		}
+		entry, ok := byStaff[staffID]
+		if !ok {
+			entry = &StaffAvailability{
+				StaffID:     staffID,
+				StaffName:   staffName,
+				Assignments: []StaffAvailabilityAssignment{},
+			}
+			byStaff[staffID] = entry
+			order = append(order, staffID)
+		}
+		a := StaffAvailabilityAssignment{
+			EventID:   eventID,
+			EventName: eventName,
+			EventDate: eventDate.Format("2006-01-02"),
+			Status:    status,
+		}
+		if shiftStart != nil {
+			s := shiftStart.UTC().Format(time.RFC3339)
+			a.ShiftStart = &s
+		}
+		if shiftEnd != nil {
+			s := shiftEnd.UTC().Format(time.RFC3339)
+			a.ShiftEnd = &s
+		}
+		entry.Assignments = append(entry.Assignments, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate staff availability: %w", err)
+	}
+
+	out := make([]StaffAvailability, 0, len(order))
+	for _, id := range order {
+		out = append(out, *byStaff[id])
+	}
+	return out, nil
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -163,6 +163,9 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 		r.Route("/staff", func(r chi.Router) {
 			r.Get("/", staffHandler.ListStaff)
 			r.Post("/", staffHandler.CreateStaff)
+			// availability must be registered before /{id} so chi does not treat
+			// "availability" as an id param.
+			r.Get("/availability", staffHandler.GetStaffAvailability)
 			r.Get("/{id}", staffHandler.GetStaff)
 			r.Put("/{id}", staffHandler.UpdateStaff)
 			r.Delete("/{id}", staffHandler.DeleteStaff)

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/EventStaff.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/EventStaff.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+// MARK: - Assignment Status
+
+/// Status del ciclo de vida de una asignacion de staff a un evento.
+/// Los valores son los mismos del backend: pending | confirmed | declined | cancelled.
+public enum AssignmentStatus: String, Codable, Sendable, CaseIterable {
+    case pending
+    case confirmed
+    case declined
+    case cancelled
+}
+
 // MARK: - Event Staff (asignacion de personal a evento)
 
 /// Asignacion de un `Staff` a un evento. El costo (`feeAmount`) vive en la
@@ -16,12 +27,29 @@ public struct EventStaff: Codable, Identifiable, Sendable, Hashable {
     public var notificationLastResult: String?
     public let createdAt: String
 
+    // MARK: - Ola 1 (turnos + estado)
+
+    /// Inicio del turno en ISO8601 UTC. Puede cruzar medianoche.
+    public var shiftStart: String?
+    /// Fin del turno en ISO8601 UTC.
+    public var shiftEnd: String?
+    /// Raw status string. Nulo en payloads de upsert (preserva existente).
+    /// En reads siempre viene con uno de los 4 valores; usar `assignmentStatus`
+    /// para acceso tipado con fallback a `.confirmed`.
+    public var status: String?
+
     // MARK: - Joined (staff_*)
 
     public var staffName: String?
     public var staffRoleLabel: String?
     public var staffPhone: String?
     public var staffEmail: String?
+
+    /// Helper tipado. Si el raw es nil o invalido, cae a `.confirmed`
+    /// (default historico del backend).
+    public var assignmentStatus: AssignmentStatus {
+        AssignmentStatus(rawValue: status ?? "confirmed") ?? .confirmed
+    }
 
     // MARK: - Init
 
@@ -35,6 +63,9 @@ public struct EventStaff: Codable, Identifiable, Sendable, Hashable {
         notificationSentAt: String? = nil,
         notificationLastResult: String? = nil,
         createdAt: String,
+        shiftStart: String? = nil,
+        shiftEnd: String? = nil,
+        status: String? = nil,
         staffName: String? = nil,
         staffRoleLabel: String? = nil,
         staffPhone: String? = nil,
@@ -49,6 +80,9 @@ public struct EventStaff: Codable, Identifiable, Sendable, Hashable {
         self.notificationSentAt = notificationSentAt
         self.notificationLastResult = notificationLastResult
         self.createdAt = createdAt
+        self.shiftStart = shiftStart
+        self.shiftEnd = shiftEnd
+        self.status = status
         self.staffName = staffName
         self.staffRoleLabel = staffRoleLabel
         self.staffPhone = staffPhone

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/StaffAvailability.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/StaffAvailability.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Staff Availability Assignment
+
+/// Una asignacion dentro del reporte de disponibilidad.
+/// `eventDate` llega como YYYY-MM-DD (sin hora); los turnos son opcionales y
+/// llegan en ISO8601 UTC cuando se capturaron.
+public struct StaffAvailabilityAssignment: Codable, Sendable, Hashable {
+    public let eventId: String
+    public let eventName: String
+    public let eventDate: String
+    public let shiftStart: String?
+    public let shiftEnd: String?
+    public let status: String
+
+    public init(
+        eventId: String,
+        eventName: String,
+        eventDate: String,
+        shiftStart: String? = nil,
+        shiftEnd: String? = nil,
+        status: String
+    ) {
+        self.eventId = eventId
+        self.eventName = eventName
+        self.eventDate = eventDate
+        self.shiftStart = shiftStart
+        self.shiftEnd = shiftEnd
+        self.status = status
+    }
+}
+
+// MARK: - Staff Availability
+
+/// Disponibilidad agregada por staff. Solo incluye colaboradores con
+/// asignaciones en la ventana consultada; lista vacia = todos libres.
+public struct StaffAvailability: Codable, Identifiable, Sendable, Hashable {
+    public let staffId: String
+    public let staffName: String
+    public let assignments: [StaffAvailabilityAssignment]
+
+    public var id: String { staffId }
+
+    public init(
+        staffId: String,
+        staffName: String,
+        assignments: [StaffAvailabilityAssignment]
+    ) {
+        self.staffId = staffId
+        self.staffName = staffName
+        self.assignments = assignments
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
@@ -108,13 +108,28 @@ public struct SelectedStaffAssignment: Identifiable, Hashable {
     public var roleOverride: String
     public var notes: String
 
+    // MARK: - Ola 1 (turnos + estado)
+
+    /// Inicio del turno como `Date` local. Se serializa a ISO8601 UTC en el body.
+    /// Nil = no se capturo turno.
+    public var shiftStart: Date?
+    /// Fin del turno como `Date` local. `shiftEnd < shiftStart` significa que
+    /// cruza medianoche — el backend acepta ambos timestamps en UTC y deja
+    /// que el consumidor interprete.
+    public var shiftEnd: Date?
+    /// Status tipado. Default `.confirmed` — coherente con el fallback del backend.
+    public var status: AssignmentStatus
+
     public init(
         staffId: String,
         staffName: String = "",
         staffRoleLabel: String? = nil,
         feeAmount: Double = 0,
         roleOverride: String = "",
-        notes: String = ""
+        notes: String = "",
+        shiftStart: Date? = nil,
+        shiftEnd: Date? = nil,
+        status: AssignmentStatus = .confirmed
     ) {
         self.staffId = staffId
         self.staffName = staffName
@@ -122,6 +137,9 @@ public struct SelectedStaffAssignment: Identifiable, Hashable {
         self.feeAmount = feeAmount
         self.roleOverride = roleOverride
         self.notes = notes
+        self.shiftStart = shiftStart
+        self.shiftEnd = shiftEnd
+        self.status = status
     }
 }
 
@@ -473,6 +491,15 @@ public final class EventFormViewModel {
                 )
             }
 
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime]
+            let isoFractional = ISO8601DateFormatter()
+            isoFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            func parseISO(_ s: String?) -> Date? {
+                guard let s, !s.isEmpty else { return nil }
+                return iso.date(from: s) ?? isoFractional.date(from: s)
+            }
+
             selectedStaff = eventStaff.map { es in
                 SelectedStaffAssignment(
                     staffId: es.staffId,
@@ -480,7 +507,10 @@ public final class EventFormViewModel {
                     staffRoleLabel: es.staffRoleLabel ?? staff.first(where: { $0.id == es.staffId })?.roleLabel,
                     feeAmount: es.feeAmount ?? 0,
                     roleOverride: es.roleOverride ?? "",
-                    notes: es.notes ?? ""
+                    notes: es.notes ?? "",
+                    shiftStart: parseISO(es.shiftStart),
+                    shiftEnd: parseISO(es.shiftEnd),
+                    status: es.assignmentStatus
                 )
             }
 
@@ -773,10 +803,11 @@ public final class EventFormViewModel {
                 "source": $0.source.rawValue,
                 "exclude_cost": $0.excludeCost
             ] },
-            "staff": selectedStaff.map { assignment in
+            "staff": selectedStaff.map { assignment -> [String: Any] in
                 var dict: [String: Any] = [
                     "staff_id": assignment.staffId,
                     "fee_amount": assignment.feeAmount,
+                    "status": assignment.status.rawValue,
                 ]
                 let trimmedRole = assignment.roleOverride.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmedRole.isEmpty {
@@ -785,6 +816,14 @@ public final class EventFormViewModel {
                 let trimmedNotes = assignment.notes.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !trimmedNotes.isEmpty {
                     dict["notes"] = trimmedNotes
+                }
+                let iso = ISO8601DateFormatter()
+                iso.formatOptions = [.withInternetDateTime]
+                if let start = assignment.shiftStart {
+                    dict["shift_start"] = iso.string(from: start)
+                }
+                if let end = assignment.shiftEnd {
+                    dict["shift_end"] = iso.string(from: end)
                 }
                 return dict
             }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
@@ -113,9 +113,9 @@ public struct SelectedStaffAssignment: Identifiable, Hashable {
     /// Inicio del turno como `Date` local. Se serializa a ISO8601 UTC en el body.
     /// Nil = no se capturo turno.
     public var shiftStart: Date?
-    /// Fin del turno como `Date` local. `shiftEnd < shiftStart` significa que
-    /// cruza medianoche — el backend acepta ambos timestamps en UTC y deja
-    /// que el consumidor interprete.
+    /// Fin del turno como `Date` local. Si `shiftEnd <= shiftStart` el turno
+    /// cruza medianoche — la serializacion empuja el end +1 dia antes de
+    /// enviarlo al backend, que tiene un CHECK `shift_end > shift_start`.
     public var shiftEnd: Date?
     /// Status tipado. Default `.confirmed` — coherente con el fallback del backend.
     public var status: AssignmentStatus
@@ -821,8 +821,17 @@ public final class EventFormViewModel {
                 iso.formatOptions = [.withInternetDateTime]
                 if let start = assignment.shiftStart {
                     dict["shift_start"] = iso.string(from: start)
-                }
-                if let end = assignment.shiftEnd {
+                    if let rawEnd = assignment.shiftEnd {
+                        // Overnight turnos: si el usuario eligio una hora de salida
+                        // anterior a la de entrada, interpretamos que cruza
+                        // medianoche y empujamos el end al dia siguiente para que
+                        // pase el CHECK `shift_end > shift_start` del backend.
+                        let end = rawEnd <= start
+                            ? Calendar.current.date(byAdding: .day, value: 1, to: rawEnd) ?? rawEnd
+                            : rawEnd
+                        dict["shift_end"] = iso.string(from: end)
+                    }
+                } else if let end = assignment.shiftEnd {
                     dict["shift_end"] = iso.string(from: end)
                 }
                 return dict

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
@@ -14,6 +14,11 @@ struct Step4PersonnelPanel: View {
 
     @State private var showStaffPicker = false
     @State private var staffSearch = ""
+    @State private var expandedShiftRow: UUID?
+
+    /// Cachea la disponibilidad del dia del evento. Vive aca (no en el VM del
+    /// form) para no contaminar la logica del form con datos de solo lectura.
+    @State private var availabilityVM: StaffAvailabilityViewModel?
 
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.md) {
@@ -73,6 +78,9 @@ struct Step4PersonnelPanel: View {
         .sheet(isPresented: $showStaffPicker) {
             staffPickerSheet
         }
+        .task(id: viewModel.eventDate) {
+            await refreshAvailability()
+        }
     }
 
     // MARK: - Staff Row
@@ -96,6 +104,8 @@ struct Step4PersonnelPanel: View {
                 }
 
                 Spacer()
+
+                statusMenu(index: index, current: assignment.status)
 
                 Button {
                     viewModel.removeStaff(at: index)
@@ -164,6 +174,8 @@ struct Step4PersonnelPanel: View {
                             .stroke(SolennixColors.border, lineWidth: 1)
                     )
             }
+
+            shiftDisclosure(index: index, assignment: assignment)
         }
         .padding(Spacing.md)
         .background(SolennixColors.card)
@@ -172,6 +184,114 @@ struct Step4PersonnelPanel: View {
             RoundedRectangle(cornerRadius: CornerRadius.md)
                 .stroke(SolennixColors.border, lineWidth: 1)
         )
+    }
+
+    // MARK: - Status Menu
+
+    private func statusMenu(index: Int, current: AssignmentStatus) -> some View {
+        Menu {
+            ForEach(AssignmentStatus.allCases, id: \.self) { option in
+                Button {
+                    viewModel.selectedStaff[index].status = option
+                } label: {
+                    if option == current {
+                        Label(label(for: option), systemImage: "checkmark")
+                    } else {
+                        Text(label(for: option))
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(color(for: current))
+                    .frame(width: 8, height: 8)
+                Text(label(for: current))
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(color(for: current))
+                Image(systemName: "chevron.down")
+                    .font(.caption2)
+                    .foregroundStyle(color(for: current))
+            }
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, 4)
+            .background(background(for: current))
+            .clipShape(Capsule())
+        }
+    }
+
+    // MARK: - Shift Disclosure
+
+    private func shiftDisclosure(index: Int, assignment: SelectedStaffAssignment) -> some View {
+        let isExpanded = expandedShiftRow == assignment.id
+            || assignment.shiftStart != nil
+            || assignment.shiftEnd != nil
+
+        return VStack(alignment: .leading, spacing: Spacing.xs) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    expandedShiftRow = isExpanded ? nil : assignment.id
+                }
+            } label: {
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                    Text("Agregar horario (opcional)")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+                .foregroundStyle(SolennixColors.primary)
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                HStack(spacing: Spacing.sm) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Entra")
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.textTertiary)
+                        DatePicker(
+                            "",
+                            selection: Binding(
+                                get: { viewModel.selectedStaff[index].shiftStart ?? defaultShiftStart() },
+                                set: { viewModel.selectedStaff[index].shiftStart = $0 }
+                            ),
+                            displayedComponents: [.hourAndMinute]
+                        )
+                        .labelsHidden()
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Sale")
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.textTertiary)
+                        DatePicker(
+                            "",
+                            selection: Binding(
+                                get: { viewModel.selectedStaff[index].shiftEnd ?? defaultShiftEnd() },
+                                set: { viewModel.selectedStaff[index].shiftEnd = $0 }
+                            ),
+                            displayedComponents: [.hourAndMinute]
+                        )
+                        .labelsHidden()
+                    }
+
+                    Spacer()
+
+                    if assignment.shiftStart != nil || assignment.shiftEnd != nil {
+                        Button {
+                            viewModel.selectedStaff[index].shiftStart = nil
+                            viewModel.selectedStaff[index].shiftEnd = nil
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(SolennixColors.textTertiary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Staff Picker Sheet
@@ -204,6 +324,17 @@ struct Step4PersonnelPanel: View {
                                             Text(role)
                                                 .font(.caption)
                                                 .foregroundStyle(SolennixColors.textSecondary)
+                                        }
+
+                                        if isStaffBusyOnEventDate(item.id) {
+                                            HStack(spacing: 4) {
+                                                Image(systemName: "clock.badge.exclamationmark")
+                                                    .font(.caption2)
+                                                Text("Ocupado ese dia")
+                                                    .font(.caption2)
+                                                    .fontWeight(.medium)
+                                            }
+                                            .foregroundStyle(SolennixColors.warning)
                                         }
                                     }
 
@@ -244,10 +375,75 @@ struct Step4PersonnelPanel: View {
         }
     }
 
+    // MARK: - Availability
+
+    /// Refresca el cache de ocupacion cuando cambia la fecha del evento.
+    /// El VM de disponibilidad vive en state local (`@State`) porque su data
+    /// solo importa mientras el picker esta abierto.
+    private func refreshAvailability() async {
+        if availabilityVM == nil {
+            availabilityVM = StaffAvailabilityViewModel(apiClient: viewModel.apiClient)
+        }
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withFullDate]
+        iso.timeZone = TimeZone(identifier: "UTC")
+        let dateString = iso.string(from: viewModel.eventDate)
+        availabilityVM?.reset()
+        await availabilityVM?.load(for: dateString)
+    }
+
+    private func isStaffBusyOnEventDate(_ staffId: String) -> Bool {
+        guard let vm = availabilityVM else { return false }
+        // Excluimos el propio evento en edicion — si ya tiene a este staff
+        // asignado aca, no queremos marcarlo como conflicto consigo mismo.
+        guard let assignments = vm.busyByStaffId[staffId] else { return false }
+        let currentEventId = viewModel.editId
+        return assignments.contains { a in
+            if let currentEventId, a.eventId == currentEventId { return false }
+            let s = AssignmentStatus(rawValue: a.status) ?? .confirmed
+            return s == .pending || s == .confirmed
+        }
+    }
+
     // MARK: - Helpers
+
+    private func defaultShiftStart() -> Date {
+        viewModel.startTime ?? viewModel.eventDate
+    }
+
+    private func defaultShiftEnd() -> Date {
+        viewModel.endTime ?? viewModel.eventDate.addingTimeInterval(3600 * 4)
+    }
 
     private func formatCurrency(_ value: Double) -> String {
         "$\(String(format: "%.2f", value))"
+    }
+
+    fileprivate func label(for status: AssignmentStatus) -> String {
+        switch status {
+        case .pending:   return "Sin confirmar"
+        case .confirmed: return "Confirmado"
+        case .declined:  return "Rechazó"
+        case .cancelled: return "Cancelado"
+        }
+    }
+
+    fileprivate func color(for status: AssignmentStatus) -> Color {
+        switch status {
+        case .pending:   return SolennixColors.warning
+        case .confirmed: return SolennixColors.success
+        case .declined:  return SolennixColors.error
+        case .cancelled: return SolennixColors.textTertiary
+        }
+    }
+
+    fileprivate func background(for status: AssignmentStatus) -> Color {
+        switch status {
+        case .pending:   return SolennixColors.warningBg
+        case .confirmed: return SolennixColors.successBg
+        case .declined:  return SolennixColors.errorBg
+        case .cancelled: return SolennixColors.surfaceAlt
+        }
     }
 }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
@@ -330,7 +330,7 @@ struct Step4PersonnelPanel: View {
                                             HStack(spacing: 4) {
                                                 Image(systemName: "clock.badge.exclamationmark")
                                                     .font(.caption2)
-                                                Text("Ocupado ese dia")
+                                                Text("Ocupado ese día")
                                                     .font(.caption2)
                                                     .fontWeight(.medium)
                                             }
@@ -384,10 +384,14 @@ struct Step4PersonnelPanel: View {
         if availabilityVM == nil {
             availabilityVM = StaffAvailabilityViewModel(apiClient: viewModel.apiClient)
         }
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withFullDate]
-        iso.timeZone = TimeZone(identifier: "UTC")
-        let dateString = iso.string(from: viewModel.eventDate)
+        // Formateamos en el calendario local para evitar que un offset UTC
+        // desplace el `YYYY-MM-DD` al dia anterior/siguiente (las fechas del
+        // backend viven en tz de usuario, no en UTC puro).
+        let components = Calendar.current.dateComponents([.year, .month, .day], from: viewModel.eventDate)
+        guard let year = components.year, let month = components.month, let day = components.day else {
+            return
+        }
+        let dateString = String(format: "%04d-%02d-%02d", year, month, day)
         availabilityVM?.reset()
         await availabilityVM?.load(for: dateString)
     }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventStaffDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventStaffDetailView.swift
@@ -120,6 +120,14 @@ public struct EventStaffDetailView: View {
                 }
             }
 
+            statusBadge(for: assignment.assignmentStatus)
+
+            if let shift = formatShift(start: assignment.shiftStart, end: assignment.shiftEnd) {
+                Label(shift, systemImage: "clock")
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textSecondary)
+            }
+
             if let phone = assignment.staffPhone, !phone.isEmpty {
                 Label(phone, systemImage: "phone")
                     .font(.caption)
@@ -156,6 +164,74 @@ public struct EventStaffDetailView: View {
         .background(SolennixColors.card)
         .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
         .shadowSm()
+    }
+
+    // MARK: - Status Badge
+
+    private func statusBadge(for status: AssignmentStatus) -> some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(statusColor(status))
+                .frame(width: 6, height: 6)
+            Text(statusLabel(status))
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(statusColor(status))
+        }
+        .padding(.horizontal, Spacing.sm)
+        .padding(.vertical, 3)
+        .background(statusBg(status))
+        .clipShape(Capsule())
+    }
+
+    private func statusLabel(_ s: AssignmentStatus) -> String {
+        switch s {
+        case .pending:   return "Sin confirmar"
+        case .confirmed: return "Confirmado"
+        case .declined:  return "Rechazó"
+        case .cancelled: return "Cancelado"
+        }
+    }
+
+    private func statusColor(_ s: AssignmentStatus) -> Color {
+        switch s {
+        case .pending:   return SolennixColors.warning
+        case .confirmed: return SolennixColors.success
+        case .declined:  return SolennixColors.error
+        case .cancelled: return SolennixColors.textTertiary
+        }
+    }
+
+    private func statusBg(_ s: AssignmentStatus) -> Color {
+        switch s {
+        case .pending:   return SolennixColors.warningBg
+        case .confirmed: return SolennixColors.successBg
+        case .declined:  return SolennixColors.errorBg
+        case .cancelled: return SolennixColors.surfaceAlt
+        }
+    }
+
+    /// Formatea un rango de turno en HH:mm local para el usuario. Si uno
+    /// solo de los extremos esta presente, lo muestra con "—" del otro lado.
+    private func formatShift(start: String?, end: String?) -> String? {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+        let isoFrac = ISO8601DateFormatter()
+        isoFrac.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+
+        func parse(_ s: String?) -> String? {
+            guard let s, !s.isEmpty else { return nil }
+            let d = iso.date(from: s) ?? isoFrac.date(from: s)
+            return d.map { formatter.string(from: $0) }
+        }
+
+        let s = parse(start)
+        let e = parse(end)
+        if s == nil && e == nil { return nil }
+        return "\(s ?? "—") – \(e ?? "—")"
     }
 
     // MARK: - Computed

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffAvailabilityViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffAvailabilityViewModel.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Observation
+import SolennixCore
+import SolennixNetwork
+
+// MARK: - Staff Availability View Model
+
+/// Cachea la disponibilidad por fecha para que el picker de personal pueda
+/// marcar "Ocupado ese dia" sin hacer una llamada por staff.
+/// Usa `@Observable` (iOS 17+) — nada de Combine, nada de @Published.
+@Observable
+public final class StaffAvailabilityViewModel {
+
+    // MARK: - State
+
+    /// Disponibilidad indexada por `staffId` para lookup O(1) desde la UI.
+    /// Un staff ausente de este dict significa "sin asignaciones conocidas"
+    /// para la fecha cacheada (no necesariamente libre — depende de si se
+    /// llamo `load(for:)` primero).
+    public var busyByStaffId: [String: [StaffAvailabilityAssignment]] = [:]
+
+    /// Ultima fecha cargada (YYYY-MM-DD). Permite saltar reloads redundantes.
+    public var loadedDate: String?
+
+    public var isLoading: Bool = false
+    public var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    private let apiClient: APIClient
+
+    // MARK: - Init
+
+    public init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Loading
+
+    /// Pide disponibilidad para una fecha puntual y popula `busyByStaffId`.
+    /// Si la fecha ya esta cacheada, no hace nada.
+    @MainActor
+    public func load(for date: String) async {
+        if loadedDate == date { return }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            let result = try await apiClient.getStaffAvailability(date: date)
+            var map: [String: [StaffAvailabilityAssignment]] = [:]
+            for entry in result {
+                map[entry.staffId] = entry.assignments
+            }
+            busyByStaffId = map
+            loadedDate = date
+        } catch {
+            errorMessage = (error as? APIError)?.errorDescription
+                ?? "No pudimos verificar la disponibilidad."
+        }
+    }
+
+    /// Invalida el cache. Util cuando la fecha del evento cambia y queremos
+    /// forzar un refetch aunque coincida con la anterior.
+    public func reset() {
+        busyByStaffId = [:]
+        loadedDate = nil
+    }
+
+    // MARK: - Helpers
+
+    /// `true` si el staff tiene al menos una asignacion activa en la fecha
+    /// cacheada. Asignaciones `cancelled` o `declined` no bloquean.
+    public func isBusy(staffId: String) -> Bool {
+        guard let assignments = busyByStaffId[staffId] else { return false }
+        return assignments.contains { a in
+            let s = AssignmentStatus(rawValue: a.status) ?? .confirmed
+            return s == .pending || s == .confirmed
+        }
+    }
+}

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/APIClient+StaffAvailability.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/APIClient+StaffAvailability.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SolennixCore
+
+// MARK: - Staff Availability
+
+/// Typed helpers para el endpoint `GET /api/staff/availability`.
+/// Solo expone wrappers sobre `APIClient.get` — toda la complejidad (auth,
+/// retries, decoding) vive en el cliente base.
+public extension APIClient {
+
+    /// Disponibilidad del personal para una sola fecha (YYYY-MM-DD).
+    /// Devuelve solo staff CON asignaciones en esa fecha; array vacio = libres.
+    func getStaffAvailability(date: String) async throws -> [StaffAvailability] {
+        try await get(Endpoint.staffAvailability, params: ["date": date])
+    }
+
+    /// Disponibilidad del personal para un rango inclusivo (YYYY-MM-DD).
+    /// Devuelve solo staff CON asignaciones dentro del rango.
+    func getStaffAvailability(start: String, end: String) async throws -> [StaffAvailability] {
+        try await get(
+            Endpoint.staffAvailability,
+            params: ["start": start, "end": end]
+        )
+    }
+}

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
@@ -76,6 +76,11 @@ public enum Endpoint {
         "/staff/\(id)"
     }
 
+    /// Reporte de disponibilidad de staff para una fecha o rango.
+    /// Consumido via `GET /api/staff/availability?date=YYYY-MM-DD` o
+    /// `?start=YYYY-MM-DD&end=YYYY-MM-DD`.
+    public static let staffAvailability = "/staff/availability"
+
     // MARK: - Products
 
     public static let products = "/products"

--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -980,15 +980,28 @@ Visualización + registro de pago por transferencia con approve/reject. Reemplaz
 | Fee opcional por asignación | ✅ | ✅ | ✅ | ✅ `event_staff.fee_amount` |
 | Toggle "notificar por email" (guarda flag) | ✅ | ✅ | ✅ | ✅ `staff.notification_email_opt_in` |
 | **Phase 2 — email al colaborador al asignar** (Pro+) | ✅ *(trigger en save, shipped 2026-04-17)* | ✅ | ✅ | ✅ goroutine en `UpdateEventItems` + Resend |
+| **Ola 1 — turnos + estado + disponibilidad** (todos los planes, shipped 2026-04-19) | ✅ | ✅ | ✅ | ✅ migration 043 + `GET /api/staff/availability` |
 
-**Data model (migration 042):**
+**Data model (migration 042 + 043):**
 - `staff` — catálogo per-user con `name`, `role_label`, `phone`, `email`, `notes`, `notification_email_opt_in`, `invited_user_id` (hook Phase 3, nullable FK a users).
 - `event_staff` — junction con `fee_amount`, `role_override`, `notes`, `notification_sent_at`, `notification_last_result`. UNIQUE `(event_id, staff_id)`.
+- **Ola 1 (migration 043)** agrega a `event_staff`: `shift_start` / `shift_end` (TIMESTAMPTZ, nullables — TIMESTAMPTZ porque los turnos pueden cruzar medianoche), `status` (enum `pending | confirmed | declined | cancelled`, default `confirmed` para retrocompatibilidad). Constraint `shift_end > shift_start`.
 
 **Tier gating:**
-- **Phase 1:** sin gate — todos los planes pueden usar el catálogo.
+- **Phase 1 / Ola 1:** sin gate — todos los planes pueden usar el catálogo, turnos, estados y disponibilidad.
 - **Phase 2 (Pro+):** activa email de notificación al asignar.
 - **Phase 3 (Business+):** login del colaborador + scope de sus eventos + thread con gerente (reusa Pilar 5 D de [[14_CLIENT_EXPERIENCE_IDEAS]]).
+
+**Ola 1 — capa operativa (shipped 2026-04-19):**
+- **Turnos:** `shift_start` / `shift_end` por asignación (opcionales). UI usa pickers colapsables "Agregar horario (opcional)" y sugiere como default la ventana del evento. Backend almacena UTC; clientes convierten a local.
+- **Estado RSVP:** `status` con 4 valores (pending / confirmed / declined / cancelled). Default `confirmed` preserva el comportamiento pre-Ola-1. Badges de color en UI: amber/green/rose/slate. Strings Rioplatense: "Sin confirmar", "Confirmado", "Rechazó", "Cancelado".
+- **Disponibilidad:** endpoint `GET /api/staff/availability?date=YYYY-MM-DD` (o rango con `start`/`end`). Devuelve solo staff con asignaciones en la ventana (ausencia = libre). Se consume dentro del Step 4 del EventForm — indicador "Ocupado ese día" al lado del nombre en el selector. **Sin pantalla nueva.**
+- **UPSERT resiliente:** el patrón de `notification_sent_at` (preservar en re-save) se extiende a `status` vía `COALESCE($status, event_staff.status)` — clientes viejos que no envían `status` en el payload NO sobreescriben el RSVP actual. Ver [backend/internal/repository/event_repo.go](../../backend/internal/repository/event_repo.go) método `UpdateEventItems`.
+
+**Roadmap siguiente (no implementado):**
+- **Ola 2 — Equipos:** tabla `staff_teams` + `staff_team_members` para asignar cuadrillas en bloque (un equipo de N meseros). Team lead como badge visual, no rol técnico.
+- **Ola 3 — Staff como servicio vendible:** `Product.staff_team_id` opcional para cobrar al cliente con markup vs. costo interno. Reutiliza Products/Quotes (no un tercer tipo de item).
+- **Phase 3:** login del colaborador vía `invited_user_id` — intacto como estaba planeado.
 
 **Navegación:**
 - Web sidebar y iPad sidebar → entrada "Personal" entre Clientes y Productos.

--- a/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
+++ b/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
@@ -17,6 +17,16 @@ status: active
 **Fecha:** Abril 2026
 **Version:** 1.2
 
+> [!info] 2026-04-19 — Personal Ola 1: turnos + estado RSVP + disponibilidad (paridad iOS · Android · Web · Backend)
+> Feature Personal (shipped 2026-04-16 como catálogo plano + costo por evento) expandida con la capa operativa. Motivación del usuario: escalar el uso para equipos de meseros / empresas de catering, sin cerrar la puerta a que el mismo modelo sirva al organizador con plantilla propia. Phase 3 (login del colaborador) se mantiene intacto como roadmap futuro.
+> - **Backend (migration 043)**: `event_staff` recibe `shift_start`, `shift_end` (TIMESTAMPTZ nullables — pueden cruzar medianoche) y `status` (enum `pending | confirmed | declined | cancelled`, default `confirmed`). Constraint `shift_end > shift_start`. Todo aditivo — filas existentes siguen válidas.
+> - **Backend UPSERT resiliente**: `UpdateEventItems` en `event_repo.go` usa `COALESCE($status, event_staff.status)` para preservar el RSVP cuando un cliente viejo no envía el campo. Mismo patrón que `notification_sent_at` de Phase 2.
+> - **Backend endpoint**: `GET /api/staff/availability?date=YYYY-MM-DD` (o rango `start`/`end`). Devuelve solo staff con asignaciones `pending|confirmed` en la ventana; el cliente infiere "libre" por ausencia.
+> - **iOS / Android / Web**: modelos extendidos con `shift_start`/`shift_end`/`status` (opcionales — retrocompatibles). Step 4 del EventForm suma pickers de horario colapsables ("Agregar horario (opcional)") y selector de estado con badges de color (amber / green / rose muted / slate). Indicador "Ocupado ese día" al lado de los nombres en el selector de staff cuando la fecha del evento matchea. **Sin pantallas nuevas.**
+> - **UX**: strings Rioplatense ("Sin confirmar", "Confirmado", "Rechazó", "Cancelado"). Defaults inteligentes — `status = confirmed` y `shift_start/end = NULL` mantienen el comportamiento pre-Ola-1 para quienes no quieren usar la feature.
+> - **Sin gating de plan** en esta ola — todos los planes pueden usar turnos / estado / disponibilidad. Gating sigue siendo solo en Phase 2 (Pro+) para el email, y Phase 3 (Business+) para el login del colaborador.
+> - **Roadmap siguiente** (no incluido en esta ola, documentado en [[02_FEATURES#15.ter Personal]]): Ola 2 — equipos (`staff_teams`) para asignar cuadrillas en bloque; Ola 3 — staff como servicio vendible vía `Product.staff_team_id` opcional (markup vs. costo interno).
+
 > [!info] 2026-04-19 — iOS: botón explícito "$ Anticipo" (paridad con Web/Android, issue #80 Opción B)
 > iOS quedaba sin el botón directo para registrar anticipo en `EventPaymentsDetailView` — el usuario tenía que tipear el monto a mano. Cerrada la brecha con `viewModel.depositBalance` como saldo pendiente del anticipo y un `PremiumButton` dinámico que aparece cuando `depositBalance > 0.01`.
 > - Nuevo botón "$ Anticipo - $X" en `EventPaymentsDetailView.swift` (junto a "Registrar Pago" / "Liquidar"), visible mientras quede anticipo por cobrar.

--- a/web/src/hooks/queries/queryKeys.ts
+++ b/web/src/hooks/queries/queryKeys.ts
@@ -42,6 +42,8 @@ export const queryKeys = {
     paginated: (page?: number, limit?: number, sort?: string, order?: string) =>
       ['staff', 'paginated', { page, limit, sort, order }] as const,
     detail: (id: string) => ['staff', id] as const,
+    availability: (date: string) => ['staff', 'availability', date] as const,
+    assignments: (staffId: string) => ['staff', staffId, 'assignments'] as const,
   },
   payments: {
     byEvent: (eventId: string) => ['payments', 'event', eventId] as const,

--- a/web/src/hooks/queries/useStaffQueries.ts
+++ b/web/src/hooks/queries/useStaffQueries.ts
@@ -38,6 +38,28 @@ export function useEventStaff(eventId: string | undefined) {
   });
 }
 
+// Staff availability for a single date — used inside EventStaff picker to
+// badge collaborators already booked that day. Skips when date is falsy.
+export function useStaffAvailability(date: string | null | undefined) {
+  return useQuery({
+    queryKey: queryKeys.staff.availability(date ?? ''),
+    queryFn: () => staffService.getAvailability({ date: date! }),
+    enabled: !!date,
+    staleTime: 30 * 1000,
+  });
+}
+
+// Range variant — used in StaffDetails "Próximas asignaciones". Only enabled
+// when both bounds are provided.
+export function useStaffAvailabilityRange(start: string | null | undefined, end: string | null | undefined) {
+  return useQuery({
+    queryKey: ['staff', 'availability', 'range', start ?? '', end ?? ''] as const,
+    queryFn: () => staffService.getAvailability({ start: start!, end: end! }),
+    enabled: !!start && !!end,
+    staleTime: 30 * 1000,
+  });
+}
+
 // ── Mutations ──
 
 export function useCreateStaff() {

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -79,6 +79,32 @@ interface Product {
   base_price: number;
 }
 
+// Convert an ISO8601 UTC string (e.g. the backend's shift_start) to the
+// browser-local HH:mm representation used by <input type="time">. Returns
+// null when the input is empty/invalid so the field stays cleared.
+const isoToLocalHHmm = (iso: string | null | undefined): string | null => {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}:${mm}`;
+};
+
+// Combine a YYYY-MM-DD event date with a HH:mm local time into an ISO8601
+// UTC string. Returns null when either piece is missing. Used at submit
+// time to build the shift_start/shift_end payload.
+const hhmmToUtcIso = (eventDate: string | null | undefined, hhmm: string | null): string | null => {
+  if (!eventDate || !hhmm) return null;
+  const [h, m] = hhmm.split(":").map((n) => Number(n));
+  if (Number.isNaN(h) || Number.isNaN(m)) return null;
+  const [y, mo, d] = eventDate.split("-").map((n) => Number(n));
+  if (Number.isNaN(y) || Number.isNaN(mo) || Number.isNaN(d)) return null;
+  const local = new Date(y, mo - 1, d, h, m, 0, 0);
+  if (Number.isNaN(local.getTime())) return null;
+  return local.toISOString();
+};
+
 const eventSchema = z.object({
   client_id: z.string().min(1, "Selecciona un cliente"),
   event_date: z.string().min(1, "Selecciona una fecha"),
@@ -305,6 +331,10 @@ export const EventForm: React.FC = () => {
           fee_amount: r.fee_amount ?? null,
           role_override: r.role_override ?? "",
           notes: r.notes ?? "",
+          // Shift ISO8601 UTC → HH:mm local para edición en UI.
+          shift_start: r.shift_start ? isoToLocalHHmm(r.shift_start) : null,
+          shift_end: r.shift_end ? isoToLocalHHmm(r.shift_end) : null,
+          status: r.status ?? null,
         })),
       );
     }).catch(() => { /* empty list on error — parity with equipment */ });
@@ -656,7 +686,15 @@ export const EventForm: React.FC = () => {
   const handleAddStaff = () => {
     setSelectedStaff((prev) => [
       ...prev,
-      { staff_id: "", fee_amount: null, role_override: "", notes: "" },
+      {
+        staff_id: "",
+        fee_amount: null,
+        role_override: "",
+        notes: "",
+        shift_start: null,
+        shift_end: null,
+        status: null,
+      },
     ]);
   };
 
@@ -880,6 +918,9 @@ export const EventForm: React.FC = () => {
               feeAmount: s.fee_amount,
               roleOverride: s.role_override || null,
               notes: s.notes || null,
+              shiftStart: hhmmToUtcIso(eventDateValue, s.shift_start),
+              shiftEnd: hhmmToUtcIso(eventDateValue, s.shift_end),
+              status: s.status, // null = preserve current value on upsert
             })),
         );
       }
@@ -1156,6 +1197,7 @@ export const EventForm: React.FC = () => {
                   <EventStaff
                     staffCatalog={staffCatalog}
                     selectedStaff={selectedStaff}
+                    eventDate={eventDateValue}
                     onAdd={handleAddStaff}
                     onRemove={handleRemoveStaff}
                     onChange={handleStaffChange}

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -92,17 +92,42 @@ const isoToLocalHHmm = (iso: string | null | undefined): string | null => {
 };
 
 // Combine a YYYY-MM-DD event date with a HH:mm local time into an ISO8601
-// UTC string. Returns null when either piece is missing. Used at submit
-// time to build the shift_start/shift_end payload.
-const hhmmToUtcIso = (eventDate: string | null | undefined, hhmm: string | null): string | null => {
+// UTC string. `dayOffset` shifts the day by N (used for overnight shifts).
+// Returns null when either piece is missing.
+const hhmmToUtcIso = (
+  eventDate: string | null | undefined,
+  hhmm: string | null,
+  dayOffset = 0,
+): string | null => {
   if (!eventDate || !hhmm) return null;
   const [h, m] = hhmm.split(":").map((n) => Number(n));
   if (Number.isNaN(h) || Number.isNaN(m)) return null;
   const [y, mo, d] = eventDate.split("-").map((n) => Number(n));
   if (Number.isNaN(y) || Number.isNaN(mo) || Number.isNaN(d)) return null;
-  const local = new Date(y, mo - 1, d, h, m, 0, 0);
+  const local = new Date(y, mo - 1, d + dayOffset, h, m, 0, 0);
   if (Number.isNaN(local.getTime())) return null;
   return local.toISOString();
+};
+
+// Serialize a shift range, bumping the end by +1 day when the user chose an
+// end time on or before the start (overnight turno). Backend enforces
+// CHECK (shift_end > shift_start), so "19:00 → 02:00" would otherwise be
+// rejected.
+const serializeShift = (
+  eventDate: string | null | undefined,
+  start: string | null,
+  end: string | null,
+): { shiftStart: string | null; shiftEnd: string | null } => {
+  const shiftStart = hhmmToUtcIso(eventDate, start);
+  if (!end) return { shiftStart, shiftEnd: null };
+  if (!start) return { shiftStart: null, shiftEnd: hhmmToUtcIso(eventDate, end) };
+  const [sh, sm] = start.split(":").map(Number);
+  const [eh, em] = end.split(":").map(Number);
+  const overnight = eh * 60 + em <= sh * 60 + sm;
+  return {
+    shiftStart,
+    shiftEnd: hhmmToUtcIso(eventDate, end, overnight ? 1 : 0),
+  };
 };
 
 const eventSchema = z.object({
@@ -913,15 +938,18 @@ export const EventForm: React.FC = () => {
             })),
           selectedStaff
             .filter((s) => s.staff_id)
-            .map((s) => ({
-              staffId: s.staff_id,
-              feeAmount: s.fee_amount,
-              roleOverride: s.role_override || null,
-              notes: s.notes || null,
-              shiftStart: hhmmToUtcIso(eventDateValue, s.shift_start),
-              shiftEnd: hhmmToUtcIso(eventDateValue, s.shift_end),
-              status: s.status, // null = preserve current value on upsert
-            })),
+            .map((s) => {
+              const shift = serializeShift(eventDateValue, s.shift_start, s.shift_end);
+              return {
+                staffId: s.staff_id,
+                feeAmount: s.fee_amount,
+                roleOverride: s.role_override || null,
+                notes: s.notes || null,
+                shiftStart: shift.shiftStart,
+                shiftEnd: shift.shiftEnd,
+                status: s.status, // null = preserve current value on upsert
+              };
+            }),
         );
       }
 
@@ -1198,6 +1226,7 @@ export const EventForm: React.FC = () => {
                     staffCatalog={staffCatalog}
                     selectedStaff={selectedStaff}
                     eventDate={eventDateValue}
+                    eventId={id ?? null}
                     onAdd={handleAddStaff}
                     onRemove={handleRemoveStaff}
                     onChange={handleStaffChange}

--- a/web/src/pages/Events/components/EventStaff.tsx
+++ b/web/src/pages/Events/components/EventStaff.tsx
@@ -1,32 +1,70 @@
-import { Plus, Trash2, UserCog } from 'lucide-react';
-import type { Staff } from '../../../types/entities';
+import { useMemo, useState } from 'react';
+import { Clock, Plus, Trash2, UserCog } from 'lucide-react';
+import type { AssignmentStatus, Staff } from '../../../types/entities';
+import { useStaffAvailability } from '@/hooks/queries/useStaffQueries';
 
 // Shape tracked in EventForm state — matches EventStaffAssignment but with
 // a deterministic row id so the list can be edited before the event has an
 // event_id in the backend.
+//
+// Ola 1 — shift window + status. shift_start/end son TIME (HH:mm) en UI,
+// se convierten a ISO8601 UTC en el submit combinándolos con event_date.
+// status null = preservar en upsert (semántica del backend).
 export interface SelectedStaffAssignment {
   staff_id: string;
   fee_amount: number | null;
   role_override: string;
   notes: string;
+  shift_start: string | null; // "HH:mm" local o null
+  shift_end: string | null;   // "HH:mm" local o null
+  status: AssignmentStatus | null;
 }
+
+export type StaffFieldValue = string | number | null;
 
 interface EventStaffProps {
   staffCatalog: Staff[];
   selectedStaff: SelectedStaffAssignment[];
+  eventDate?: string | null; // YYYY-MM-DD para availability lookup
   onAdd: () => void;
   onRemove: (index: number) => void;
-  onChange: (index: number, field: keyof SelectedStaffAssignment, value: string | number | null) => void;
+  onChange: (index: number, field: keyof SelectedStaffAssignment, value: StaffFieldValue) => void;
 }
+
+const STATUS_OPTIONS: { value: AssignmentStatus; label: string }[] = [
+  { value: 'pending', label: 'Sin confirmar' },
+  { value: 'confirmed', label: 'Confirmado' },
+  { value: 'declined', label: 'Rechazó' },
+  { value: 'cancelled', label: 'Cancelado' },
+];
 
 export const EventStaff: React.FC<EventStaffProps> = ({
   staffCatalog,
   selectedStaff,
+  eventDate,
   onAdd,
   onRemove,
   onChange,
 }) => {
   const emptyCatalog = staffCatalog.length === 0;
+
+  // Availability — solo pedimos si tenemos fecha. El hook se skipea en caso contrario.
+  const { data: availability = [] } = useStaffAvailability(eventDate || null);
+
+  const busyStaffIds = useMemo(() => {
+    const set = new Set<string>();
+    for (const row of availability) {
+      if (row.assignments.length > 0) set.add(row.staff_id);
+    }
+    return set;
+  }, [availability]);
+
+  // Track which rows have expanded the "Agregar horario (opcional)" panel.
+  const [shiftExpanded, setShiftExpanded] = useState<Record<number, boolean>>({});
+
+  const toggleShift = (index: number) => {
+    setShiftExpanded((prev) => ({ ...prev, [index]: !prev[index] }));
+  };
 
   return (
     <div className="space-y-4">
@@ -54,6 +92,11 @@ export const EventStaff: React.FC<EventStaffProps> = ({
             const availableCatalog = staffCatalog.filter(
               (s) => s.id === item.staff_id || !selectedStaff.some((sel, i) => i !== index && sel.staff_id === s.id),
             );
+            const isShiftOpen =
+              shiftExpanded[index] || !!item.shift_start || !!item.shift_end;
+            // Default mostrado del select cuando no hay status seteado = "confirmed".
+            const statusValue: AssignmentStatus = item.status ?? 'confirmed';
+
             return (
               <div
                 key={index}
@@ -67,13 +110,22 @@ export const EventStaff: React.FC<EventStaffProps> = ({
                     className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
                   >
                     <option value="">Seleccionar…</option>
-                    {availableCatalog.map((s) => (
-                      <option key={s.id} value={s.id}>
-                        {s.name}
-                        {s.role_label ? ` · ${s.role_label}` : ''}
-                      </option>
-                    ))}
+                    {availableCatalog.map((s) => {
+                      const busy = eventDate && busyStaffIds.has(s.id) && s.id !== item.staff_id;
+                      return (
+                        <option key={s.id} value={s.id}>
+                          {s.name}
+                          {s.role_label ? ` · ${s.role_label}` : ''}
+                          {busy ? ' · Ocupado ese día' : ''}
+                        </option>
+                      );
+                    })}
                   </select>
+                  {eventDate && item.staff_id && busyStaffIds.has(item.staff_id) && (
+                    <span className="mt-1 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+                      Ocupado ese día
+                    </span>
+                  )}
                 </div>
 
                 <div className="sm:col-span-3">
@@ -117,7 +169,22 @@ export const EventStaff: React.FC<EventStaffProps> = ({
                   </button>
                 </div>
 
-                <div className="sm:col-span-12">
+                <div className="sm:col-span-4">
+                  <label className="block text-xs font-medium text-text-secondary mb-1">Estado</label>
+                  <select
+                    value={statusValue}
+                    onChange={(e) => onChange(index, 'status', e.target.value as AssignmentStatus)}
+                    className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
+                  >
+                    {STATUS_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="sm:col-span-8">
                   <label className="block text-xs font-medium text-text-secondary mb-1">Notas</label>
                   <input
                     type="text"
@@ -126,6 +193,48 @@ export const EventStaff: React.FC<EventStaffProps> = ({
                     className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
                     placeholder="Hora de llegada, indicaciones…"
                   />
+                </div>
+
+                <div className="sm:col-span-12">
+                  {!isShiftOpen ? (
+                    <button
+                      type="button"
+                      onClick={() => toggleShift(index)}
+                      className="inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+                    >
+                      <Clock className="h-4 w-4" aria-hidden="true" />
+                      Agregar horario (opcional)
+                    </button>
+                  ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-xs font-medium text-text-secondary mb-1">
+                          Entrada
+                        </label>
+                        <input
+                          type="time"
+                          value={item.shift_start ?? ''}
+                          onChange={(e) =>
+                            onChange(index, 'shift_start', e.target.value === '' ? null : e.target.value)
+                          }
+                          className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-xs font-medium text-text-secondary mb-1">
+                          Salida
+                        </label>
+                        <input
+                          type="time"
+                          value={item.shift_end ?? ''}
+                          onChange={(e) =>
+                            onChange(index, 'shift_end', e.target.value === '' ? null : e.target.value)
+                          }
+                          className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
+                        />
+                      </div>
+                    </div>
+                  )}
                 </div>
               </div>
             );

--- a/web/src/pages/Events/components/EventStaff.tsx
+++ b/web/src/pages/Events/components/EventStaff.tsx
@@ -26,6 +26,7 @@ interface EventStaffProps {
   staffCatalog: Staff[];
   selectedStaff: SelectedStaffAssignment[];
   eventDate?: string | null; // YYYY-MM-DD para availability lookup
+  eventId?: string | null;   // Excluir este evento del flag "ocupado"
   onAdd: () => void;
   onRemove: (index: number) => void;
   onChange: (index: number, field: keyof SelectedStaffAssignment, value: StaffFieldValue) => void;
@@ -42,6 +43,7 @@ export const EventStaff: React.FC<EventStaffProps> = ({
   staffCatalog,
   selectedStaff,
   eventDate,
+  eventId,
   onAdd,
   onRemove,
   onChange,
@@ -51,13 +53,18 @@ export const EventStaff: React.FC<EventStaffProps> = ({
   // Availability — solo pedimos si tenemos fecha. El hook se skipea en caso contrario.
   const { data: availability = [] } = useStaffAvailability(eventDate || null);
 
+  // Excluimos el evento actual al calcular busy: un staff ya asignado a este
+  // mismo evento NO debe mostrarse como "Ocupado ese día" consigo mismo.
   const busyStaffIds = useMemo(() => {
     const set = new Set<string>();
     for (const row of availability) {
-      if (row.assignments.length > 0) set.add(row.staff_id);
+      const hasOther = row.assignments.some(
+        (a) => !eventId || a.event_id !== eventId,
+      );
+      if (hasOther) set.add(row.staff_id);
     }
     return set;
-  }, [availability]);
+  }, [availability, eventId]);
 
   // Track which rows have expanded the "Agregar horario (opcional)" panel.
   const [shiftExpanded, setShiftExpanded] = useState<Record<number, boolean>>({});

--- a/web/src/pages/Staff/StaffDetails.tsx
+++ b/web/src/pages/Staff/StaffDetails.tsx
@@ -53,13 +53,20 @@ export const StaffDetails: React.FC = () => {
   const deleteMut = useDeleteStaff();
   const [confirmOpen, setConfirmOpen] = React.useState(false);
 
-  // Próximas asignaciones — ventana rolling de 90 días desde hoy.
+  // Próximas asignaciones — ventana rolling de 90 días desde hoy. Usamos la
+  // fecha en zona local (no UTC) para que la ventana coincida con lo que el
+  // usuario ve en su calendario; toISOString() podría correr un día.
   const { rangeStart, rangeEnd } = useMemo(() => {
+    const ymdLocal = (d: Date) => {
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      return `${y}-${m}-${day}`;
+    };
     const today = new Date();
     const end = new Date(today);
     end.setDate(end.getDate() + 90);
-    const ymd = (d: Date) => d.toISOString().split("T")[0];
-    return { rangeStart: ymd(today), rangeEnd: ymd(end) };
+    return { rangeStart: ymdLocal(today), rangeEnd: ymdLocal(end) };
   }, []);
   const { data: availability = [] } = useStaffAvailabilityRange(
     staff ? rangeStart : null,

--- a/web/src/pages/Staff/StaffDetails.tsx
+++ b/web/src/pages/Staff/StaffDetails.tsx
@@ -1,8 +1,50 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, Edit, Mail, Phone, Trash2, UserCog } from "lucide-react";
-import { useStaffMember, useDeleteStaff } from "@/hooks/queries/useStaffQueries";
+import { ArrowLeft, CalendarClock, Edit, Mail, Phone, Trash2, UserCog } from "lucide-react";
+import {
+  useStaffMember,
+  useDeleteStaff,
+  useStaffAvailabilityRange,
+} from "@/hooks/queries/useStaffQueries";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
+import type { AssignmentStatus } from "@/types/entities";
+
+const STATUS_LABELS: Record<AssignmentStatus, string> = {
+  pending: "Sin confirmar",
+  confirmed: "Confirmado",
+  declined: "Rechazó",
+  cancelled: "Cancelado",
+};
+
+// Tailwind palette mapping — stays off the brand gold/navy so badges feel
+// semantic rather than decorative.
+const STATUS_CLASSES: Record<AssignmentStatus, string> = {
+  pending: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200",
+  confirmed: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200",
+  declined: "bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-200",
+  cancelled: "bg-slate-200 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200",
+};
+
+const formatShiftRange = (start?: string | null, end?: string | null): string | null => {
+  const fmt = (iso: string) => {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  };
+  const s = start ? fmt(start) : null;
+  const e = end ? fmt(end) : null;
+  if (s && e) return `${s} – ${e}`;
+  if (s) return `Desde ${s}`;
+  if (e) return `Hasta ${e}`;
+  return null;
+};
+
+const formatEventDate = (ymd: string): string => {
+  const [y, m, d] = ymd.split("-").map((n) => Number(n));
+  if (Number.isNaN(y) || Number.isNaN(m) || Number.isNaN(d)) return ymd;
+  const dt = new Date(y, m - 1, d);
+  return dt.toLocaleDateString(undefined, { weekday: "short", day: "numeric", month: "short", year: "numeric" });
+};
 
 export const StaffDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -10,6 +52,25 @@ export const StaffDetails: React.FC = () => {
   const { data: staff, isLoading } = useStaffMember(id);
   const deleteMut = useDeleteStaff();
   const [confirmOpen, setConfirmOpen] = React.useState(false);
+
+  // Próximas asignaciones — ventana rolling de 90 días desde hoy.
+  const { rangeStart, rangeEnd } = useMemo(() => {
+    const today = new Date();
+    const end = new Date(today);
+    end.setDate(end.getDate() + 90);
+    const ymd = (d: Date) => d.toISOString().split("T")[0];
+    return { rangeStart: ymd(today), rangeEnd: ymd(end) };
+  }, []);
+  const { data: availability = [] } = useStaffAvailabilityRange(
+    staff ? rangeStart : null,
+    staff ? rangeEnd : null,
+  );
+  const upcomingAssignments = useMemo(() => {
+    if (!staff) return [];
+    const entry = availability.find((a) => a.staff_id === staff.id);
+    if (!entry) return [];
+    return [...entry.assignments].sort((a, b) => a.event_date.localeCompare(b.event_date));
+  }, [availability, staff]);
 
   if (isLoading) return <div className="text-text-secondary">Cargando…</div>;
   if (!staff) {
@@ -121,6 +182,45 @@ export const StaffDetails: React.FC = () => {
             </dd>
           </div>
         </dl>
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl shadow-sm p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <CalendarClock className="h-5 w-5 text-primary" aria-hidden="true" />
+          <h2 className="text-lg font-semibold text-text">Próximas asignaciones</h2>
+        </div>
+        {upcomingAssignments.length === 0 ? (
+          <p className="text-sm text-text-secondary">
+            No tiene eventos asignados en los próximos 90 días.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {upcomingAssignments.map((a) => {
+              const shift = formatShiftRange(a.shift_start, a.shift_end);
+              return (
+                <li key={a.event_id} className="py-3 flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <Link
+                      to={`/events/${a.event_id}/summary`}
+                      className="font-medium text-text hover:text-primary hover:underline truncate block"
+                    >
+                      {a.event_name || "Evento"}
+                    </Link>
+                    <div className="text-xs text-text-secondary mt-0.5">
+                      {formatEventDate(a.event_date)}
+                      {shift ? ` · ${shift}` : ""}
+                    </div>
+                  </div>
+                  <span
+                    className={`shrink-0 inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full ${STATUS_CLASSES[a.status]}`}
+                  >
+                    {STATUS_LABELS[a.status]}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/web/src/services/eventService.ts
+++ b/web/src/services/eventService.ts
@@ -125,7 +125,15 @@ export const eventService = {
     extras: { description: string; cost: number; price: number; exclude_utility?: boolean; include_in_checklist?: boolean }[],
     equipment?: { inventoryId: string; quantity: number; notes?: string }[],
     supplies?: { inventoryId: string; quantity: number; unitCost: number; source: 'stock' | 'purchase'; excludeCost?: boolean }[],
-    staff?: { staffId: string; feeAmount?: number | null; roleOverride?: string | null; notes?: string | null }[],
+    staff?: {
+      staffId: string;
+      feeAmount?: number | null;
+      roleOverride?: string | null;
+      notes?: string | null;
+      shiftStart?: string | null;
+      shiftEnd?: string | null;
+      status?: 'pending' | 'confirmed' | 'declined' | 'cancelled' | null;
+    }[],
   ) {
     // Map frontend structure to backend expected JSON
     // Backend expects: { products: [{product_id, ...}], extras: [...], equipment: [...], supplies: [...] }
@@ -173,6 +181,11 @@ export const eventService = {
         fee_amount: st.feeAmount ?? null,
         role_override: st.roleOverride ?? null,
         notes: st.notes ?? null,
+        shift_start: st.shiftStart ?? null,
+        shift_end: st.shiftEnd ?? null,
+        // status omitted when null so backend preserves the existing value
+        // on upsert (treats null/undefined the same as absent).
+        ...(st.status ? { status: st.status } : {}),
       }));
     }
 

--- a/web/src/services/staffService.ts
+++ b/web/src/services/staffService.ts
@@ -4,6 +4,7 @@ import type {
   PaginatedResponse,
   PaginationParams,
   Staff,
+  StaffAvailability,
   StaffInsert,
   StaffUpdate,
 } from '../types/entities';
@@ -44,5 +45,13 @@ export const staffService = {
 
   async getByEvent(eventId: string): Promise<EventStaff[]> {
     return api.get<EventStaff[]>(`/events/${eventId}/staff`);
+  },
+
+  async getAvailability(params: { date?: string; start?: string; end?: string }): Promise<StaffAvailability[]> {
+    const query: Record<string, string> = {};
+    if (params.date) query.date = params.date;
+    if (params.start) query.start = params.start;
+    if (params.end) query.end = params.end;
+    return api.get<StaffAvailability[]>('/staff/availability', query);
   },
 };

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -191,6 +191,10 @@ export interface Staff {
 export type StaffInsert = Omit<Staff, 'id' | 'user_id' | 'created_at' | 'updated_at'>
 export type StaffUpdate = Partial<StaffInsert>
 
+// Status de una asignación Staff↔Evento. Default backend: 'confirmed'.
+// En writes: null/omit = preservar el valor actual en upsert.
+export type AssignmentStatus = 'pending' | 'confirmed' | 'declined' | 'cancelled'
+
 // EventStaff: asignación de un Staff a un evento.
 export interface EventStaff {
     id: string
@@ -201,6 +205,10 @@ export interface EventStaff {
     notes?: string | null
     notification_sent_at?: string | null
     notification_last_result?: string | null
+    // Ola 1 — ventana de turno (UTC) y estado de confirmación.
+    shift_start?: string | null
+    shift_end?: string | null
+    status?: AssignmentStatus | null
     created_at: string
 
     // Joined desde staff
@@ -217,6 +225,27 @@ export interface EventStaffAssignment {
     fee_amount?: number | null
     role_override?: string | null
     notes?: string | null
+    shift_start?: string | null
+    shift_end?: string | null
+    status?: AssignmentStatus | null
+}
+
+// ===== Staff Availability (Ola 1) =====
+// GET /api/staff/availability?date=YYYY-MM-DD | ?start=...&end=...
+// Solo devuelve staff CON asignaciones en la ventana pedida.
+export interface StaffAvailabilityAssignment {
+    event_id: string
+    event_name: string
+    event_date: string // YYYY-MM-DD
+    shift_start?: string | null
+    shift_end?: string | null
+    status: AssignmentStatus
+}
+
+export interface StaffAvailability {
+    staff_id: string
+    staff_name: string
+    assignments: StaffAvailabilityAssignment[]
 }
 
 // ===== Pagination =====


### PR DESCRIPTION
## Summary

Expands the Personal (Staff) feature with the **operational layer** — shift windows, assignment status, and a "who is busy" indicator — across backend + iOS + Android + Web. Designed so the same model serves both organizers with their own team and catering/waiter-service businesses.

Builds on the catalog shipped in Phase 1 (2026-04-16) and Phase 2 email notifications (2026-04-17). Phase 3 (collaborator login) remains untouched as roadmap.

### Changes

**Backend (migration 043)**
- `event_staff.shift_start` / `shift_end` (TIMESTAMPTZ, nullable — may cross midnight)
- `event_staff.status` enum: `pending | confirmed | declined | cancelled`, default `confirmed`
- CHECK constraint `shift_end > shift_start`
- New endpoint `GET /api/staff/availability?date=YYYY-MM-DD` (or `start`/`end` range)
- UPSERT uses `COALESCE($status, event_staff.status)` so older clients that omit the field don't clobber stored RSVP state — same resilience pattern as `notification_sent_at`

**Clients (iOS / Android / Web)**
- EventForm step 4: collapsible "Agregar horario (opcional)" time pickers + status selector (amber/green/rose/slate badges)
- Staff picker shows "Ocupado ese día" next to staff with existing assignments on the event's date (current event filtered out when editing)
- Staff detail: shift window + status badge on assignments

**UX principles**
- All existing assignments render identically — new fields are additive
- Rioplatense Spanish: "Sin confirmar", "Confirmado", "Rechazó", "Cancelado", "Ocupado ese día"
- No new top-level screens — availability lives inside the EventForm
- No plan gating in this wave — all plans get shifts/status/availability

## Test plan

- [ ] Backend: `cd backend && go build ./... && go test ./...` passes
- [ ] iOS: `xcodebuild -scheme Solennix -destination 'platform=iOS Simulator,name=iPhone 16' build` passes
- [ ] Android: `cd android && ./gradlew assembleDebug` passes (JAVA_HOME=openjdk@17)
- [ ] Web: `cd web && npm run check && npm run build && npm run test:run` passes
- [ ] Migration 043 up/down are reversible
- [ ] Old client without `status` in payload does NOT clobber stored RSVP (regression against `notification_sent_at` pattern)
- [ ] Editing an event does not flag its own staff as "Ocupado ese día"
- [ ] Shift that crosses midnight (e.g. 19:00 → 02:00 next day) persists and displays correctly in local time

## Roadmap next

- **Ola 2** — `staff_teams` + `staff_team_members` for block-assigning crews
- **Ola 3** — `Product.staff_team_id` optional for sellable staff service with markup vs internal cost
- **Phase 3** — collaborator login via `invited_user_id` (unchanged)