### PR TITLE
feat: Personal Ola 2 — staff teams (crews) for block assignment

### DIFF
--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
@@ -88,6 +88,9 @@ import com.creapolis.solennix.feature.settings.ui.TermsScreen
 import com.creapolis.solennix.feature.staff.ui.StaffDetailScreen
 import com.creapolis.solennix.feature.staff.ui.StaffFormScreen
 import com.creapolis.solennix.feature.staff.ui.StaffListScreen
+import com.creapolis.solennix.feature.staff.ui.StaffTeamDetailScreen
+import com.creapolis.solennix.feature.staff.ui.StaffTeamFormScreen
+import com.creapolis.solennix.feature.staff.ui.StaffTeamListScreen
 
 @Composable
 fun CompactBottomNavLayout(initialDeepLinkRoute: String? = null) {
@@ -357,7 +360,39 @@ fun CompactBottomNavLayout(initialDeepLinkRoute: String? = null) {
                     viewModel = hiltViewModel(),
                     onStaffClick = { id -> navController.navigate("staff_detail/$id") },
                     onAddStaffClick = { navController.navigate("staff_form") },
-                    onSearchClick = { navController.navigate(buildSearchRoute()) }
+                    onSearchClick = { navController.navigate(buildSearchRoute()) },
+                    onTeamsClick = { navController.navigate("staff_teams") }
+                )
+            }
+            composable("staff_teams") {
+                StaffTeamListScreen(
+                    viewModel = hiltViewModel(),
+                    onTeamClick = { id -> navController.navigate("staff_team_detail/$id") },
+                    onAddTeamClick = { navController.navigate("staff_team_form") },
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable("staff_team_detail/{teamId}") {
+                StaffTeamDetailScreen(
+                    viewModel = hiltViewModel(),
+                    onNavigateBack = { navController.popBackStack() },
+                    onEditClick = { id -> navController.navigate("staff_team_form?teamId=$id") }
+                )
+            }
+            composable("staff_team_form?teamId={teamId}", arguments = listOf(navArgument("teamId") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            })) {
+                StaffTeamFormScreen(
+                    viewModel = hiltViewModel(),
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable("staff_team_form") {
+                StaffTeamFormScreen(
+                    viewModel = hiltViewModel(),
+                    onNavigateBack = { navController.popBackStack() }
                 )
             }
             composable("staff_detail/{staffId}") {

--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/di/DataModule.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/di/DataModule.kt
@@ -45,6 +45,11 @@ interface DataModule {
     ): StaffRepository
 
     @Binds
+    fun bindsStaffTeamRepository(
+        repository: DefaultStaffTeamRepository
+    ): StaffTeamRepository
+
+    @Binds
     fun bindsEventPublicLinkRepository(
         repository: DefaultEventPublicLinkRepository
     ): EventPublicLinkRepository

--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/StaffTeamRepository.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/StaffTeamRepository.kt
@@ -1,0 +1,45 @@
+package com.creapolis.solennix.core.data.repository
+
+import com.creapolis.solennix.core.model.StaffTeam
+import com.creapolis.solennix.core.network.ApiService
+import com.creapolis.solennix.core.network.Endpoints
+import com.creapolis.solennix.core.network.get
+import com.creapolis.solennix.core.network.post
+import com.creapolis.solennix.core.network.put
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Repositorio de equipos (Ola 2 del módulo Personal). Network-only: los
+ * equipos se consultan on-demand y no se cachean en Room porque son un
+ * recurso de acceso puntual (form de evento, gestión eventual).
+ */
+interface StaffTeamRepository {
+    suspend fun listTeams(): List<StaffTeam>
+    suspend fun getTeam(id: String): StaffTeam
+    suspend fun createTeam(team: StaffTeam): StaffTeam
+    suspend fun updateTeam(team: StaffTeam): StaffTeam
+    suspend fun deleteTeam(id: String)
+}
+
+@Singleton
+class DefaultStaffTeamRepository @Inject constructor(
+    private val apiService: ApiService
+) : StaffTeamRepository {
+
+    override suspend fun listTeams(): List<StaffTeam> =
+        apiService.get(Endpoints.STAFF_TEAMS)
+
+    override suspend fun getTeam(id: String): StaffTeam =
+        apiService.get(Endpoints.staffTeam(id))
+
+    override suspend fun createTeam(team: StaffTeam): StaffTeam =
+        apiService.post(Endpoints.STAFF_TEAMS, team)
+
+    override suspend fun updateTeam(team: StaffTeam): StaffTeam =
+        apiService.put(Endpoints.staffTeam(team.id), team)
+
+    override suspend fun deleteTeam(id: String) {
+        apiService.delete(Endpoints.staffTeam(id))
+    }
+}

--- a/android/core/model/src/main/java/com/creapolis/solennix/core/model/StaffTeam.kt
+++ b/android/core/model/src/main/java/com/creapolis/solennix/core/model/StaffTeam.kt
@@ -1,0 +1,37 @@
+package com.creapolis.solennix.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Equipo de colaboradores — agrupa staff recurrente para asignación en bloque
+ * a eventos. Ola 2 del "Personal".
+ *
+ * [members] llega sólo en respuestas detalladas (GET by id / POST / PUT).
+ * [memberCount] llega sólo en el listado liviano.
+ */
+@Serializable
+data class StaffTeam(
+    val id: String = "",
+    @SerialName("user_id") val userId: String = "",
+    val name: String,
+    @SerialName("role_label") val roleLabel: String? = null,
+    val notes: String? = null,
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("updated_at") val updatedAt: String = "",
+    val members: List<StaffTeamMember>? = null,
+    @SerialName("member_count") val memberCount: Int? = null
+)
+
+@Serializable
+data class StaffTeamMember(
+    @SerialName("team_id") val teamId: String = "",
+    @SerialName("staff_id") val staffId: String,
+    @SerialName("is_lead") val isLead: Boolean = false,
+    val position: Int = 0,
+    @SerialName("created_at") val createdAt: String = "",
+    @SerialName("staff_name") val staffName: String? = null,
+    @SerialName("staff_role_label") val staffRoleLabel: String? = null,
+    @SerialName("staff_phone") val staffPhone: String? = null,
+    @SerialName("staff_email") val staffEmail: String? = null
+)

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
@@ -23,6 +23,10 @@ object Endpoints {
     fun staff(id: String) = "staff/$id"
     fun eventStaff(eventId: String) = "events/$eventId/staff"
 
+    // Staff Teams (Equipos)
+    const val STAFF_TEAMS = "staff/teams"
+    fun staffTeam(id: String) = "staff/teams/$id"
+
     // Events
     const val EVENTS = "events"
     const val UPCOMING_EVENTS = "events/upcoming"

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventFormScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventFormScreen.kt
@@ -1877,6 +1877,7 @@ fun ProductPickerSheet(
 @Composable
 private fun StaffAssignmentPanel(viewModel: EventFormViewModel) {
     var showStaffPicker by remember { mutableStateOf(false) }
+    var showTeamPicker by remember { mutableStateOf(false) }
     val availableStaff by viewModel.availableStaff.collectAsStateWithLifecycle()
 
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -1934,13 +1935,27 @@ private fun StaffAssignmentPanel(viewModel: EventFormViewModel) {
                 }
             }
         } else if (viewModel.selectedStaff.isEmpty()) {
-            OutlinedButton(
-                onClick = { showStaffPicker = true },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("Asignar colaborador")
+            Column(modifier = Modifier.fillMaxWidth()) {
+                OutlinedButton(
+                    onClick = { showStaffPicker = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Agregar colaborador")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick = {
+                        viewModel.loadTeams()
+                        showTeamPicker = true
+                    },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.Group, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Agregar equipo completo")
+                }
             }
         } else {
             viewModel.selectedStaff.forEach { assignment ->
@@ -1969,6 +1984,19 @@ private fun StaffAssignmentPanel(viewModel: EventFormViewModel) {
                     color = SolennixTheme.colors.primary
                 )
             }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = {
+                    viewModel.loadTeams()
+                    showTeamPicker = true
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(Icons.Default.Group, contentDescription = null, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Agregar equipo completo")
+            }
         }
     }
 
@@ -1976,6 +2004,13 @@ private fun StaffAssignmentPanel(viewModel: EventFormViewModel) {
         StaffPickerSheet(
             viewModel = viewModel,
             onDismiss = { showStaffPicker = false }
+        )
+    }
+
+    if (showTeamPicker) {
+        TeamPickerSheet(
+            viewModel = viewModel,
+            onDismiss = { showTeamPicker = false }
         )
     }
 }
@@ -2373,6 +2408,147 @@ private fun StaffPickerSheet(
                     }
                 }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TeamPickerSheet(
+    viewModel: EventFormViewModel,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val teams by viewModel.availableTeams.collectAsStateWithLifecycle()
+    val scope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "Seleccioná un equipo",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                "Los miembros se suman como asignaciones nuevas. Podés ajustar el " +
+                    "fee, turno o estado de cada uno después.",
+                style = MaterialTheme.typography.bodySmall,
+                color = SolennixTheme.colors.secondaryText
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            when {
+                viewModel.isLoadingTeams && teams.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+                viewModel.teamsErrorMessage != null && teams.isEmpty() -> {
+                    Text(
+                        viewModel.teamsErrorMessage.orEmpty(),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = SolennixTheme.colors.error
+                    )
+                }
+                teams.isEmpty() -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            "Sin equipos todavía. Creá uno desde Personal → Equipos.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = SolennixTheme.colors.secondaryText
+                        )
+                    }
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                        items(teams, key = { it.id }) { team ->
+                            Card(
+                                onClick = {
+                                    viewModel.addTeamAssignment(team.id) { added, skipped ->
+                                        val msg = buildString {
+                                            append("Equipo aplicado: ")
+                                            append(
+                                                when (added) {
+                                                    0 -> "sin nuevos miembros"
+                                                    1 -> "1 agregado"
+                                                    else -> "$added agregados"
+                                                }
+                                            )
+                                            if (skipped > 0) append(" · $skipped ya estaban")
+                                        }
+                                        scope.launch { snackbarHostState.showSnackbar(msg) }
+                                    }
+                                    onDismiss()
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 4.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = SolennixTheme.colors.card
+                                ),
+                                shape = MaterialTheme.shapes.medium
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        Icons.Default.Group,
+                                        contentDescription = null,
+                                        tint = SolennixTheme.colors.primary
+                                    )
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            team.name,
+                                            style = MaterialTheme.typography.titleSmall,
+                                            color = SolennixTheme.colors.primaryText
+                                        )
+                                        team.roleLabel?.takeIf { it.isNotBlank() }?.let { label ->
+                                            Text(
+                                                label,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = SolennixTheme.colors.primary
+                                            )
+                                        }
+                                        val count = team.memberCount ?: team.members?.size ?: 0
+                                        Text(
+                                            when (count) {
+                                                0 -> "Sin miembros"
+                                                1 -> "1 miembro"
+                                                else -> "$count miembros"
+                                            },
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = SolennixTheme.colors.secondaryText
+                                        )
+                                    }
+                                    Icon(
+                                        Icons.Default.Add,
+                                        contentDescription = "Aplicar",
+                                        tint = SolennixTheme.colors.primary
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            SnackbarHost(hostState = snackbarHostState)
         }
     }
 }

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventFormViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventFormViewModel.kt
@@ -14,6 +14,7 @@ import com.creapolis.solennix.core.data.repository.EventRepository
 import com.creapolis.solennix.core.data.repository.InventoryRepository
 import com.creapolis.solennix.core.data.repository.ProductRepository
 import com.creapolis.solennix.core.data.repository.StaffRepository
+import com.creapolis.solennix.core.data.repository.StaffTeamRepository
 import com.creapolis.solennix.core.designsystem.event.UiEvent
 import com.creapolis.solennix.core.model.*
 import com.creapolis.solennix.core.network.ApiService
@@ -37,6 +38,7 @@ class EventFormViewModel @Inject constructor(
     private val productRepository: ProductRepository,
     private val inventoryRepository: InventoryRepository,
     private val staffRepository: StaffRepository,
+    private val staffTeamRepository: StaffTeamRepository,
     private val apiService: ApiService,
     private val planLimitsManager: PlanLimitsManager,
     private val authManager: AuthManager,
@@ -179,6 +181,15 @@ class EventFormViewModel @Inject constructor(
     val staffAvailability: StateFlow<Map<String, List<StaffAvailabilityAssignment>>> =
         _staffAvailability.asStateFlow()
     private var availabilityJob: Job? = null
+
+    // Ola 2: equipos (staff teams). Se cargan bajo demanda cuando se abre el
+    // picker de "Agregar equipo completo". Network-only — no cacheamos en Room.
+    private val _availableTeams = MutableStateFlow<List<StaffTeam>>(emptyList())
+    val availableTeams: StateFlow<List<StaffTeam>> = _availableTeams.asStateFlow()
+    var isLoadingTeams by mutableStateOf(false)
+        private set
+    var teamsErrorMessage by mutableStateOf<String?>(null)
+        private set
 
     // Step 6: Location & Details (moved to GeneralInfo in UI)
     var location by mutableStateOf("")
@@ -1053,6 +1064,73 @@ class EventFormViewModel @Inject constructor(
         val index = selectedStaff.indexOfFirst { it.staffId == staffId }
         if (index < 0) return
         selectedStaff[index] = selectedStaff[index].copy(notes = notes)
+    }
+
+    // ===== Staff Teams (Ola 2) =====
+
+    /** Lista equipos del usuario para el picker. Refresca on-demand. */
+    fun loadTeams() {
+        viewModelScope.launch {
+            isLoadingTeams = true
+            teamsErrorMessage = null
+            try {
+                _availableTeams.value = staffTeamRepository.listTeams()
+                    .sortedBy { it.name.lowercase() }
+            } catch (e: Exception) {
+                teamsErrorMessage = "No pudimos cargar los equipos: ${e.message}"
+            } finally {
+                isLoadingTeams = false
+            }
+        }
+    }
+
+    /**
+     * Expande un equipo: trae su detalle (con miembros) y agrega los staff que
+     * no estén ya asignados al evento. Preserva la lógica Ola 1 — cada miembro
+     * queda como asignación independiente y el usuario puede ajustar fee /
+     * turno / estado después.
+     */
+    fun addTeamAssignment(teamId: String, onDone: (added: Int, skipped: Int) -> Unit = { _, _ -> }) {
+        viewModelScope.launch {
+            try {
+                val team = staffTeamRepository.getTeam(teamId)
+                val catalog = _availableStaff.value.associateBy { it.id }
+                val currentIds = selectedStaff.map { it.staffId }.toSet()
+                var added = 0
+                var skipped = 0
+                team.members.orEmpty().sortedBy { it.position }.forEach { member ->
+                    if (member.staffId in currentIds) {
+                        skipped++
+                        return@forEach
+                    }
+                    // Prefer the fresh staff from catalog; fall back to the snapshot
+                    // that came inside the team payload.
+                    val resolvedName = catalog[member.staffId]?.name
+                        ?: member.staffName
+                        ?: "Colaborador"
+                    val resolvedRole = catalog[member.staffId]?.roleLabel
+                        ?: member.staffRoleLabel
+                    selectedStaff.add(
+                        SelectedStaffAssignment(
+                            staffId = member.staffId,
+                            feeAmount = null,
+                            roleOverride = "",
+                            notes = "",
+                            staffName = resolvedName,
+                            staffRoleLabel = resolvedRole,
+                            shiftStart = null,
+                            shiftEnd = null,
+                            status = AssignmentStatus.CONFIRMED.raw
+                        )
+                    )
+                    added++
+                }
+                onDone(added, skipped)
+            } catch (e: Exception) {
+                teamsErrorMessage = "No pudimos agregar el equipo: ${e.message}"
+                onDone(0, 0)
+            }
+        }
     }
 
     /** Costo total del personal — suma de `feeAmount` (null cuenta como 0). */

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffListScreen.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffListScreen.kt
@@ -10,13 +10,16 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -54,7 +57,8 @@ fun StaffListScreen(
     viewModel: StaffListViewModel,
     onStaffClick: (String) -> Unit,
     onAddStaffClick: () -> Unit,
-    onSearchClick: () -> Unit = {}
+    onSearchClick: () -> Unit = {},
+    onTeamsClick: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -100,6 +104,47 @@ fun StaffListScreen(
                     shape = MaterialTheme.shapes.medium,
                     singleLine = true
                 )
+
+                Card(
+                    onClick = onTeamsClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                    shape = MaterialTheme.shapes.medium
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            Icons.Default.Group,
+                            contentDescription = null,
+                            tint = SolennixTheme.colors.primary
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                "Equipos",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Text(
+                                "Agrupá colaboradores para asignar en bloque",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = SolennixTheme.colors.secondaryText
+                            )
+                        }
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = SolennixTheme.colors.secondaryText
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(8.dp))
 
                 Row(
                     modifier = Modifier

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffTeamDetailScreen.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffTeamDetailScreen.kt
@@ -1,0 +1,293 @@
+package com.creapolis.solennix.feature.staff.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Notes
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.creapolis.solennix.core.designsystem.component.Avatar
+import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.StaffTeamMember
+import com.creapolis.solennix.feature.staff.viewmodel.StaffTeamDetailViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StaffTeamDetailScreen(
+    viewModel: StaffTeamDetailViewModel,
+    onNavigateBack: () -> Unit,
+    onEditClick: (String) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(viewModel.deleteSuccess) {
+        if (viewModel.deleteSuccess) onNavigateBack()
+    }
+
+    Scaffold(
+        topBar = {
+            SolennixTopAppBar(
+                title = { Text("Detalle del equipo") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                },
+                actions = {
+                    uiState.team?.let { team ->
+                        IconButton(onClick = { onEditClick(team.id) }) {
+                            Icon(Icons.Default.Edit, contentDescription = "Editar")
+                        }
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(
+                                Icons.Default.Delete,
+                                contentDescription = "Eliminar",
+                                tint = SolennixTheme.colors.error
+                            )
+                        }
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            uiState.errorMessage != null && uiState.team == null -> {
+                Box(
+                    Modifier.fillMaxSize().padding(padding).padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(uiState.errorMessage.orEmpty(), color = SolennixTheme.colors.error)
+                }
+            }
+            uiState.team != null -> {
+                val team = uiState.team ?: return@Scaffold
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding)
+                        .verticalScroll(scrollState)
+                        .padding(16.dp)
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.Group,
+                            contentDescription = null,
+                            tint = SolennixTheme.colors.primary,
+                            modifier = Modifier.size(48.dp)
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column {
+                            Text(
+                                team.name,
+                                style = MaterialTheme.typography.headlineSmall,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            team.roleLabel?.takeIf { it.isNotBlank() }?.let { label ->
+                                Text(
+                                    label,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = SolennixTheme.colors.primary
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    team.notes?.takeIf { it.isNotBlank() }?.let { notes ->
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                            shape = MaterialTheme.shapes.medium
+                        ) {
+                            Column(modifier = Modifier.padding(16.dp)) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(
+                                        Icons.Default.Notes,
+                                        contentDescription = null,
+                                        tint = SolennixTheme.colors.primary
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        "Notas",
+                                        style = MaterialTheme.typography.titleMedium,
+                                        color = SolennixTheme.colors.primaryText
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    notes,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = SolennixTheme.colors.secondaryText
+                                )
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+
+                    Text(
+                        "Miembros",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = SolennixTheme.colors.primaryText,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    val sortedMembers = team.members.orEmpty().sortedBy { it.position }
+                    if (sortedMembers.isEmpty()) {
+                        Text(
+                            "Este equipo aún no tiene miembros. Editá el equipo para agregar colaboradores.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = SolennixTheme.colors.secondaryText
+                        )
+                    } else {
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                            shape = MaterialTheme.shapes.medium
+                        ) {
+                            Column {
+                                sortedMembers.forEachIndexed { idx, member ->
+                                    TeamMemberRow(member = member)
+                                    if (idx < sortedMembers.size - 1) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                            color = SolennixTheme.colors.divider.copy(alpha = 0.5f)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(32.dp))
+                }
+            }
+        }
+    }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Eliminar equipo") },
+            text = {
+                Text(
+                    "¿Eliminar este equipo? Los colaboradores que lo integran no se borran — " +
+                        "sólo se deshace la agrupación."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteDialog = false
+                        viewModel.deleteTeam()
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = SolennixTheme.colors.error
+                    )
+                ) {
+                    Text("Eliminar")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Cancelar")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun TeamMemberRow(member: StaffTeamMember) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Avatar(name = member.staffName ?: "Colaborador", photoUrl = null, size = 40.dp)
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                member.staffName ?: "Colaborador",
+                style = MaterialTheme.typography.titleSmall,
+                color = SolennixTheme.colors.primaryText
+            )
+            member.staffRoleLabel?.takeIf { it.isNotBlank() }?.let { role ->
+                Text(
+                    role,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.primary
+                )
+            }
+        }
+        if (member.isLead) {
+            AssistChip(
+                onClick = {},
+                label = { Text("Lidera") },
+                leadingIcon = {
+                    Icon(
+                        Icons.Default.Star,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = SolennixTheme.colors.primary
+                    )
+                },
+                colors = AssistChipDefaults.assistChipColors(
+                    containerColor = SolennixTheme.colors.primaryLight.copy(alpha = 0.35f),
+                    labelColor = SolennixTheme.colors.primary
+                )
+            )
+        }
+    }
+}

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffTeamFormScreen.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffTeamFormScreen.kt
@@ -1,0 +1,388 @@
+package com.creapolis.solennix.feature.staff.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Badge
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Notes
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.creapolis.solennix.core.designsystem.component.PremiumButton
+import com.creapolis.solennix.core.designsystem.component.SolennixTextField
+import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.feature.staff.viewmodel.SelectedTeamMember
+import com.creapolis.solennix.feature.staff.viewmodel.StaffTeamFormViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StaffTeamFormScreen(
+    viewModel: StaffTeamFormViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    var showMemberPicker by remember { mutableStateOf(false) }
+
+    LaunchedEffect(viewModel.saveSuccess) {
+        if (viewModel.saveSuccess) onNavigateBack()
+    }
+
+    Scaffold(
+        topBar = {
+            SolennixTopAppBar(
+                title = {
+                    Text(if (viewModel.isEditMode) "Editar equipo" else "Crear equipo")
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        if (viewModel.isLoading) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(scrollState)
+                    .padding(16.dp)
+            ) {
+                SolennixTextField(
+                    value = viewModel.name,
+                    onValueChange = { viewModel.name = it },
+                    label = "Nombre *",
+                    leadingIcon = Icons.Default.Group,
+                    errorMessage = viewModel.nameError
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                SolennixTextField(
+                    value = viewModel.roleLabel,
+                    onValueChange = { viewModel.roleLabel = it },
+                    label = "Rol del equipo (ej. Banquetes, Producción)",
+                    leadingIcon = Icons.Default.Badge
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                SolennixTextField(
+                    value = viewModel.notes,
+                    onValueChange = { viewModel.notes = it },
+                    label = "Notas",
+                    leadingIcon = Icons.Default.Notes
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        "Miembros",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = SolennixTheme.colors.primaryText,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        "${viewModel.members.size}",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = SolennixTheme.colors.secondaryText
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+
+                if (viewModel.members.isEmpty()) {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(
+                            containerColor = SolennixTheme.colors.primary.copy(alpha = 0.08f)
+                        ),
+                        shape = MaterialTheme.shapes.medium
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                "Aún no agregaste miembros.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                "Seleccioná colaboradores de tu catálogo para armar el equipo.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = SolennixTheme.colors.secondaryText
+                            )
+                        }
+                    }
+                } else {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+                        shape = MaterialTheme.shapes.medium
+                    ) {
+                        Column {
+                            viewModel.members.forEachIndexed { idx, member ->
+                                MemberFormRow(
+                                    member = member,
+                                    onToggleLead = { viewModel.toggleLead(member.staffId) },
+                                    onRemove = { viewModel.removeMember(member.staffId) }
+                                )
+                                if (idx < viewModel.members.size - 1) {
+                                    HorizontalDivider(
+                                        modifier = Modifier.padding(horizontal = 16.dp),
+                                        color = SolennixTheme.colors.divider.copy(alpha = 0.5f)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedButton(
+                    onClick = { showMemberPicker = true },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Agregar miembro")
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                if (viewModel.errorMessage != null) {
+                    Text(
+                        text = viewModel.errorMessage.orEmpty(),
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(bottom = 16.dp)
+                    )
+                }
+
+                PremiumButton(
+                    text = if (viewModel.isEditMode) "Guardar cambios" else "Crear equipo",
+                    onClick = { viewModel.saveTeam() },
+                    isLoading = viewModel.isSaving,
+                    enabled = !viewModel.isSaving
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+
+    if (showMemberPicker) {
+        MemberPickerSheet(
+            viewModel = viewModel,
+            onDismiss = { showMemberPicker = false }
+        )
+    }
+}
+
+@Composable
+private fun MemberFormRow(
+    member: SelectedTeamMember,
+    onToggleLead: () -> Unit,
+    onRemove: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Icon(
+            Icons.Default.Person,
+            contentDescription = null,
+            tint = SolennixTheme.colors.primary,
+            modifier = Modifier.size(28.dp)
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                member.staffName,
+                style = MaterialTheme.typography.titleSmall,
+                color = SolennixTheme.colors.primaryText
+            )
+            if (!member.staffRoleLabel.isNullOrBlank()) {
+                Text(
+                    member.staffRoleLabel,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = SolennixTheme.colors.primary
+                )
+            }
+        }
+        IconButton(onClick = onToggleLead) {
+            Icon(
+                if (member.isLead) Icons.Default.Star else Icons.Default.StarBorder,
+                contentDescription = if (member.isLead) "Quitar como líder" else "Marcar como líder",
+                tint = if (member.isLead) SolennixTheme.colors.primary else SolennixTheme.colors.secondaryText
+            )
+        }
+        IconButton(onClick = onRemove) {
+            Icon(
+                Icons.Default.Close,
+                contentDescription = "Quitar del equipo",
+                tint = SolennixTheme.colors.error
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MemberPickerSheet(
+    viewModel: StaffTeamFormViewModel,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val available by viewModel.availableStaff.collectAsStateWithLifecycle()
+    var query by remember { mutableStateOf("") }
+
+    val selectedIds = remember(viewModel.members.size) {
+        viewModel.members.map { it.staffId }.toSet()
+    }
+    val filtered = remember(query, available, selectedIds) {
+        available.filter { staff ->
+            staff.id !in selectedIds && (
+                query.isBlank() ||
+                    staff.name.contains(query, ignoreCase = true) ||
+                    (staff.roleLabel?.contains(query, ignoreCase = true) == true)
+                )
+        }
+    }
+
+    ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                "Agregar miembro",
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text("Buscar por nombre o rol...") },
+                leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+                singleLine = true,
+                shape = MaterialTheme.shapes.medium
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            if (filtered.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 32.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        if (available.isEmpty())
+                            "Aún no tenés colaboradores. Agregalos desde Más → Personal."
+                        else
+                            "Sin resultados",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = SolennixTheme.colors.secondaryText
+                    )
+                }
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                    items(filtered, key = { it.id }) { staff ->
+                        Card(
+                            onClick = {
+                                viewModel.addMember(staff)
+                                onDismiss()
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = SolennixTheme.colors.card
+                            ),
+                            shape = MaterialTheme.shapes.medium
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        staff.name,
+                                        style = MaterialTheme.typography.titleSmall,
+                                        color = SolennixTheme.colors.primaryText
+                                    )
+                                    val subtitle = listOfNotNull(
+                                        staff.roleLabel?.takeIf { it.isNotBlank() },
+                                        staff.email?.takeIf { it.isNotBlank() }
+                                    ).joinToString(" · ")
+                                    if (subtitle.isNotBlank()) {
+                                        Text(
+                                            subtitle,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = SolennixTheme.colors.secondaryText
+                                        )
+                                    }
+                                }
+                                Icon(
+                                    Icons.Default.Add,
+                                    contentDescription = "Agregar",
+                                    tint = SolennixTheme.colors.primary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffTeamListScreen.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/StaffTeamListScreen.kt
@@ -1,0 +1,259 @@
+package com.creapolis.solennix.feature.staff.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
+import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
+import com.creapolis.solennix.core.model.StaffTeam
+import com.creapolis.solennix.feature.staff.viewmodel.StaffTeamListViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StaffTeamListScreen(
+    viewModel: StaffTeamListViewModel,
+    onTeamClick: (String) -> Unit,
+    onAddTeamClick: () -> Unit,
+    onNavigateBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var pendingDelete by remember { mutableStateOf<StaffTeam?>(null) }
+
+    LifecycleResumeEffect(viewModel) {
+        viewModel.refresh()
+        onPauseOrDispose { }
+    }
+
+    Scaffold(
+        topBar = {
+            SolennixTopAppBar(
+                title = { Text("Equipos") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Volver"
+                        )
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAddTeamClick,
+                containerColor = SolennixTheme.colors.primary,
+                contentColor = Color.White
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Crear equipo")
+            }
+        },
+        contentWindowInsets = WindowInsets(0)
+    ) { padding ->
+        PullToRefreshBox(
+            isRefreshing = uiState.isRefreshing,
+            onRefresh = { viewModel.refresh() },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when {
+                uiState.isLoading && uiState.teams.isEmpty() -> {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        CircularProgressIndicator()
+                    }
+                }
+                uiState.teams.isEmpty() -> {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .padding(24.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            Icon(
+                                Icons.Default.Group,
+                                contentDescription = null,
+                                tint = SolennixTheme.colors.primary,
+                                modifier = Modifier.size(48.dp)
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text(
+                                "Sin equipos todavía",
+                                style = MaterialTheme.typography.titleMedium,
+                                color = SolennixTheme.colors.primaryText
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                "Agrupá a tus colaboradores recurrentes en equipos para " +
+                                    "asignarlos en bloque a un evento.",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = SolennixTheme.colors.secondaryText
+                            )
+                            if (uiState.errorMessage != null) {
+                                Spacer(modifier = Modifier.height(12.dp))
+                                Text(
+                                    uiState.errorMessage.orEmpty(),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = SolennixTheme.colors.error
+                                )
+                            }
+                        }
+                    }
+                }
+                else -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        items(uiState.teams, key = { it.id }) { team ->
+                            StaffTeamRow(
+                                team = team,
+                                onClick = { onTeamClick(team.id) },
+                                onDeleteClick = { pendingDelete = team }
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    val toDelete = pendingDelete
+    if (toDelete != null) {
+        AlertDialog(
+            onDismissRequest = { pendingDelete = null },
+            title = { Text("Eliminar equipo") },
+            text = {
+                Text(
+                    "¿Eliminar \"${toDelete.name}\"? Los colaboradores no se borran — " +
+                        "sólo se deshace la agrupación."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteTeam(toDelete.id)
+                        pendingDelete = null
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = SolennixTheme.colors.error
+                    )
+                ) {
+                    Text("Eliminar")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingDelete = null }) {
+                    Text("Cancelar")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun StaffTeamRow(
+    team: StaffTeam,
+    onClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    Card(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                Icons.Default.Group,
+                contentDescription = null,
+                tint = SolennixTheme.colors.primary,
+                modifier = Modifier.size(32.dp)
+            )
+            Spacer(modifier = Modifier.size(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    team.name,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = SolennixTheme.colors.primaryText
+                )
+                team.roleLabel?.takeIf { it.isNotBlank() }?.let { label ->
+                    Text(
+                        label,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = SolennixTheme.colors.primary
+                    )
+                }
+                val count = team.memberCount ?: team.members?.size ?: 0
+                Text(
+                    when (count) {
+                        0 -> "Sin miembros"
+                        1 -> "1 miembro"
+                        else -> "$count miembros"
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = SolennixTheme.colors.secondaryText
+                )
+            }
+            IconButton(onClick = onDeleteClick) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Eliminar",
+                    tint = SolennixTheme.colors.error
+                )
+            }
+        }
+    }
+}

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/viewmodel/StaffTeamDetailViewModel.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/viewmodel/StaffTeamDetailViewModel.kt
@@ -1,0 +1,72 @@
+package com.creapolis.solennix.feature.staff.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.data.repository.StaffTeamRepository
+import com.creapolis.solennix.core.model.StaffTeam
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class StaffTeamDetailUiState(
+    val team: StaffTeam? = null,
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null
+)
+
+@HiltViewModel
+class StaffTeamDetailViewModel @Inject constructor(
+    private val teamRepository: StaffTeamRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val teamId: String = checkNotNull(savedStateHandle["teamId"])
+
+    private val _uiState = MutableStateFlow(StaffTeamDetailUiState())
+    val uiState: StateFlow<StaffTeamDetailUiState> = _uiState.asStateFlow()
+
+    var deleteSuccess by mutableStateOf(false)
+        private set
+
+    init {
+        load()
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            try {
+                val team = teamRepository.getTeam(teamId)
+                _uiState.update { it.copy(team = team, isLoading = false) }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        errorMessage = "No pudimos cargar el equipo: ${e.message}"
+                    )
+                }
+            }
+        }
+    }
+
+    fun deleteTeam() {
+        viewModelScope.launch {
+            try {
+                teamRepository.deleteTeam(teamId)
+                deleteSuccess = true
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(errorMessage = "No pudimos eliminar el equipo: ${e.message}")
+                }
+            }
+        }
+    }
+}

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/viewmodel/StaffTeamFormViewModel.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/viewmodel/StaffTeamFormViewModel.kt
@@ -1,0 +1,177 @@
+package com.creapolis.solennix.feature.staff.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.data.repository.StaffRepository
+import com.creapolis.solennix.core.data.repository.StaffTeamRepository
+import com.creapolis.solennix.core.model.Staff
+import com.creapolis.solennix.core.model.StaffTeam
+import com.creapolis.solennix.core.model.StaffTeamMember
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Miembro seleccionado en el form. Guardamos el snapshot para que la UI
+ * pueda pintar nombre/rol sin volver a consultar staff.
+ */
+data class SelectedTeamMember(
+    val staffId: String,
+    val staffName: String,
+    val staffRoleLabel: String?,
+    val isLead: Boolean
+)
+
+@HiltViewModel
+class StaffTeamFormViewModel @Inject constructor(
+    private val teamRepository: StaffTeamRepository,
+    private val staffRepository: StaffRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val teamId: String? = savedStateHandle.get<String>("teamId")?.takeIf { it.isNotBlank() }
+    val isEditMode: Boolean = teamId != null
+
+    var name by mutableStateOf("")
+    var roleLabel by mutableStateOf("")
+    var notes by mutableStateOf("")
+
+    val members = mutableStateListOf<SelectedTeamMember>()
+
+    var isLoading by mutableStateOf(false)
+    var isSaving by mutableStateOf(false)
+    var saveSuccess by mutableStateOf(false)
+    var errorMessage by mutableStateOf<String?>(null)
+    var hasAttemptedSubmit by mutableStateOf(false)
+
+    private val _availableStaff = MutableStateFlow<List<Staff>>(emptyList())
+    val availableStaff: StateFlow<List<Staff>> = _availableStaff.asStateFlow()
+
+    val nameError: String?
+        get() = if (hasAttemptedSubmit && name.isBlank()) "El nombre es obligatorio" else null
+
+    val isFormValid: Boolean
+        get() = name.isNotBlank()
+
+    init {
+        loadStaffCatalog()
+        if (teamId != null) {
+            loadTeam(teamId)
+        }
+    }
+
+    private fun loadStaffCatalog() {
+        viewModelScope.launch {
+            staffRepository.getStaff().collect { list ->
+                _availableStaff.value = list
+            }
+        }
+        viewModelScope.launch {
+            try {
+                staffRepository.syncStaff()
+            } catch (_: Exception) {
+                // Non-fatal: UI cae al cache
+            }
+        }
+    }
+
+    private fun loadTeam(id: String) {
+        viewModelScope.launch {
+            isLoading = true
+            try {
+                val team = teamRepository.getTeam(id)
+                name = team.name
+                roleLabel = team.roleLabel ?: ""
+                notes = team.notes ?: ""
+                members.clear()
+                team.members?.sortedBy { it.position }?.forEach { m ->
+                    members.add(
+                        SelectedTeamMember(
+                            staffId = m.staffId,
+                            staffName = m.staffName ?: "Colaborador",
+                            staffRoleLabel = m.staffRoleLabel,
+                            isLead = m.isLead
+                        )
+                    )
+                }
+            } catch (e: Exception) {
+                errorMessage = "No pudimos cargar el equipo: ${e.message}"
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    fun addMember(staff: Staff) {
+        if (members.any { it.staffId == staff.id }) return
+        members.add(
+            SelectedTeamMember(
+                staffId = staff.id,
+                staffName = staff.name,
+                staffRoleLabel = staff.roleLabel,
+                isLead = false
+            )
+        )
+    }
+
+    fun removeMember(staffId: String) {
+        members.removeAll { it.staffId == staffId }
+    }
+
+    fun toggleLead(staffId: String) {
+        val index = members.indexOfFirst { it.staffId == staffId }
+        if (index < 0) return
+        members[index] = members[index].copy(isLead = !members[index].isLead)
+    }
+
+    fun saveTeam() {
+        hasAttemptedSubmit = true
+        if (!isFormValid) return
+        viewModelScope.launch {
+            isSaving = true
+            errorMessage = null
+            try {
+                val payloadMembers = members.mapIndexed { idx, sel ->
+                    StaffTeamMember(
+                        teamId = teamId ?: "",
+                        staffId = sel.staffId,
+                        isLead = sel.isLead,
+                        position = idx,
+                        createdAt = "",
+                        staffName = sel.staffName,
+                        staffRoleLabel = sel.staffRoleLabel
+                    )
+                }
+                val team = StaffTeam(
+                    id = teamId ?: UUID.randomUUID().toString(),
+                    userId = "",
+                    name = name.trim(),
+                    roleLabel = roleLabel.trim().takeIf { it.isNotBlank() },
+                    notes = notes.trim().takeIf { it.isNotBlank() },
+                    createdAt = "",
+                    updatedAt = "",
+                    members = payloadMembers
+                )
+                if (teamId != null) {
+                    teamRepository.updateTeam(team)
+                } else {
+                    teamRepository.createTeam(team)
+                }
+                saveSuccess = true
+            } catch (e: Exception) {
+                errorMessage = "No pudimos guardar el equipo: ${e.message}"
+            } finally {
+                isSaving = false
+            }
+        }
+    }
+}

--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/viewmodel/StaffTeamListViewModel.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/viewmodel/StaffTeamListViewModel.kt
@@ -1,0 +1,72 @@
+package com.creapolis.solennix.feature.staff.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.core.data.repository.StaffTeamRepository
+import com.creapolis.solennix.core.model.StaffTeam
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class StaffTeamListUiState(
+    val teams: List<StaffTeam> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val errorMessage: String? = null
+)
+
+@HiltViewModel
+class StaffTeamListViewModel @Inject constructor(
+    private val teamRepository: StaffTeamRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StaffTeamListUiState(isLoading = true))
+    val uiState: StateFlow<StaffTeamListUiState> = _uiState.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isRefreshing = true, errorMessage = null) }
+            try {
+                val teams = teamRepository.listTeams()
+                _uiState.update {
+                    it.copy(
+                        teams = teams.sortedBy { team -> team.name.lowercase() },
+                        isLoading = false,
+                        isRefreshing = false
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        errorMessage = "No pudimos cargar los equipos: ${e.message}"
+                    )
+                }
+            }
+        }
+    }
+
+    fun deleteTeam(id: String) {
+        viewModelScope.launch {
+            try {
+                teamRepository.deleteTeam(id)
+                _uiState.update { state ->
+                    state.copy(teams = state.teams.filterNot { it.id == id })
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(errorMessage = "No pudimos eliminar el equipo: ${e.message}")
+                }
+            }
+        }
+    }
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -101,6 +101,7 @@ func main() {
 	eventFormLinkRepo := repository.NewEventFormLinkRepo(pool)
 	eventPublicLinkRepo := repository.NewEventPublicLinkRepo(pool)
 	staffRepo := repository.NewStaffRepo(pool)
+	staffTeamRepo := repository.NewStaffTeamRepo(pool)
 
 	// Set persistent token blacklist (replaces in-memory sync.Map)
 	mw.SetTokenBlacklist(revokedTokenRepo)
@@ -156,9 +157,10 @@ func main() {
 	eventFormHandler := handlers.NewEventFormHandler(eventFormLinkRepo, productRepo, userRepo, cfg.FrontendURL, pool)
 	eventPublicLinkHandler := handlers.NewEventPublicLinkHandler(eventPublicLinkRepo, eventRepo, clientRepo, userRepo, paymentRepo, cfg.FrontendURL)
 	staffHandler := handlers.NewStaffHandler(staffRepo)
+	staffTeamHandler := handlers.NewStaffTeamHandler(staffTeamRepo)
 
 	// Create router
-	r := router.New(authHandler, crudHandler, subHandler, searchHandler, eventPaymentHandler, uploadHandler, adminHandler, dashboardHandler, auditHandler, unavailHandler, deviceHandler, liveActivityHandler, eventFormHandler, eventPublicLinkHandler, staffHandler, authService, userRepo, auditRepo, pool, cfg.CORSAllowedOrigins, cfg.UploadDir)
+	r := router.New(authHandler, crudHandler, subHandler, searchHandler, eventPaymentHandler, uploadHandler, adminHandler, dashboardHandler, auditHandler, unavailHandler, deviceHandler, liveActivityHandler, eventFormHandler, eventPublicLinkHandler, staffHandler, staffTeamHandler, authService, userRepo, auditRepo, pool, cfg.CORSAllowedOrigins, cfg.UploadDir)
 
 	// Background job: expire gifted plans that have passed their expiry date.
 	// Runs once at startup then every hour.

--- a/backend/internal/database/migrations/044_create_staff_teams.down.sql
+++ b/backend/internal/database/migrations/044_create_staff_teams.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS staff_team_members;
+DROP TABLE IF EXISTS staff_teams;

--- a/backend/internal/database/migrations/044_create_staff_teams.up.sql
+++ b/backend/internal/database/migrations/044_create_staff_teams.up.sql
@@ -1,0 +1,37 @@
+-- Ola 2 of Personal expansion: staff teams (crews).
+-- Lets the organizer group staff into named teams (e.g. "Equipo de meseros
+-- Plata", "Cuadrilla de montaje") so they can be assigned to an event in one
+-- click — the UI expands the team into N rows in event_staff on save.
+--
+-- Ownership is per user (multi-tenant). Members reference `staff` rows; both
+-- sides cascade on delete. The team/member tables intentionally carry NO fee
+-- or status — those still live on the per-assignment row in event_staff so the
+-- same team can be used in multiple events with different costs/RSVPs.
+CREATE TABLE staff_teams (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    -- role_label is the default role applied to each member on expansion
+    -- when event_staff.role_override is left blank (e.g. team "Meseros Plata"
+    -- with role_label = "Mesero" means each assignment defaults to "Mesero").
+    role_label TEXT,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_staff_teams_user_id ON staff_teams(user_id);
+
+-- staff_team_members is a composite-PK junction.
+-- is_lead is a visual/semantic flag only — not a permission (Phase 3 may wire
+-- it to the invited-user flow). position controls display order in the team.
+CREATE TABLE staff_team_members (
+    team_id UUID NOT NULL REFERENCES staff_teams(id) ON DELETE CASCADE,
+    staff_id UUID NOT NULL REFERENCES staff(id) ON DELETE CASCADE,
+    is_lead BOOLEAN NOT NULL DEFAULT false,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team_id, staff_id)
+);
+
+CREATE INDEX idx_staff_team_members_staff_id ON staff_team_members(staff_id);

--- a/backend/internal/handlers/interfaces.go
+++ b/backend/internal/handlers/interfaces.go
@@ -86,6 +86,16 @@ type StaffRepository interface {
 	GetAvailability(ctx context.Context, userID uuid.UUID, start, end string) ([]repository.StaffAvailability, error)
 }
 
+// StaffTeamRepository defines staff team repo operations (Ola 2).
+type StaffTeamRepository interface {
+	GetAll(ctx context.Context, userID uuid.UUID) ([]models.StaffTeam, error)
+	GetByID(ctx context.Context, id, userID uuid.UUID) (*models.StaffTeam, error)
+	Create(ctx context.Context, t *models.StaffTeam) error
+	Update(ctx context.Context, t *models.StaffTeam) error
+	Delete(ctx context.Context, id, userID uuid.UUID) error
+	CountByUserID(ctx context.Context, userID uuid.UUID) (int, error)
+}
+
 // ProductRepository defines product repo operations.
 type ProductRepository interface {
 	GetAll(ctx context.Context, userID uuid.UUID) ([]models.Product, error)

--- a/backend/internal/handlers/staff_team_handler.go
+++ b/backend/internal/handlers/staff_team_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -8,7 +9,23 @@ import (
 	"github.com/google/uuid"
 	"github.com/tiagofur/solennix-backend/internal/middleware"
 	"github.com/tiagofur/solennix-backend/internal/models"
+	"github.com/tiagofur/solennix-backend/internal/repository"
 )
+
+// writeStaffTeamError maps repo errors to the right status code and message,
+// preventing internal error text from leaking to the client. Anything not
+// recognized becomes 500 with the caller-provided generic message; details
+// stay in the server log.
+func writeStaffTeamError(w http.ResponseWriter, err error, genericMsg string) {
+	switch {
+	case errors.Is(err, repository.ErrStaffTeamNotFound):
+		writeError(w, http.StatusNotFound, "Team not found")
+	case errors.Is(err, repository.ErrInvalidTeamMember):
+		writeError(w, http.StatusBadRequest, "invalid team member (unknown or cross-tenant staff)")
+	default:
+		writeError(w, http.StatusInternalServerError, genericMsg)
+	}
+}
 
 // StaffTeamHandler handles CRUD for the organizer's staff teams (Ola 2).
 type StaffTeamHandler struct {
@@ -65,7 +82,7 @@ func (h *StaffTeamHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
 	t.UserID = userID
 	if err := h.repo.Create(r.Context(), &t); err != nil {
 		slog.Error("create staff team failed", "error", err, "user_id", userID)
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStaffTeamError(w, err, "Failed to create team")
 		return
 	}
 	writeJSON(w, http.StatusCreated, t)
@@ -93,7 +110,7 @@ func (h *StaffTeamHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
 	t.UserID = userID
 	if err := h.repo.Update(r.Context(), &t); err != nil {
 		slog.Error("update staff team failed", "error", err, "user_id", userID)
-		writeError(w, http.StatusInternalServerError, err.Error())
+		writeStaffTeamError(w, err, "Failed to update team")
 		return
 	}
 	writeJSON(w, http.StatusOK, t)

--- a/backend/internal/handlers/staff_team_handler.go
+++ b/backend/internal/handlers/staff_team_handler.go
@@ -60,7 +60,8 @@ func (h *StaffTeamHandler) GetTeam(w http.ResponseWriter, r *http.Request) {
 	}
 	t, err := h.repo.GetByID(r.Context(), id, userID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "Team not found")
+		slog.Error("get staff team failed", "error", err, "user_id", userID, "team_id", id)
+		writeStaffTeamError(w, err, "Failed to fetch team")
 		return
 	}
 	writeJSON(w, http.StatusOK, t)
@@ -126,7 +127,8 @@ func (h *StaffTeamHandler) DeleteTeam(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.repo.Delete(r.Context(), id, userID); err != nil {
-		writeError(w, http.StatusNotFound, "Team not found")
+		slog.Error("delete staff team failed", "error", err, "user_id", userID, "team_id", id)
+		writeStaffTeamError(w, err, "Failed to delete team")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/handlers/staff_team_handler.go
+++ b/backend/internal/handlers/staff_team_handler.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/tiagofur/solennix-backend/internal/middleware"
+	"github.com/tiagofur/solennix-backend/internal/models"
+)
+
+// StaffTeamHandler handles CRUD for the organizer's staff teams (Ola 2).
+type StaffTeamHandler struct {
+	repo StaffTeamRepository
+}
+
+func NewStaffTeamHandler(repo StaffTeamRepository) *StaffTeamHandler {
+	return &StaffTeamHandler{repo: repo}
+}
+
+// ListTeams lists the organizer's teams (summary with member counts, no member rows).
+// GET /api/staff/teams
+func (h *StaffTeamHandler) ListTeams(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	teams, err := h.repo.GetAll(r.Context(), userID)
+	if err != nil {
+		slog.Error("list staff teams failed", "error", err, "user_id", userID)
+		writeError(w, http.StatusInternalServerError, "Failed to fetch teams")
+		return
+	}
+	writeJSON(w, http.StatusOK, teams)
+}
+
+// GetTeam returns one team with its members (joined with staff info).
+// GET /api/staff/teams/{id}
+func (h *StaffTeamHandler) GetTeam(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid team ID")
+		return
+	}
+	t, err := h.repo.GetByID(r.Context(), id, userID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "Team not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}
+
+// CreateTeam creates a team and its initial members in one transaction.
+// POST /api/staff/teams
+func (h *StaffTeamHandler) CreateTeam(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	var t models.StaffTeam
+	if err := decodeJSON(r, &t); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if err := ValidateStaffTeam(&t); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	t.UserID = userID
+	if err := h.repo.Create(r.Context(), &t); err != nil {
+		slog.Error("create staff team failed", "error", err, "user_id", userID)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, t)
+}
+
+// UpdateTeam updates team meta and replaces members atomically.
+// PUT /api/staff/teams/{id}
+func (h *StaffTeamHandler) UpdateTeam(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid team ID")
+		return
+	}
+	var t models.StaffTeam
+	if err := decodeJSON(r, &t); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if err := ValidateStaffTeam(&t); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	t.ID = id
+	t.UserID = userID
+	if err := h.repo.Update(r.Context(), &t); err != nil {
+		slog.Error("update staff team failed", "error", err, "user_id", userID)
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}
+
+// DeleteTeam removes the team. Members cascade via FK.
+// DELETE /api/staff/teams/{id}
+func (h *StaffTeamHandler) DeleteTeam(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	id, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid team ID")
+		return
+	}
+	if err := h.repo.Delete(r.Context(), id, userID); err != nil {
+		writeError(w, http.StatusNotFound, "Team not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/internal/handlers/validation.go
+++ b/backend/internal/handlers/validation.go
@@ -396,6 +396,43 @@ func ValidateStaff(s *models.Staff) error {
 	return nil
 }
 
+// ValidateStaffTeam validates a staff team and its members.
+// Tenant isolation (members must belong to the same user) is enforced at the
+// repository layer because it requires DB lookups per staff_id.
+func ValidateStaffTeam(t *models.StaffTeam) error {
+	if t.Name == "" {
+		return ValidationError{Field: "name", Message: "is required"}
+	}
+	if err := validateStringLength("name", t.Name, MaxNameLength); err != nil {
+		return err
+	}
+	if t.RoleLabel != nil {
+		if err := validateStringLength("role_label", *t.RoleLabel, MaxNameLength); err != nil {
+			return err
+		}
+	}
+	if t.Notes != nil {
+		if err := validateStringLength("notes", *t.Notes, MaxNotesLength); err != nil {
+			return err
+		}
+	}
+	seen := make(map[uuid.UUID]bool, len(t.Members))
+	for i := range t.Members {
+		m := &t.Members[i]
+		if m.StaffID == (uuid.UUID{}) {
+			return ValidationError{Field: "members.staff_id", Message: "is required"}
+		}
+		if seen[m.StaffID] {
+			return ValidationError{Field: "members.staff_id", Message: "duplicate member"}
+		}
+		seen[m.StaffID] = true
+	}
+	t.Name = sanitizeString(t.Name)
+	t.RoleLabel = sanitizeOptionalString(t.RoleLabel)
+	t.Notes = sanitizeOptionalString(t.Notes)
+	return nil
+}
+
 // ValidateEventStaff validates event staff assignments.
 func ValidateEventStaff(es *models.EventStaff) error {
 	if es.StaffID == (uuid.UUID{}) {

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -371,6 +371,40 @@ type EventStaff struct {
 	StaffEmail     *string `json:"staff_email,omitempty"`
 }
 
+// StaffTeam is a named group of staff (e.g. "Meseros Plata", "Cuadrilla de
+// montaje") so the organizer can assign the whole crew to an event in one
+// click. Members are populated by GetByID; MemberCount by list queries for
+// cheap display. RoleLabel is the default role applied to each expanded
+// assignment when role_override is blank.
+type StaffTeam struct {
+	ID          uuid.UUID         `json:"id"`
+	UserID      uuid.UUID         `json:"user_id"`
+	Name        string            `json:"name"`
+	RoleLabel   *string           `json:"role_label,omitempty"`
+	Notes       *string           `json:"notes,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+	Members     []StaffTeamMember `json:"members,omitempty"`
+	MemberCount *int              `json:"member_count,omitempty"`
+}
+
+// StaffTeamMember is the junction between a team and a staff row. Carries no
+// fee/status — those belong on event_staff per assignment so the same team can
+// be assigned to multiple events with different costs/RSVPs.
+type StaffTeamMember struct {
+	TeamID    uuid.UUID `json:"team_id"`
+	StaffID   uuid.UUID `json:"staff_id"`
+	IsLead    bool      `json:"is_lead"`
+	Position  int       `json:"position"`
+	CreatedAt time.Time `json:"created_at"`
+
+	// Joined from staff for display convenience
+	StaffName      *string `json:"staff_name,omitempty"`
+	StaffRoleLabel *string `json:"staff_role_label,omitempty"`
+	StaffPhone     *string `json:"staff_phone,omitempty"`
+	StaffEmail     *string `json:"staff_email,omitempty"`
+}
+
 // EventPublicLink is a shareable, revocable token that opens a read-only
 // portal (PRD/12 feature A) for the end client of an event — the person who
 // hired the organizer. Unlike EventFormLink (which captures a lead), this

--- a/backend/internal/repository/staff_team_repo.go
+++ b/backend/internal/repository/staff_team_repo.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"context"
 	"fmt"
 
@@ -8,6 +9,15 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/tiagofur/solennix-backend/internal/models"
+)
+
+// Sentinel errors so handlers can classify failures without parsing messages.
+// ErrStaffTeamNotFound maps to 404; ErrInvalidTeamMember (bad staff_id or
+// cross-tenant) maps to 400. Anything else is treated as 500 by the handler
+// with a generic message (details stay in the server logs).
+var (
+	ErrStaffTeamNotFound  = errors.New("staff team not found")
+	ErrInvalidTeamMember  = errors.New("invalid team member")
 )
 
 type StaffTeamRepo struct {
@@ -61,7 +71,10 @@ func (r *StaffTeamRepo) GetByID(ctx context.Context, id, userID uuid.UUID) (*mod
 		WHERE id = $1 AND user_id = $2`, staffTeamColumns), id, userID)
 	if err := row.Scan(&t.ID, &t.UserID, &t.Name, &t.RoleLabel, &t.Notes,
 		&t.CreatedAt, &t.UpdatedAt); err != nil {
-		return nil, fmt.Errorf("staff team not found: %w", err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrStaffTeamNotFound
+		}
+		return nil, fmt.Errorf("get staff team: %w", err)
 	}
 	members, err := r.getMembers(ctx, t.ID)
 	if err != nil {
@@ -140,7 +153,7 @@ func (r *StaffTeamRepo) Update(ctx context.Context, t *models.StaffTeam) error {
 		return fmt.Errorf("update staff_team: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("staff team not found")
+		return ErrStaffTeamNotFound
 	}
 
 	if _, err := tx.Exec(ctx, `DELETE FROM staff_team_members WHERE team_id = $1`, t.ID); err != nil {
@@ -159,10 +172,11 @@ func upsertTeamMembers(ctx context.Context, tx pgx.Tx, teamID, userID uuid.UUID,
 		var ownerID uuid.UUID
 		err := tx.QueryRow(ctx, `SELECT user_id FROM staff WHERE id = $1`, m.StaffID).Scan(&ownerID)
 		if err != nil {
-			return fmt.Errorf("staff_id %s not found", m.StaffID)
+			// Bad client input (unknown staff_id) — callers map to 400.
+			return fmt.Errorf("%w: staff_id %s not found", ErrInvalidTeamMember, m.StaffID)
 		}
 		if ownerID != userID {
-			return fmt.Errorf("staff_id %s does not belong to this user", m.StaffID)
+			return fmt.Errorf("%w: staff_id %s does not belong to this user", ErrInvalidTeamMember, m.StaffID)
 		}
 		if _, err := tx.Exec(ctx, `INSERT INTO staff_team_members
 			(team_id, staff_id, is_lead, position) VALUES ($1, $2, $3, $4)`,
@@ -179,7 +193,7 @@ func (r *StaffTeamRepo) Delete(ctx context.Context, id, userID uuid.UUID) error 
 		return err
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("staff team not found")
+		return ErrStaffTeamNotFound
 	}
 	return nil
 }

--- a/backend/internal/repository/staff_team_repo.go
+++ b/backend/internal/repository/staff_team_repo.go
@@ -1,0 +1,191 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tiagofur/solennix-backend/internal/models"
+)
+
+type StaffTeamRepo struct {
+	pool *pgxpool.Pool
+}
+
+func NewStaffTeamRepo(pool *pgxpool.Pool) *StaffTeamRepo {
+	return &StaffTeamRepo{pool: pool}
+}
+
+const staffTeamColumns = `id, user_id, name, role_label, notes, created_at, updated_at`
+
+// GetAll returns all teams for the user, each with a cheap member_count but
+// NO member rows — the list view only needs the count.
+func (r *StaffTeamRepo) GetAll(ctx context.Context, userID uuid.UUID) ([]models.StaffTeam, error) {
+	query := fmt.Sprintf(`SELECT t.id, t.user_id, t.name, t.role_label, t.notes,
+			t.created_at, t.updated_at,
+			(SELECT COUNT(*) FROM staff_team_members m WHERE m.team_id = t.id) AS member_count
+		FROM staff_teams t
+		WHERE t.user_id = $1
+		ORDER BY t.name
+		LIMIT %d`, GetAllSafetyLimit)
+	rows, err := r.pool.Query(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]models.StaffTeam, 0)
+	for rows.Next() {
+		var t models.StaffTeam
+		var count int
+		if err := rows.Scan(&t.ID, &t.UserID, &t.Name, &t.RoleLabel, &t.Notes,
+			&t.CreatedAt, &t.UpdatedAt, &count); err != nil {
+			return nil, err
+		}
+		c := count
+		t.MemberCount = &c
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate staff_teams: %w", err)
+	}
+	return out, nil
+}
+
+// GetByID returns a single team with its members (joined with staff info).
+func (r *StaffTeamRepo) GetByID(ctx context.Context, id, userID uuid.UUID) (*models.StaffTeam, error) {
+	t := &models.StaffTeam{}
+	row := r.pool.QueryRow(ctx, fmt.Sprintf(`SELECT %s FROM staff_teams
+		WHERE id = $1 AND user_id = $2`, staffTeamColumns), id, userID)
+	if err := row.Scan(&t.ID, &t.UserID, &t.Name, &t.RoleLabel, &t.Notes,
+		&t.CreatedAt, &t.UpdatedAt); err != nil {
+		return nil, fmt.Errorf("staff team not found: %w", err)
+	}
+	members, err := r.getMembers(ctx, t.ID)
+	if err != nil {
+		return nil, err
+	}
+	t.Members = members
+	return t, nil
+}
+
+func (r *StaffTeamRepo) getMembers(ctx context.Context, teamID uuid.UUID) ([]models.StaffTeamMember, error) {
+	query := `SELECT m.team_id, m.staff_id, m.is_lead, m.position, m.created_at,
+			s.name, s.role_label, s.phone, s.email
+		FROM staff_team_members m
+		LEFT JOIN staff s ON s.id = m.staff_id
+		WHERE m.team_id = $1
+		ORDER BY m.position ASC, s.name ASC`
+	rows, err := r.pool.Query(ctx, query, teamID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]models.StaffTeamMember, 0)
+	for rows.Next() {
+		var m models.StaffTeamMember
+		if err := rows.Scan(&m.TeamID, &m.StaffID, &m.IsLead, &m.Position, &m.CreatedAt,
+			&m.StaffName, &m.StaffRoleLabel, &m.StaffPhone, &m.StaffEmail); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate staff_team_members: %w", err)
+	}
+	return out, nil
+}
+
+// Create inserts the team and its initial members in a transaction.
+func (r *StaffTeamRepo) Create(ctx context.Context, t *models.StaffTeam) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	err = tx.QueryRow(ctx, `INSERT INTO staff_teams (user_id, name, role_label, notes)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at, updated_at`,
+		t.UserID, t.Name, t.RoleLabel, t.Notes).
+		Scan(&t.ID, &t.CreatedAt, &t.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("insert staff_team: %w", err)
+	}
+
+	if err := upsertTeamMembers(ctx, tx, t.ID, t.UserID, t.Members); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// Update replaces the team's meta AND its member list atomically.
+// Members are diffed via full replace (DELETE missing + UPSERT provided) —
+// there's no per-member state to preserve, so this is safe.
+func (r *StaffTeamRepo) Update(ctx context.Context, t *models.StaffTeam) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx, `UPDATE staff_teams
+		SET name = $3, role_label = $4, notes = $5, updated_at = NOW()
+		WHERE id = $1 AND user_id = $2`,
+		t.ID, t.UserID, t.Name, t.RoleLabel, t.Notes)
+	if err != nil {
+		return fmt.Errorf("update staff_team: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("staff team not found")
+	}
+
+	if _, err := tx.Exec(ctx, `DELETE FROM staff_team_members WHERE team_id = $1`, t.ID); err != nil {
+		return fmt.Errorf("delete old members: %w", err)
+	}
+	if err := upsertTeamMembers(ctx, tx, t.ID, t.UserID, t.Members); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func upsertTeamMembers(ctx context.Context, tx pgx.Tx, teamID, userID uuid.UUID, members []models.StaffTeamMember) error {
+	for _, m := range members {
+		// Safety: verify the staff row belongs to the same user (tenant isolation).
+		// A malicious or buggy client could otherwise attach another org's staff.
+		var ownerID uuid.UUID
+		err := tx.QueryRow(ctx, `SELECT user_id FROM staff WHERE id = $1`, m.StaffID).Scan(&ownerID)
+		if err != nil {
+			return fmt.Errorf("staff_id %s not found", m.StaffID)
+		}
+		if ownerID != userID {
+			return fmt.Errorf("staff_id %s does not belong to this user", m.StaffID)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO staff_team_members
+			(team_id, staff_id, is_lead, position) VALUES ($1, $2, $3, $4)`,
+			teamID, m.StaffID, m.IsLead, m.Position); err != nil {
+			return fmt.Errorf("insert staff_team_member: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *StaffTeamRepo) Delete(ctx context.Context, id, userID uuid.UUID) error {
+	tag, err := r.pool.Exec(ctx, `DELETE FROM staff_teams WHERE id = $1 AND user_id = $2`, id, userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("staff team not found")
+	}
+	return nil
+}
+
+func (r *StaffTeamRepo) CountByUserID(ctx context.Context, userID uuid.UUID) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM staff_teams WHERE user_id = $1`, userID).Scan(&count)
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -19,6 +19,7 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 	liveActivityHandler *handlers.LiveActivityHandler, eventFormHandler *handlers.EventFormHandler,
 	eventPublicLinkHandler *handlers.EventPublicLinkHandler,
 	staffHandler *handlers.StaffHandler,
+	staffTeamHandler *handlers.StaffTeamHandler,
 	authService *services.AuthService, userRepo *repository.UserRepo, auditRepo mw.AuditLogger, pool *pgxpool.Pool, corsOrigins []string, uploadDir string) http.Handler {
 
 	r := chi.NewRouter()
@@ -166,6 +167,14 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 			// availability must be registered before /{id} so chi does not treat
 			// "availability" as an id param.
 			r.Get("/availability", staffHandler.GetStaffAvailability)
+			// Teams (Ola 2) — static prefix wins over /{id} in chi's trie.
+			r.Route("/teams", func(r chi.Router) {
+				r.Get("/", staffTeamHandler.ListTeams)
+				r.Post("/", staffTeamHandler.CreateTeam)
+				r.Get("/{id}", staffTeamHandler.GetTeam)
+				r.Put("/{id}", staffTeamHandler.UpdateTeam)
+				r.Delete("/{id}", staffTeamHandler.DeleteTeam)
+			})
 			r.Get("/{id}", staffHandler.GetStaff)
 			r.Put("/{id}", staffHandler.UpdateStaff)
 			r.Delete("/{id}", staffHandler.DeleteStaff)

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -168,13 +168,17 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 			// "availability" as an id param.
 			r.Get("/availability", staffHandler.GetStaffAvailability)
 			// Teams (Ola 2) — static prefix wins over /{id} in chi's trie.
-			r.Route("/teams", func(r chi.Router) {
-				r.Get("/", staffTeamHandler.ListTeams)
-				r.Post("/", staffTeamHandler.CreateTeam)
-				r.Get("/{id}", staffTeamHandler.GetTeam)
-				r.Put("/{id}", staffTeamHandler.UpdateTeam)
-				r.Delete("/{id}", staffTeamHandler.DeleteTeam)
-			})
+			// Guarded so router tests / future wiring can pass nil without
+			// triggering a method-on-nil panic when a request hits /teams.
+			if staffTeamHandler != nil {
+				r.Route("/teams", func(r chi.Router) {
+					r.Get("/", staffTeamHandler.ListTeams)
+					r.Post("/", staffTeamHandler.CreateTeam)
+					r.Get("/{id}", staffTeamHandler.GetTeam)
+					r.Put("/{id}", staffTeamHandler.UpdateTeam)
+					r.Delete("/{id}", staffTeamHandler.DeleteTeam)
+				})
+			}
 			r.Get("/{id}", staffHandler.GetStaff)
 			r.Put("/{id}", staffHandler.UpdateStaff)
 			r.Delete("/{id}", staffHandler.DeleteStaff)

--- a/backend/internal/router/router_api_integration_test.go
+++ b/backend/internal/router/router_api_integration_test.go
@@ -36,7 +36,7 @@ func TestAPIIntegrationCoreFlows(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
 
 	registerBody := map[string]interface{}{
 		"email":    "router.integration@test.dev",
@@ -184,7 +184,7 @@ func TestAPIContractMatrixAuthenticatedValidationErrors(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
 
 	status, body := performJSONRequest(t, h, http.MethodPost, "/api/auth/register", "", map[string]interface{}{
 		"email":    "router.contracts@test.dev",
@@ -307,7 +307,7 @@ func TestAPIContractMatrixSuccessShapes(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
 
 	status, body := performJSONRequest(t, h, http.MethodPost, "/api/auth/register", "", map[string]interface{}{
 		"email":    "router.success.contracts@test.dev",
@@ -614,7 +614,7 @@ func TestGoldenContractsV1(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
 
 	responses := map[string]observedResponse{}
 

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -25,7 +25,7 @@ func (n *noopAuditLogger) Create(_ context.Context, _ *models.AuditLog) error { 
 
 func TestNewRouter(t *testing.T) {
 	authService := services.NewAuthService("test-secret", 1)
-	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
+	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
 
 	t.Run("GivenHealthEndpoint_WhenRequest_ThenReturnsOK", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
@@ -64,7 +64,7 @@ func TestNewRouter(t *testing.T) {
 		testFilePath := filepath.Join(tempDir, "test.png")
 		_ = os.WriteFile(testFilePath, []byte("fake image data"), 0644)
 
-		h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(tempDir, nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, tempDir)
+		h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(tempDir, nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, tempDir)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/uploads/test.png", nil)
 		rr := httptest.NewRecorder()
@@ -78,7 +78,7 @@ func TestNewRouter(t *testing.T) {
 }
 func TestProtectedRoutesRequireValidBearerToken(t *testing.T) {
 	authService := services.NewAuthService("test-secret", 1)
-	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
+	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
 
 	protectedRequests := []struct {
 		name   string
@@ -133,7 +133,7 @@ func TestProtectedRoutesRequireValidBearerToken(t *testing.T) {
 
 func TestRouterErrorContractMatrix(t *testing.T) {
 	authService := services.NewAuthService("test-secret", 1)
-	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
+	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
 
 	cases := []struct {
 		name       string

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/StaffTeam.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/StaffTeam.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// MARK: - Staff Team (Cuadrilla / Equipo)
+
+/// Grupo nombrado de colaboradores (meseros, fotografos, DJs...) que el
+/// organizador puede asignar a un evento de un solo toque.
+/// El backend devuelve `members` solo en GET/POST/PUT por ID y
+/// `memberCount` solo en el listado — por eso ambos son opcionales.
+public struct StaffTeam: Codable, Identifiable, Sendable, Hashable {
+    public let id: String
+    public let userId: String
+    public var name: String
+    public var roleLabel: String?
+    public var notes: String?
+    public let createdAt: String
+    public let updatedAt: String
+    public var members: [StaffTeamMember]?
+    public var memberCount: Int?
+
+    public init(
+        id: String,
+        userId: String,
+        name: String,
+        roleLabel: String? = nil,
+        notes: String? = nil,
+        createdAt: String,
+        updatedAt: String,
+        members: [StaffTeamMember]? = nil,
+        memberCount: Int? = nil
+    ) {
+        self.id = id
+        self.userId = userId
+        self.name = name
+        self.roleLabel = roleLabel
+        self.notes = notes
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.members = members
+        self.memberCount = memberCount
+    }
+}
+
+// MARK: - Staff Team Member
+
+/// Relacion team <-> staff. Los campos `staff*` vienen joineados por el
+/// backend — se llenan en el GET por ID pero pueden ser nil si el staff
+/// fue borrado despues de crear el team.
+public struct StaffTeamMember: Codable, Sendable, Hashable, Identifiable {
+    public let teamId: String
+    public let staffId: String
+    public var isLead: Bool
+    public var position: Int
+    public let createdAt: String
+    public var staffName: String?
+    public var staffRoleLabel: String?
+    public var staffPhone: String?
+    public var staffEmail: String?
+
+    public var id: String { "\(teamId):\(staffId)" }
+
+    public init(
+        teamId: String,
+        staffId: String,
+        isLead: Bool = false,
+        position: Int = 0,
+        createdAt: String = "",
+        staffName: String? = nil,
+        staffRoleLabel: String? = nil,
+        staffPhone: String? = nil,
+        staffEmail: String? = nil
+    ) {
+        self.teamId = teamId
+        self.staffId = staffId
+        self.isLead = isLead
+        self.position = position
+        self.createdAt = createdAt
+        self.staffName = staffName
+        self.staffRoleLabel = staffRoleLabel
+        self.staffPhone = staffPhone
+        self.staffEmail = staffEmail
+    }
+}

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Route.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Route.swift
@@ -32,6 +32,11 @@ public enum Route: Hashable {
     case staffDetail(id: String)
     case staffForm(id: String? = nil)
 
+    // MARK: Staff Teams (Cuadrillas)
+    case staffTeamList
+    case staffTeamDetail(id: String)
+    case staffTeamForm(id: String? = nil)
+
     // MARK: Products
     case productList
     case productDetail(id: String)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
@@ -640,6 +640,36 @@ public final class EventFormViewModel {
         selectedStaff.remove(at: index)
     }
 
+    /// Agrega todos los miembros de un team al evento, saltando los que ya
+    /// estaban asignados. Si el staff no tiene role propio y el team si tiene
+    /// `roleLabel`, se usa ese como `roleOverride` del evento.
+    /// Devuelve cuantos miembros se agregaron efectivamente.
+    @discardableResult
+    public func addStaffTeam(_ team: StaffTeam) -> Int {
+        let teamRole = team.roleLabel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let members = (team.members ?? []).sorted { $0.position < $1.position }
+        var added = 0
+
+        for member in members {
+            if selectedStaff.contains(where: { $0.staffId == member.staffId }) { continue }
+
+            let staffRole = member.staffRoleLabel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let roleOverride = staffRole.isEmpty ? teamRole : ""
+
+            selectedStaff.append(
+                SelectedStaffAssignment(
+                    staffId: member.staffId,
+                    staffName: member.staffName ?? "",
+                    staffRoleLabel: member.staffRoleLabel,
+                    roleOverride: roleOverride
+                )
+            )
+            added += 1
+        }
+
+        return added
+    }
+
     /// Suma de costos de staff asignado (se muestra en el panel pero NO afecta
     /// el total del evento en Phase 1 — es informativo).
     public var staffCost: Double {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
@@ -129,8 +129,8 @@ struct Step4PersonnelPanel: View {
                 } else if teams.isEmpty {
                     EmptyStateView(
                         icon: "person.3.sequence",
-                        title: "Sin equipos todavia",
-                        message: "Agrupa a tu equipo de meseros o fotografos desde Personal > Equipos para asignarlos con un solo toque."
+                        title: "Sin equipos todavía",
+                        message: "Agrupá a tu equipo de meseros o fotógrafos desde Personal > Equipos para asignarlos con un solo toque."
                     )
                 } else {
                     List {
@@ -302,7 +302,7 @@ struct Step4PersonnelPanel: View {
                     .font(.caption2)
                     .foregroundStyle(SolennixColors.textTertiary)
 
-                TextField("Notas de la asignacion", text: $viewModel.selectedStaff[index].notes)
+                TextField("Notas de la asignación", text: $viewModel.selectedStaff[index].notes)
                     .font(.body)
                     .foregroundStyle(SolennixColors.text)
                     .padding(.horizontal, Spacing.sm)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step4PersonnelPanel.swift
@@ -13,8 +13,13 @@ struct Step4PersonnelPanel: View {
     @Bindable var viewModel: EventFormViewModel
 
     @State private var showStaffPicker = false
+    @State private var showTeamPicker = false
     @State private var staffSearch = ""
     @State private var expandedShiftRow: UUID?
+
+    /// Cache de equipos del organizador (se carga on-demand al abrir el picker).
+    @State private var teams: [StaffTeam] = []
+    @State private var isLoadingTeams: Bool = false
 
     /// Cachea la disponibilidad del dia del evento. Vive aca (no en el VM del
     /// form) para no contaminar la logica del form con datos de solo lectura.
@@ -31,30 +36,57 @@ struct Step4PersonnelPanel: View {
                 staffRow(assignment: assignment, index: index)
             }
 
-            // Add staff button
-            Button {
-                showStaffPicker = true
-            } label: {
-                HStack(spacing: Spacing.sm) {
-                    Image(systemName: "person.crop.circle.badge.plus")
-                        .foregroundStyle(SolennixColors.primary)
+            // Add staff / team buttons
+            HStack(spacing: Spacing.sm) {
+                Button {
+                    showStaffPicker = true
+                } label: {
+                    HStack(spacing: Spacing.sm) {
+                        Image(systemName: "person.crop.circle.badge.plus")
+                            .foregroundStyle(SolennixColors.primary)
 
-                    Text("Agregar Personal")
-                        .font(.subheadline)
-                        .fontWeight(.medium)
-                        .foregroundStyle(SolennixColors.primary)
+                        Text("Agregar Personal")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(SolennixColors.primary)
 
-                    Spacer()
+                        Spacer()
+                    }
+                    .padding(Spacing.md)
+                    .background(SolennixColors.primaryLight)
+                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: CornerRadius.md)
+                            .stroke(SolennixColors.primary.opacity(0.3), lineWidth: 1)
+                    )
                 }
-                .padding(Spacing.md)
-                .background(SolennixColors.primaryLight)
-                .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
-                .overlay(
-                    RoundedRectangle(cornerRadius: CornerRadius.md)
-                        .stroke(SolennixColors.primary.opacity(0.3), lineWidth: 1)
-                )
+                .buttonStyle(.plain)
+
+                Button {
+                    showTeamPicker = true
+                    Task { await loadTeamsIfNeeded() }
+                } label: {
+                    HStack(spacing: Spacing.sm) {
+                        Image(systemName: "person.3.fill")
+                            .foregroundStyle(SolennixColors.primary)
+
+                        Text("Agregar equipo completo")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                            .foregroundStyle(SolennixColors.primary)
+
+                        Spacer()
+                    }
+                    .padding(Spacing.md)
+                    .background(SolennixColors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: CornerRadius.md)
+                            .stroke(SolennixColors.primary.opacity(0.3), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
             }
-            .buttonStyle(.plain)
 
             // Staff cost total (informativo — no suma al total en Phase 1)
             if !viewModel.selectedStaff.isEmpty {
@@ -78,8 +110,116 @@ struct Step4PersonnelPanel: View {
         .sheet(isPresented: $showStaffPicker) {
             staffPickerSheet
         }
+        .sheet(isPresented: $showTeamPicker) {
+            teamPickerSheet
+        }
         .task(id: viewModel.eventDate) {
             await refreshAvailability()
+        }
+    }
+
+    // MARK: - Team Picker
+
+    private var teamPickerSheet: some View {
+        NavigationStack {
+            Group {
+                if isLoadingTeams && teams.isEmpty {
+                    ProgressView("Cargando equipos...")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if teams.isEmpty {
+                    EmptyStateView(
+                        icon: "person.3.sequence",
+                        title: "Sin equipos todavia",
+                        message: "Agrupa a tu equipo de meseros o fotografos desde Personal > Equipos para asignarlos con un solo toque."
+                    )
+                } else {
+                    List {
+                        Section {
+                            Text("Seleccioná un equipo para asignar a todos sus miembros. Los que ya esten asignados se ignoran.")
+                                .font(.caption)
+                                .foregroundStyle(SolennixColors.textSecondary)
+                        }
+
+                        ForEach(teams) { team in
+                            Button {
+                                let added = viewModel.addStaffTeam(team)
+                                HapticsHelper.play(added > 0 ? .success : .warning)
+                                showTeamPicker = false
+                            } label: {
+                                HStack(spacing: Spacing.md) {
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: CornerRadius.md)
+                                            .fill(SolennixColors.primaryLight)
+                                            .frame(width: 40, height: 40)
+                                        Image(systemName: "person.3.fill")
+                                            .font(.subheadline)
+                                            .foregroundStyle(SolennixColors.primary)
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(team.name)
+                                            .font(.body)
+                                            .fontWeight(.semibold)
+                                            .foregroundStyle(SolennixColors.text)
+
+                                        HStack(spacing: Spacing.sm) {
+                                            if let role = team.roleLabel, !role.isEmpty {
+                                                Text(role)
+                                                    .font(.caption)
+                                                    .foregroundStyle(SolennixColors.textSecondary)
+                                            }
+                                            if let count = team.memberCount {
+                                                Text(count == 1 ? "1 miembro" : "\(count) miembros")
+                                                    .font(.caption)
+                                                    .foregroundStyle(SolennixColors.textTertiary)
+                                            }
+                                        }
+                                    }
+
+                                    Spacer()
+
+                                    Image(systemName: "chevron.right")
+                                        .font(.caption)
+                                        .foregroundStyle(SolennixColors.textTertiary)
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle("Agregar equipo")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cerrar") { showTeamPicker = false }
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            }
+        }
+    }
+
+    private func loadTeamsIfNeeded() async {
+        // Siempre que se abre el picker refrescamos — asi el usuario ve los
+        // cambios hechos en el catalogo sin salir del form.
+        isLoadingTeams = true
+        defer { isLoadingTeams = false }
+        do {
+            // Listado liviano — para el detalle de miembros llamamos por ID.
+            let list = try await viewModel.apiClient.listStaffTeams()
+            // Hidratamos miembros por cada team (N requests pero N suele ser chico).
+            var hydrated: [StaffTeam] = []
+            for t in list {
+                if let full = try? await viewModel.apiClient.getStaffTeam(id: t.id) {
+                    hydrated.append(full)
+                } else {
+                    hydrated.append(t)
+                }
+            }
+            teams = hydrated
+        } catch {
+            teams = []
         }
     }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffTeamFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffTeamFormViewModel.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Observation
+import SolennixCore
+import SolennixNetwork
+
+// MARK: - Staff Team Member Draft
+
+/// Draft en memoria — union del staff elegido + flags editables.
+/// `position` se calcula al guardar por el orden del array.
+public struct StaffTeamMemberDraft: Identifiable, Hashable {
+    public var staffId: String
+    public var staffName: String
+    public var staffRoleLabel: String?
+    public var staffPhone: String?
+    public var staffEmail: String?
+    public var isLead: Bool
+
+    public var id: String { staffId }
+
+    public init(
+        staffId: String,
+        staffName: String,
+        staffRoleLabel: String? = nil,
+        staffPhone: String? = nil,
+        staffEmail: String? = nil,
+        isLead: Bool = false
+    ) {
+        self.staffId = staffId
+        self.staffName = staffName
+        self.staffRoleLabel = staffRoleLabel
+        self.staffPhone = staffPhone
+        self.staffEmail = staffEmail
+        self.isLead = isLead
+    }
+}
+
+// MARK: - Staff Team Form View Model
+
+@Observable
+public final class StaffTeamFormViewModel {
+
+    // MARK: - Form Fields
+
+    public var name: String = ""
+    public var roleLabel: String = ""
+    public var notes: String = ""
+    public var members: [StaffTeamMemberDraft] = []
+
+    /// Catalogo completo de staff — se carga una sola vez para el picker.
+    public var staffCatalog: [Staff] = []
+
+    // MARK: - UI State
+
+    public var isLoading: Bool = false
+    public var isSaving: Bool = false
+    public var errorMessage: String?
+    public var isEdit: Bool = false
+    public var editId: String?
+
+    // MARK: - Dependencies
+
+    private let apiClient: APIClient
+
+    public init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Validation
+
+    public var isNameValid: Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed.count <= 255
+    }
+
+    public var isFormValid: Bool {
+        isNameValid
+    }
+
+    // MARK: - Load
+
+    @MainActor
+    public func loadCatalog() async {
+        do {
+            let items: [Staff] = try await apiClient.getAll(Endpoint.staff)
+            staffCatalog = items
+        } catch {
+            errorMessage = mapError(error)
+        }
+    }
+
+    @MainActor
+    public func loadTeam(id: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let team = try await apiClient.getStaffTeam(id: id)
+            name = team.name
+            roleLabel = team.roleLabel ?? ""
+            notes = team.notes ?? ""
+            isEdit = true
+            editId = team.id
+
+            let sorted = (team.members ?? []).sorted { $0.position < $1.position }
+            members = sorted.map { m in
+                StaffTeamMemberDraft(
+                    staffId: m.staffId,
+                    staffName: m.staffName ?? "(sin nombre)",
+                    staffRoleLabel: m.staffRoleLabel,
+                    staffPhone: m.staffPhone,
+                    staffEmail: m.staffEmail,
+                    isLead: m.isLead
+                )
+            }
+        } catch {
+            errorMessage = mapError(error)
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Member Operations
+
+    public func addMember(_ staff: Staff) {
+        guard !members.contains(where: { $0.staffId == staff.id }) else { return }
+        members.append(
+            StaffTeamMemberDraft(
+                staffId: staff.id,
+                staffName: staff.name,
+                staffRoleLabel: staff.roleLabel,
+                staffPhone: staff.phone,
+                staffEmail: staff.email
+            )
+        )
+    }
+
+    public func removeMember(at offsets: IndexSet) {
+        members.remove(atOffsets: offsets)
+    }
+
+    public func moveMember(from source: IndexSet, to destination: Int) {
+        members.move(fromOffsets: source, toOffset: destination)
+    }
+
+    public func toggleLead(for staffId: String) {
+        guard let idx = members.firstIndex(where: { $0.staffId == staffId }) else { return }
+        members[idx].isLead.toggle()
+    }
+
+    // MARK: - Save
+
+    @MainActor
+    public func save() async -> StaffTeam? {
+        guard isFormValid else {
+            errorMessage = "El nombre es obligatorio"
+            return nil
+        }
+
+        isSaving = true
+        errorMessage = nil
+
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedRole = roleLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNotes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let memberPayloads = members.enumerated().map { idx, draft in
+            StaffTeamMemberPayload(
+                staffId: draft.staffId,
+                isLead: draft.isLead,
+                position: idx
+            )
+        }
+
+        let payload = StaffTeamPayload(
+            name: trimmedName,
+            roleLabel: trimmedRole.isEmpty ? nil : trimmedRole,
+            notes: trimmedNotes.isEmpty ? nil : trimmedNotes,
+            members: memberPayloads
+        )
+
+        do {
+            let result: StaffTeam
+            if isEdit, let editId {
+                result = try await apiClient.updateStaffTeam(id: editId, payload: payload)
+            } else {
+                result = try await apiClient.createStaffTeam(payload)
+            }
+            HapticsHelper.play(.success)
+            isSaving = false
+            return result
+        } catch {
+            HapticsHelper.play(.error)
+            errorMessage = mapError(error)
+            isSaving = false
+            return nil
+        }
+    }
+
+    // MARK: - Error Mapping
+
+    private func mapError(_ error: Error) -> String {
+        if let apiError = error as? APIError {
+            return apiError.errorDescription ?? "Ocurrio un error inesperado."
+        }
+        return "Ocurrio un error inesperado. Intenta de nuevo."
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffTeamListViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffTeamListViewModel.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Observation
+import SolennixCore
+import SolennixNetwork
+
+// MARK: - Staff Team List View Model
+
+@Observable
+public final class StaffTeamListViewModel {
+
+    // MARK: - State
+
+    public var teams: [StaffTeam] = []
+    public var isLoading: Bool = false
+    public var errorMessage: String?
+    public var searchText: String = ""
+    public var deleteTarget: StaffTeam?
+    public var showDeleteConfirm: Bool = false
+
+    // MARK: - Dependencies
+
+    private let apiClient: APIClient
+
+    // MARK: - Init
+
+    public init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - Derived
+
+    public var filteredTeams: [StaffTeam] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return teams }
+        return teams.filter { team in
+            team.name.lowercased().contains(query)
+            || (team.roleLabel?.lowercased().contains(query) ?? false)
+        }
+    }
+
+    // MARK: - Load
+
+    @MainActor
+    public func load() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            teams = try await apiClient.listStaffTeams()
+        } catch {
+            errorMessage = mapError(error)
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Delete
+
+    @MainActor
+    public func deleteTeam(_ team: StaffTeam) async {
+        do {
+            try await apiClient.deleteStaffTeam(id: team.id)
+            teams.removeAll { $0.id == team.id }
+        } catch {
+            errorMessage = mapError(error)
+        }
+    }
+
+    // MARK: - Error Mapping
+
+    private func mapError(_ error: Error) -> String {
+        if let apiError = error as? APIError {
+            return apiError.errorDescription ?? "Ocurrio un error inesperado."
+        }
+        return "Ocurrio un error inesperado. Intenta de nuevo."
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffListView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffListView.swift
@@ -59,7 +59,7 @@ public struct StaffListView: View {
             }
             Button("Cancelar", role: .cancel) {}
         } message: { item in
-            Text("Se eliminara a \(item.name). Podras deshacer durante unos segundos.")
+            Text("Se eliminará a \(item.name). Podrás deshacer durante unos segundos.")
         }
         .task {
             await viewModel.loadStaff()
@@ -86,7 +86,7 @@ public struct StaffListView: View {
                 EmptyStateView(
                     icon: "person.3",
                     title: "Sin personal",
-                    message: "Agrega a tu primer colaborador para asignarlo a eventos",
+                    message: "Agregá a tu primer colaborador para asignarlo a eventos",
                     actionTitle: "Agregar Personal"
                 ) {
                     // FAB handles navigation; empty state CTA is visual only
@@ -95,7 +95,7 @@ public struct StaffListView: View {
                 EmptyStateView(
                     icon: "magnifyingglass",
                     title: "Sin resultados",
-                    message: "No se encontro personal que coincida con tu busqueda"
+                    message: "No se encontró personal que coincida con tu búsqueda"
                 )
             }
         } else {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffListView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffListView.swift
@@ -116,6 +116,39 @@ public struct StaffListView: View {
 
     private var staffGrid: some View {
         ScrollView {
+            NavigationLink(value: Route.staffTeamList) {
+                HStack(spacing: Spacing.md) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: CornerRadius.md)
+                            .fill(SolennixColors.primaryLight)
+                            .frame(width: 36, height: 36)
+                        Image(systemName: "person.3.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(SolennixColors.primary)
+                    }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Equipos")
+                            .font(.body)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(SolennixColors.text)
+                        Text("Armá cuadrillas para asignarlas de un toque")
+                            .font(.caption)
+                            .foregroundStyle(SolennixColors.textSecondary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textTertiary)
+                }
+                .padding(Spacing.md)
+                .background(SolennixColors.card)
+                .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+                .shadowSm()
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, Spacing.md)
+            .padding(.top, Spacing.sm)
+
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 300))], spacing: Spacing.sm) {
                 ForEach(viewModel.paginatedStaff) { item in
                     NavigationLink(value: Route.staffDetail(id: item.id)) {
@@ -183,6 +216,30 @@ public struct StaffListView: View {
 
     private var staffListCompact: some View {
         List {
+            Section {
+                NavigationLink(value: Route.staffTeamList) {
+                    HStack(spacing: Spacing.md) {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: CornerRadius.md)
+                                .fill(SolennixColors.primaryLight)
+                                .frame(width: 36, height: 36)
+                            Image(systemName: "person.3.fill")
+                                .font(.subheadline)
+                                .foregroundStyle(SolennixColors.primary)
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Equipos")
+                                .font(.body)
+                                .fontWeight(.semibold)
+                                .foregroundStyle(SolennixColors.text)
+                            Text("Armá cuadrillas para asignarlas de un toque")
+                                .font(.caption)
+                                .foregroundStyle(SolennixColors.textSecondary)
+                        }
+                    }
+                }
+            }
+
             ForEach(viewModel.paginatedStaff) { item in
                 NavigationLink(value: Route.staffDetail(id: item.id)) {
                     staffRow(item)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamDetailView.swift
@@ -67,7 +67,7 @@ public struct StaffTeamDetailView: View {
             }
             Button("Cancelar", role: .cancel) {}
         } message: {
-            Text("Se eliminara el equipo \(team?.name ?? ""). Los colaboradores individuales no se borran.")
+            Text("Se eliminará el equipo \(team?.name ?? ""). Los colaboradores individuales no se borran.")
         }
         .task { await loadData() }
     }
@@ -179,7 +179,7 @@ public struct StaffTeamDetailView: View {
             let sorted = (team.members ?? []).sorted { $0.position < $1.position }
 
             if sorted.isEmpty {
-                Text("Este equipo todavia no tiene miembros. Editalo para agregarlos.")
+                Text("Este equipo todavía no tiene miembros. Editalo para agregarlos.")
                     .font(.body)
                     .foregroundStyle(SolennixColors.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamDetailView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+import SolennixCore
+import SolennixDesign
+import SolennixNetwork
+
+// MARK: - Staff Team Detail View
+
+public struct StaffTeamDetailView: View {
+
+    let teamId: String
+
+    @State private var team: StaffTeam?
+    @State private var isLoading: Bool = true
+    @State private var errorMessage: String?
+    @State private var showDeleteConfirm: Bool = false
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    private let apiClient: APIClient
+
+    public init(teamId: String, apiClient: APIClient) {
+        self.teamId = teamId
+        self.apiClient = apiClient
+    }
+
+    public var body: some View {
+        Group {
+            if isLoading && team == nil {
+                ProgressView("Cargando equipo...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let team {
+                scrollContent(team)
+            } else {
+                EmptyStateView(
+                    icon: "exclamationmark.triangle",
+                    title: "Error",
+                    message: errorMessage ?? "No se pudo cargar el equipo"
+                )
+            }
+        }
+        .background(SolennixColors.surfaceGrouped)
+        .navigationTitle(team?.name ?? "Equipo")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if team != nil {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink(value: Route.staffTeamForm(id: teamId)) {
+                        Text("Editar")
+                            .foregroundStyle(SolennixColors.primary)
+                    }
+                }
+            }
+        }
+        .confirmationDialog(
+            "Eliminar equipo",
+            isPresented: $showDeleteConfirm
+        ) {
+            Button("Eliminar", role: .destructive) {
+                Task {
+                    do {
+                        try await apiClient.deleteStaffTeam(id: teamId)
+                        dismiss()
+                    } catch {
+                        errorMessage = "Error al eliminar el equipo"
+                    }
+                }
+            }
+            Button("Cancelar", role: .cancel) {}
+        } message: {
+            Text("Se eliminara el equipo \(team?.name ?? ""). Los colaboradores individuales no se borran.")
+        }
+        .task { await loadData() }
+    }
+
+    // MARK: - Scroll Content
+
+    private func scrollContent(_ team: StaffTeam) -> some View {
+        ScrollView {
+            VStack(spacing: Spacing.lg) {
+                headerCard(team)
+
+                if let notes = team.notes, !notes.isEmpty {
+                    notesCard(notes)
+                }
+
+                membersSection(team)
+
+                deleteButton
+            }
+            .padding(.horizontal, Spacing.md)
+            .padding(.vertical, Spacing.lg)
+        }
+        .refreshable { await loadData() }
+    }
+
+    // MARK: - Header
+
+    private func headerCard(_ team: StaffTeam) -> some View {
+        VStack(spacing: Spacing.md) {
+            ZStack {
+                RoundedRectangle(cornerRadius: CornerRadius.lg)
+                    .fill(SolennixColors.primaryLight)
+                    .frame(width: 72, height: 72)
+
+                Image(systemName: "person.3.fill")
+                    .font(.title)
+                    .foregroundStyle(SolennixColors.primary)
+            }
+
+            Text(team.name)
+                .font(.title2)
+                .fontWeight(.bold)
+                .foregroundStyle(SolennixColors.text)
+                .multilineTextAlignment(.center)
+
+            if let role = team.roleLabel, !role.isEmpty {
+                HStack(spacing: Spacing.xs) {
+                    Image(systemName: "briefcase.fill")
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.primary)
+                    Text(role)
+                        .font(.subheadline)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            }
+
+            let count = team.members?.count ?? team.memberCount ?? 0
+            HStack(spacing: Spacing.xs) {
+                Image(systemName: "person.2")
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textTertiary)
+                Text(count == 1 ? "1 miembro" : "\(count) miembros")
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textTertiary)
+            }
+        }
+        .padding(Spacing.lg)
+        .frame(maxWidth: .infinity)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.card))
+        .shadowSm()
+    }
+
+    // MARK: - Notes
+
+    private func notesCard(_ notes: String) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "note.text")
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.primary)
+                Text("Notas")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(SolennixColors.textSecondary)
+            }
+
+            Text(notes)
+                .font(.body)
+                .foregroundStyle(SolennixColors.text)
+        }
+        .padding(Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .shadowSm()
+    }
+
+    // MARK: - Members
+
+    private func membersSection(_ team: StaffTeam) -> some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Miembros")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(SolennixColors.textSecondary)
+                .padding(.horizontal, Spacing.sm)
+
+            let sorted = (team.members ?? []).sorted { $0.position < $1.position }
+
+            if sorted.isEmpty {
+                Text("Este equipo todavia no tiene miembros. Editalo para agregarlos.")
+                    .font(.body)
+                    .foregroundStyle(SolennixColors.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(Spacing.md)
+                    .background(SolennixColors.card)
+                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+            } else {
+                VStack(spacing: Spacing.xs) {
+                    ForEach(sorted) { member in
+                        memberRow(member)
+                    }
+                }
+            }
+        }
+    }
+
+    private func memberRow(_ member: StaffTeamMember) -> some View {
+        HStack(spacing: Spacing.md) {
+            Avatar(name: member.staffName ?? "?", photoURL: nil, size: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: Spacing.xs) {
+                    Text(member.staffName ?? "(sin nombre)")
+                        .font(.body)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(SolennixColors.text)
+
+                    if member.isLead {
+                        Image(systemName: "crown.fill")
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.primary)
+                            .accessibilityLabel("Lidera el equipo")
+                    }
+                }
+
+                if let role = member.staffRoleLabel, !role.isEmpty {
+                    Text(role)
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+
+                HStack(spacing: Spacing.sm) {
+                    if let phone = member.staffPhone, !phone.isEmpty {
+                        Text(phone)
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.textTertiary)
+                    }
+                    if let email = member.staffEmail, !email.isEmpty {
+                        Text(email)
+                            .font(.caption2)
+                            .foregroundStyle(SolennixColors.textTertiary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+
+            Spacer()
+
+            NavigationLink(value: Route.staffDetail(id: member.staffId)) {
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(SolennixColors.textTertiary)
+            }
+        }
+        .padding(Spacing.md)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+    }
+
+    // MARK: - Delete
+
+    private var deleteButton: some View {
+        Button {
+            showDeleteConfirm = true
+        } label: {
+            HStack(spacing: Spacing.sm) {
+                Image(systemName: "trash")
+                Text("Eliminar equipo")
+            }
+            .font(.subheadline)
+            .fontWeight(.medium)
+            .foregroundStyle(SolennixColors.error)
+            .frame(maxWidth: .infinity)
+            .padding(Spacing.md)
+            .background(SolennixColors.card)
+            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Load
+
+    @MainActor
+    private func loadData() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            team = try await apiClient.getStaffTeam(id: teamId)
+        } catch {
+            if let apiError = error as? APIError {
+                errorMessage = apiError.errorDescription
+            } else {
+                errorMessage = "Ocurrio un error inesperado."
+            }
+        }
+
+        isLoading = false
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Staff Team Detail") {
+    NavigationStack {
+        StaffTeamDetailView(teamId: "team-1", apiClient: APIClient())
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamFormView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamFormView.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+import SolennixCore
+import SolennixDesign
+import SolennixNetwork
+
+// MARK: - Staff Team Form View
+
+public struct StaffTeamFormView: View {
+
+    let teamId: String?
+
+    @State private var viewModel: StaffTeamFormViewModel
+    @State private var showMemberPicker: Bool = false
+    @Environment(\.dismiss) private var dismiss
+
+    public init(teamId: String? = nil, apiClient: APIClient) {
+        self.teamId = teamId
+        _viewModel = State(initialValue: StaffTeamFormViewModel(apiClient: apiClient))
+    }
+
+    public var body: some View {
+        Form {
+            infoSection
+            notesSection
+            membersSection
+        }
+        .scrollContentBackground(.hidden)
+        .background(SolennixColors.surfaceGrouped)
+        .navigationTitle(teamId != nil ? "Editar Equipo" : "Nuevo Equipo")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task {
+                        if await viewModel.save() != nil {
+                            dismiss()
+                        }
+                    }
+                } label: {
+                    if viewModel.isSaving {
+                        ProgressView()
+                    } else {
+                        Text("Guardar")
+                            .fontWeight(.semibold)
+                            .foregroundStyle(viewModel.isFormValid ? SolennixColors.primary : SolennixColors.textTertiary)
+                    }
+                }
+                .disabled(!viewModel.isFormValid || viewModel.isSaving)
+            }
+        }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView("Cargando...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(SolennixColors.background.opacity(0.6))
+            }
+        }
+        .alert("Error", isPresented: .init(
+            get: { viewModel.errorMessage != nil },
+            set: { if !$0 { viewModel.errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(viewModel.errorMessage ?? "")
+        }
+        .sheet(isPresented: $showMemberPicker) {
+            memberPickerSheet
+        }
+        .task {
+            await viewModel.loadCatalog()
+            if let id = teamId {
+                await viewModel.loadTeam(id: id)
+            }
+        }
+    }
+
+    // MARK: - Info
+
+    private var infoSection: some View {
+        Section("Informacion") {
+            SolennixTextField(
+                label: "Nombre",
+                text: $viewModel.name,
+                placeholder: "Ej: Cuadrilla de meseros A",
+                leftIcon: "person.3",
+                errorMessage: !viewModel.name.isEmpty && !viewModel.isNameValid
+                    ? "El nombre es obligatorio (max 255)" : nil,
+                autocapitalization: .sentences
+            )
+            .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
+
+            SolennixTextField(
+                label: "Rol del equipo (opcional)",
+                text: $viewModel.roleLabel,
+                placeholder: "Ej: Meseros, Fotografia",
+                leftIcon: "briefcase",
+                autocapitalization: .words
+            )
+            .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
+        }
+    }
+
+    // MARK: - Notes
+
+    private var notesSection: some View {
+        Section("Notas") {
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text("Notas internas")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .foregroundStyle(SolennixColors.text)
+
+                TextEditor(text: $viewModel.notes)
+                    .frame(minHeight: 80)
+                    .font(.body)
+                    .foregroundStyle(SolennixColors.text)
+                    .scrollContentBackground(.hidden)
+                    .padding(Spacing.sm)
+                    .background(SolennixColors.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: CornerRadius.md)
+                            .stroke(SolennixColors.border, lineWidth: 1)
+                    )
+            }
+            .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
+        }
+    }
+
+    // MARK: - Members
+
+    private var membersSection: some View {
+        Section {
+            ForEach(viewModel.members) { member in
+                memberRow(member)
+            }
+            .onMove { source, destination in
+                viewModel.moveMember(from: source, to: destination)
+            }
+            .onDelete { offsets in
+                viewModel.removeMember(at: offsets)
+            }
+
+            Button {
+                showMemberPicker = true
+            } label: {
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: "person.crop.circle.badge.plus")
+                        .foregroundStyle(SolennixColors.primary)
+                    Text("Agregar miembro")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundStyle(SolennixColors.primary)
+                    Spacer()
+                }
+            }
+            .buttonStyle(.plain)
+            .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
+        } header: {
+            HStack {
+                Text("Miembros")
+                Spacer()
+                if !viewModel.members.isEmpty {
+                    EditButton()
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.primary)
+                }
+            }
+        } footer: {
+            Text("Ordenalos como deberian aparecer al asignar el equipo a un evento. El lider se marca con la corona.")
+                .font(.caption)
+                .foregroundStyle(SolennixColors.textTertiary)
+        }
+    }
+
+    private func memberRow(_ member: StaffTeamMemberDraft) -> some View {
+        HStack(spacing: Spacing.md) {
+            Avatar(name: member.staffName, photoURL: nil, size: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(member.staffName)
+                    .font(.body)
+                    .fontWeight(.medium)
+                    .foregroundStyle(SolennixColors.text)
+
+                if let role = member.staffRoleLabel, !role.isEmpty {
+                    Text(role)
+                        .font(.caption)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            }
+
+            Spacer()
+
+            Button {
+                viewModel.toggleLead(for: member.staffId)
+                HapticsHelper.play(.success)
+            } label: {
+                Image(systemName: member.isLead ? "crown.fill" : "crown")
+                    .font(.body)
+                    .foregroundStyle(member.isLead ? SolennixColors.primary : SolennixColors.textTertiary)
+                    .accessibilityLabel(member.isLead ? "Quitar liderazgo" : "Marcar como lider")
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+
+    // MARK: - Member Picker Sheet
+
+    private var memberPickerSheet: some View {
+        NavigationStack {
+            Group {
+                if viewModel.staffCatalog.isEmpty {
+                    EmptyStateView(
+                        icon: "person.3",
+                        title: "Sin personal",
+                        message: "Agrega colaboradores en la seccion Personal antes de armar equipos"
+                    )
+                } else {
+                    MemberPickerList(
+                        catalog: viewModel.staffCatalog,
+                        alreadySelected: Set(viewModel.members.map { $0.staffId }),
+                        onSelect: { staff in
+                            viewModel.addMember(staff)
+                            showMemberPicker = false
+                        }
+                    )
+                }
+            }
+            .navigationTitle("Agregar miembro")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cerrar") { showMemberPicker = false }
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Member Picker List (sub-view con su propio search)
+
+private struct MemberPickerList: View {
+
+    let catalog: [Staff]
+    let alreadySelected: Set<String>
+    let onSelect: (Staff) -> Void
+
+    @State private var search: String = ""
+
+    var body: some View {
+        List {
+            ForEach(filtered) { item in
+                Button {
+                    onSelect(item)
+                } label: {
+                    HStack(spacing: Spacing.sm) {
+                        Avatar(name: item.name, photoURL: nil, size: 32)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.name)
+                                .font(.body)
+                                .foregroundStyle(SolennixColors.text)
+                            if let role = item.roleLabel, !role.isEmpty {
+                                Text(role)
+                                    .font(.caption)
+                                    .foregroundStyle(SolennixColors.textSecondary)
+                            }
+                        }
+
+                        Spacer()
+
+                        if alreadySelected.contains(item.id) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(SolennixColors.success)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .disabled(alreadySelected.contains(item.id))
+            }
+        }
+        .searchable(text: $search, prompt: "Buscar personal")
+    }
+
+    private var filtered: [Staff] {
+        let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return catalog }
+        return catalog.filter { s in
+            s.name.lowercased().contains(query)
+            || (s.roleLabel?.lowercased().contains(query) ?? false)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("New Team") {
+    NavigationStack {
+        StaffTeamFormView(apiClient: APIClient())
+    }
+}
+
+#Preview("Edit Team") {
+    NavigationStack {
+        StaffTeamFormView(teamId: "team-1", apiClient: APIClient())
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamListView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamListView.swift
@@ -41,7 +41,7 @@ public struct StaffTeamListView: View {
                 }
                 Button("Cancelar", role: .cancel) {}
             } message: { team in
-                Text("Se eliminara el equipo \(team.name). Los colaboradores individuales no se borran.")
+                Text("Se eliminará el equipo \(team.name). Los colaboradores individuales no se borran.")
             }
             .task {
                 await viewModel.load()
@@ -68,8 +68,8 @@ public struct StaffTeamListView: View {
             if viewModel.searchText.isEmpty {
                 EmptyStateView(
                     icon: "person.3.sequence",
-                    title: "Sin equipos todavia",
-                    message: "Agrupa a tu equipo de meseros o fotografos para asignarlos a un evento con un solo toque.",
+                    title: "Sin equipos todavía",
+                    message: "Agrupá a tu equipo de meseros o fotógrafos para asignarlos a un evento con un solo toque.",
                     actionTitle: "Crear equipo"
                 ) {
                     // El boton del toolbar navega — este CTA es visual.
@@ -78,7 +78,7 @@ public struct StaffTeamListView: View {
                 EmptyStateView(
                     icon: "magnifyingglass",
                     title: "Sin resultados",
-                    message: "No encontramos equipos que coincidan con tu busqueda"
+                    message: "No encontramos equipos que coincidan con tu búsqueda"
                 )
             }
         } else {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamListView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamListView.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+import SolennixCore
+import SolennixDesign
+import SolennixNetwork
+
+// MARK: - Staff Team List View
+
+public struct StaffTeamListView: View {
+
+    @State private var viewModel: StaffTeamListViewModel
+
+    public init(apiClient: APIClient) {
+        _viewModel = State(initialValue: StaffTeamListViewModel(apiClient: apiClient))
+    }
+
+    public var body: some View {
+        content
+            .background(SolennixColors.surfaceGrouped)
+            .navigationTitle("Equipos")
+            .navigationBarTitleDisplayMode(.large)
+            .searchable(text: $viewModel.searchText, prompt: "Buscar equipos")
+            .refreshable { await viewModel.load() }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink(value: Route.staffTeamForm()) {
+                        Image(systemName: "plus")
+                            .font(.body)
+                            .foregroundStyle(SolennixColors.primary)
+                            .accessibilityLabel("Crear equipo")
+                    }
+                }
+            }
+            .confirmationDialog(
+                "Eliminar equipo",
+                isPresented: $viewModel.showDeleteConfirm,
+                presenting: viewModel.deleteTarget
+            ) { team in
+                Button("Eliminar", role: .destructive) {
+                    HapticsHelper.play(.warning)
+                    Task { await viewModel.deleteTeam(team) }
+                }
+                Button("Cancelar", role: .cancel) {}
+            } message: { team in
+                Text("Se eliminara el equipo \(team.name). Los colaboradores individuales no se borran.")
+            }
+            .task {
+                await viewModel.load()
+            }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        if let error = viewModel.errorMessage, viewModel.teams.isEmpty, !viewModel.isLoading {
+            EmptyStateView(
+                icon: "wifi.exclamationmark",
+                title: "Error al cargar",
+                message: error,
+                actionTitle: "Reintentar"
+            ) {
+                Task { await viewModel.load() }
+            }
+        } else if viewModel.isLoading && viewModel.teams.isEmpty {
+            ProgressView("Cargando equipos...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.filteredTeams.isEmpty && !viewModel.isLoading {
+            if viewModel.searchText.isEmpty {
+                EmptyStateView(
+                    icon: "person.3.sequence",
+                    title: "Sin equipos todavia",
+                    message: "Agrupa a tu equipo de meseros o fotografos para asignarlos a un evento con un solo toque.",
+                    actionTitle: "Crear equipo"
+                ) {
+                    // El boton del toolbar navega — este CTA es visual.
+                }
+            } else {
+                EmptyStateView(
+                    icon: "magnifyingglass",
+                    title: "Sin resultados",
+                    message: "No encontramos equipos que coincidan con tu busqueda"
+                )
+            }
+        } else {
+            teamList
+        }
+    }
+
+    private var teamList: some View {
+        List {
+            ForEach(viewModel.filteredTeams) { team in
+                NavigationLink(value: Route.staffTeamDetail(id: team.id)) {
+                    teamRow(team)
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button(role: .destructive) {
+                        HapticsHelper.play(.warning)
+                        viewModel.deleteTarget = team
+                        viewModel.showDeleteConfirm = true
+                    } label: {
+                        Label("Eliminar", systemImage: "trash")
+                    }
+
+                    NavigationLink(value: Route.staffTeamForm(id: team.id)) {
+                        Label("Editar", systemImage: "pencil")
+                    }
+                    .tint(.blue)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(SolennixColors.surfaceGrouped)
+    }
+
+    // MARK: - Row
+
+    private func teamRow(_ team: StaffTeam) -> some View {
+        HStack(spacing: Spacing.md) {
+            ZStack {
+                RoundedRectangle(cornerRadius: CornerRadius.md)
+                    .fill(SolennixColors.primaryLight)
+                    .frame(width: 44, height: 44)
+
+                Image(systemName: "person.3.fill")
+                    .font(.body)
+                    .foregroundStyle(SolennixColors.primary)
+            }
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(team.name)
+                    .font(.body)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(SolennixColors.text)
+
+                HStack(spacing: Spacing.sm) {
+                    if let role = team.roleLabel, !role.isEmpty {
+                        HStack(spacing: 2) {
+                            Image(systemName: "briefcase")
+                                .font(.caption2)
+                            Text(role)
+                                .font(.caption)
+                        }
+                        .foregroundStyle(SolennixColors.textSecondary)
+                    }
+
+                    if let count = team.memberCount {
+                        HStack(spacing: 2) {
+                            Image(systemName: "person.2")
+                                .font(.caption2)
+                            Text(memberCountLabel(count))
+                                .font(.caption)
+                        }
+                        .foregroundStyle(SolennixColors.textTertiary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+
+    private func memberCountLabel(_ count: Int) -> String {
+        count == 1 ? "1 miembro" : "\(count) miembros"
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Staff Team List") {
+    NavigationStack {
+        StaffTeamListView(apiClient: APIClient())
+    }
+}

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/APIClient+StaffTeams.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/APIClient+StaffTeams.swift
@@ -1,0 +1,66 @@
+import Foundation
+import SolennixCore
+
+// MARK: - Staff Teams
+
+/// Payload helpers para crear/actualizar cuadrillas. El backend espera
+/// `members[]` como array de `{ staff_id, is_lead, position }` — el resto
+/// de campos joineados (staff_name, staff_phone, etc.) se ignoran en el
+/// write path.
+public struct StaffTeamMemberPayload: Codable, Sendable, Hashable {
+    public let staffId: String
+    public let isLead: Bool
+    public let position: Int
+
+    public init(staffId: String, isLead: Bool = false, position: Int = 0) {
+        self.staffId = staffId
+        self.isLead = isLead
+        self.position = position
+    }
+}
+
+public struct StaffTeamPayload: Codable, Sendable {
+    public let name: String
+    public let roleLabel: String?
+    public let notes: String?
+    public let members: [StaffTeamMemberPayload]
+
+    public init(
+        name: String,
+        roleLabel: String? = nil,
+        notes: String? = nil,
+        members: [StaffTeamMemberPayload] = []
+    ) {
+        self.name = name
+        self.roleLabel = roleLabel
+        self.notes = notes
+        self.members = members
+    }
+}
+
+public extension APIClient {
+
+    /// Listado liviano — trae `memberCount` pero NO `members[]`.
+    func listStaffTeams() async throws -> [StaffTeam] {
+        try await getAll(Endpoint.staffTeams)
+    }
+
+    /// Detalle completo — trae `members[]` con staff joineado.
+    func getStaffTeam(id: String) async throws -> StaffTeam {
+        try await get(Endpoint.staffTeam(id))
+    }
+
+    func createStaffTeam(_ payload: StaffTeamPayload) async throws -> StaffTeam {
+        try await post(Endpoint.staffTeams, body: payload)
+    }
+
+    /// Reemplaza meta + members atomicamente. El backend espera el id en la
+    /// URL — el payload solo lleva los campos editables.
+    func updateStaffTeam(id: String, payload: StaffTeamPayload) async throws -> StaffTeam {
+        try await put(Endpoint.staffTeam(id), body: payload)
+    }
+
+    func deleteStaffTeam(id: String) async throws {
+        try await delete(Endpoint.staffTeam(id))
+    }
+}

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
@@ -81,6 +81,14 @@ public enum Endpoint {
     /// `?start=YYYY-MM-DD&end=YYYY-MM-DD`.
     public static let staffAvailability = "/staff/availability"
 
+    // MARK: - Staff Teams (Cuadrillas)
+
+    public static let staffTeams = "/staff/teams"
+
+    public static func staffTeam(_ id: String) -> String {
+        "/staff/teams/\(id)"
+    }
+
     // MARK: - Products
 
     public static let products = "/products"

--- a/ios/Solennix/Navigation/RouteDestination.swift
+++ b/ios/Solennix/Navigation/RouteDestination.swift
@@ -62,6 +62,14 @@ struct RouteDestination: View {
         case .staffForm(let id):
             StaffFormView(staffId: id, apiClient: apiClient)
 
+        // Staff Teams (Cuadrillas)
+        case .staffTeamList:
+            StaffTeamListView(apiClient: apiClient)
+        case .staffTeamDetail(let id):
+            StaffTeamDetailView(teamId: id, apiClient: apiClient)
+        case .staffTeamForm(let id):
+            StaffTeamFormView(teamId: id, apiClient: apiClient)
+
         // Products
         case .productList:
             ProductListView(apiClient: apiClient)

--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -998,9 +998,15 @@ Visualización + registro de pago por transferencia con approve/reject. Reemplaz
 - **Disponibilidad:** endpoint `GET /api/staff/availability?date=YYYY-MM-DD` (o rango con `start`/`end`). Devuelve solo staff con asignaciones en la ventana (ausencia = libre). Se consume dentro del Step 4 del EventForm — indicador "Ocupado ese día" al lado del nombre en el selector. **Sin pantalla nueva.**
 - **UPSERT resiliente:** el patrón de `notification_sent_at` (preservar en re-save) se extiende a `status` vía `COALESCE($status, event_staff.status)` — clientes viejos que no envían `status` en el payload NO sobreescriben el RSVP actual. Ver [backend/internal/repository/event_repo.go](../../backend/internal/repository/event_repo.go) método `UpdateEventItems`.
 
+**Ola 2 — Equipos (shipped 2026-04-19):**
+- **Tablas (migration 044):** `staff_teams` (id, user_id, name, role_label, notes, timestamps) + `staff_team_members` (team_id, staff_id, is_lead BOOL, position INT) con PK compuesta. Cascade por FK a ambos lados.
+- **Endpoints CRUD:** `GET/POST /api/staff/teams`, `GET/PUT/DELETE /api/staff/teams/{id}`. Update reemplaza miembros atómicamente (no hay estado por miembro que preservar). Validación de tenant: cada `staff_id` debe pertenecer al mismo user antes de insertar.
+- **UI (iOS · Android · Web):** Entrada "Equipos" dentro de la lista de Personal (NO un tab nuevo). CRUD completo con nombre, rol default, notas + selector de miembros multi-select desde el catálogo existente. Miembro con `is_lead = true` muestra badge (corona).
+- **Asignación al evento:** nuevo botón "Agregar equipo completo" en Step 4 del EventForm. Expande los miembros del equipo a N filas en `event_staff` reusando el UPSERT de Ola 1 — no hay endpoint nuevo. Miembros ya asignados se saltean. El usuario puede editar fee/turno/estado por fila después de expandir.
+- **Sin plan gating:** disponible para todos los planes (igual que Ola 1).
+
 **Roadmap siguiente (no implementado):**
-- **Ola 2 — Equipos:** tabla `staff_teams` + `staff_team_members` para asignar cuadrillas en bloque (un equipo de N meseros). Team lead como badge visual, no rol técnico.
-- **Ola 3 — Staff como servicio vendible:** `Product.staff_team_id` opcional para cobrar al cliente con markup vs. costo interno. Reutiliza Products/Quotes (no un tercer tipo de item).
+- **Ola 3 — Staff como servicio vendible:** `Product.staff_team_id` opcional para cobrar al cliente con markup vs. costo interno. Reutiliza Products/Quotes (no un tercer tipo de item). Requiere decisiones de negocio: cómo se congela el team al agregar al Quote, cómo se muestra el margen (price − sum(fees)), qué pasa al editar el team tras asignarlo.
 - **Phase 3:** login del colaborador vía `invited_user_id` — intacto como estaba planeado.
 
 **Navegación:**

--- a/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
+++ b/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
@@ -17,6 +17,17 @@ status: active
 **Fecha:** Abril 2026
 **Version:** 1.2
 
+> [!info] 2026-04-19 — Personal Ola 2: equipos (staff_teams + staff_team_members) para asignar cuadrillas en bloque
+> Segunda ola de expansión de Personal (después de Ola 1 del mismo día). Motivación: sin equipos, el mismo organizador que tiene una plantilla recurrente de 10 meseros tiene que agregarlos uno por uno a cada evento. Con Ola 2 los agrupa una vez y los asigna a un evento con un solo toque. Escala el modelo a empresas de catering sin cambiar el flujo base de Staff catalog.
+> - **Backend (migration 044)**: `staff_teams` (user_id, name, role_label, notes, timestamps) + `staff_team_members` (team_id, staff_id, is_lead, position) con PK compuesta. Cascade a ambos lados; miembros sin fee/status (esos siguen viviendo per-assignment en `event_staff`, así un equipo puede asignarse a varios eventos con distintos costos/RSVPs).
+> - **Repo `StaffTeamRepo`**: GetAll con `member_count` barato (sub-SELECT COUNT) para la lista; GetByID con miembros joined con staff name/role/phone/email; Create/Update/Delete transaccionales; Update reemplaza miembros atómicamente (no hay estado por miembro que preservar). Validación de tenant antes de insertar cada miembro.
+> - **Endpoints** bajo `/api/staff/teams`: `GET`, `POST`, `GET/{id}`, `PUT/{id}`, `DELETE/{id}`. Integrado como subprefijo estático del `/api/staff` existente — chi resuelve "teams" antes de `/{id}`.
+> - **iOS / Android / Web**: CRUD de equipos con pantalla propia accesible desde la lista de Personal (sin tab nuevo). Miembros se eligen desde el catálogo existente con toggle `is_lead` por fila. Badge de corona para el team lead.
+> - **Integración con EventForm**: botón "Agregar equipo completo" en el Step 4 del formulario. Expande los miembros a N filas en `event_staff` usando el mismo UPSERT de Ola 1 — no hay endpoint nuevo. Miembros ya asignados se saltean (sin duplicados). Después de expandir, fee/turno/estado son editables por fila.
+> - **Sin gating de plan** en esta ola (todos los planes).
+> - **Decisiones clave**: team no guarda fee ni status (esos viven per-assignment); miembros upsert via DELETE + INSERT en transacción (no hay estado a preservar). Validación de tenant por miembro evita que un cliente malicioso adjunte staff de otro user.
+> - **Ola 3 (no incluida)**: `Product.staff_team_id` para vender staffing al cliente con markup — requiere decisiones de producto abiertas (snapshot vs dynamic team, cálculo de margen visible).
+
 > [!info] 2026-04-19 — Personal Ola 1: turnos + estado RSVP + disponibilidad (paridad iOS · Android · Web · Backend)
 > Feature Personal (shipped 2026-04-16 como catálogo plano + costo por evento) expandida con la capa operativa. Motivación del usuario: escalar el uso para equipos de meseros / empresas de catering, sin cerrar la puerta a que el mismo modelo sirva al organizador con plantilla propia. Phase 3 (login del colaborador) se mantiene intacto como roadmap futuro.
 > - **Backend (migration 043)**: `event_staff` recibe `shift_start`, `shift_end` (TIMESTAMPTZ nullables — pueden cruzar medianoche) y `status` (enum `pending | confirmed | declined | cancelled`, default `confirmed`). Constraint `shift_end > shift_start`. Todo aditivo — filas existentes siguen válidas.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,9 @@ const ClientDetails = React.lazy(() => import("@/pages/Clients/ClientDetails").t
 const StaffList = React.lazy(() => import("@/pages/Staff/StaffList").then((m) => ({ default: m.StaffList })));
 const StaffForm = React.lazy(() => import("@/pages/Staff/StaffForm").then((m) => ({ default: m.StaffForm })));
 const StaffDetails = React.lazy(() => import("@/pages/Staff/StaffDetails").then((m) => ({ default: m.StaffDetails })));
+const StaffTeamList = React.lazy(() => import("@/pages/Staff/Teams/StaffTeamList").then((m) => ({ default: m.StaffTeamList })));
+const StaffTeamForm = React.lazy(() => import("@/pages/Staff/Teams/StaffTeamForm").then((m) => ({ default: m.StaffTeamForm })));
+const StaffTeamDetails = React.lazy(() => import("@/pages/Staff/Teams/StaffTeamDetails").then((m) => ({ default: m.StaffTeamDetails })));
 
 const ProductList = React.lazy(() => import("@/pages/Products/ProductList").then((m) => ({ default: m.ProductList })));
 const ProductForm = React.lazy(() => import("@/pages/Products/ProductForm").then((m) => ({ default: m.ProductForm })));
@@ -110,6 +113,10 @@ function App() {
                 <Route path="/clients/:id" element={<ClientDetails />} />
                 <Route path="/clients/:id/edit" element={<ClientForm />} />
                 <Route path="/staff" element={<StaffList />} />
+                <Route path="/staff/teams" element={<StaffTeamList />} />
+                <Route path="/staff/teams/new" element={<StaffTeamForm />} />
+                <Route path="/staff/teams/:id" element={<StaffTeamDetails />} />
+                <Route path="/staff/teams/:id/edit" element={<StaffTeamForm />} />
                 <Route path="/staff/new" element={<StaffForm />} />
                 <Route path="/staff/:id" element={<StaffDetails />} />
                 <Route path="/staff/:id/edit" element={<StaffForm />} />

--- a/web/src/hooks/queries/queryKeys.ts
+++ b/web/src/hooks/queries/queryKeys.ts
@@ -44,6 +44,9 @@ export const queryKeys = {
     detail: (id: string) => ['staff', id] as const,
     availability: (date: string) => ['staff', 'availability', date] as const,
     assignments: (staffId: string) => ['staff', staffId, 'assignments'] as const,
+    // Ola 2 — staff teams (cuadrillas).
+    teams: ['staff', 'teams'] as const,
+    team: (id: string) => ['staff', 'teams', id] as const,
   },
   payments: {
     byEvent: (eventId: string) => ['payments', 'event', eventId] as const,

--- a/web/src/hooks/queries/useStaffQueries.ts
+++ b/web/src/hooks/queries/useStaffQueries.ts
@@ -3,7 +3,13 @@ import { staffService } from '@/services/staffService';
 import { queryKeys } from './queryKeys';
 import { useToast } from '@/hooks/useToast';
 import { logError, getErrorMessage } from '@/lib/errorHandler';
-import type { PaginationParams, StaffInsert, StaffUpdate } from '@/types/entities';
+import type {
+  PaginationParams,
+  StaffInsert,
+  StaffTeamInsert,
+  StaffTeamUpdate,
+  StaffUpdate,
+} from '@/types/entities';
 
 // ── Queries ──
 
@@ -112,6 +118,77 @@ export function useDeleteStaff() {
     onError: (error) => {
       logError('Error deleting staff', error);
       addToast(getErrorMessage(error, 'Error al eliminar el colaborador.'), 'error');
+    },
+  });
+}
+
+// ── Staff Teams (Ola 2) ──
+
+export function useStaffTeams() {
+  return useQuery({
+    queryKey: queryKeys.staff.teams,
+    queryFn: () => staffService.listTeams(),
+  });
+}
+
+export function useStaffTeam(id: string | undefined) {
+  return useQuery({
+    queryKey: queryKeys.staff.team(id!),
+    queryFn: () => staffService.getTeam(id!),
+    enabled: !!id,
+  });
+}
+
+export function useCreateStaffTeam() {
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
+
+  return useMutation({
+    mutationKey: ['staff', 'teams', 'create'],
+    mutationFn: (data: StaffTeamInsert) => staffService.createTeam(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.staff.teams });
+    },
+    onError: (error) => {
+      logError('Error creating staff team', error);
+      addToast(getErrorMessage(error, 'Error al crear el equipo.'), 'error');
+    },
+  });
+}
+
+export function useUpdateStaffTeam() {
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
+
+  return useMutation({
+    mutationKey: ['staff', 'teams', 'update'],
+    mutationFn: ({ id, data }: { id: string; data: StaffTeamUpdate }) =>
+      staffService.updateTeam(id, data),
+    onSuccess: (_result, { id }) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.staff.teams });
+      queryClient.invalidateQueries({ queryKey: queryKeys.staff.team(id) });
+    },
+    onError: (error) => {
+      logError('Error updating staff team', error);
+      addToast(getErrorMessage(error, 'Error al actualizar el equipo.'), 'error');
+    },
+  });
+}
+
+export function useDeleteStaffTeam() {
+  const queryClient = useQueryClient();
+  const { addToast } = useToast();
+
+  return useMutation({
+    mutationKey: ['staff', 'teams', 'delete'],
+    mutationFn: (id: string) => staffService.deleteTeam(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.staff.teams });
+      addToast('Equipo eliminado correctamente.', 'success');
+    },
+    onError: (error) => {
+      logError('Error deleting staff team', error);
+      addToast(getErrorMessage(error, 'Error al eliminar el equipo.'), 'error');
     },
   });
 }

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -727,6 +727,16 @@ export const EventForm: React.FC = () => {
     setSelectedStaff((prev) => prev.filter((_, i) => i !== index));
   };
 
+  // Ola 2 — expandir un equipo en filas, deduplicando contra los ya presentes.
+  const handleAddTeamMembers = (rows: SelectedStaffAssignment[]) => {
+    setSelectedStaff((prev) => {
+      const existing = new Set(prev.map((r) => r.staff_id).filter(Boolean));
+      const toAdd = rows.filter((r) => r.staff_id && !existing.has(r.staff_id));
+      if (toAdd.length === 0) return prev;
+      return [...prev, ...toAdd];
+    });
+  };
+
   const handleStaffChange = (
     index: number,
     field: keyof SelectedStaffAssignment,
@@ -1230,6 +1240,7 @@ export const EventForm: React.FC = () => {
                     onAdd={handleAddStaff}
                     onRemove={handleRemoveStaff}
                     onChange={handleStaffChange}
+                    onAddTeamMembers={handleAddTeamMembers}
                   />
                 </div>
               )}

--- a/web/src/pages/Events/components/EventStaff.tsx
+++ b/web/src/pages/Events/components/EventStaff.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Clock, Crown, Plus, Trash2, UserCog, Users } from 'lucide-react';
 import type { AssignmentStatus, Staff } from '../../../types/entities';
 import { useStaffAvailability, useStaffTeams } from '@/hooks/queries/useStaffQueries';
@@ -329,12 +330,13 @@ export const EventStaff: React.FC<EventStaffProps> = ({
         ) : teams.length === 0 ? (
           <div className="text-sm text-text-secondary space-y-2">
             <p>Sin equipos todavía.</p>
-            <a
-              href="/staff/teams/new"
+            <Link
+              to="/staff/teams/new"
+              onClick={() => setTeamPickerOpen(false)}
               className="inline-flex items-center gap-1 text-primary hover:underline"
             >
               <Plus className="h-4 w-4" aria-hidden="true" /> Agregá tu primera cuadrilla
-            </a>
+            </Link>
           </div>
         ) : (
           <ul className="divide-y divide-border max-h-96 overflow-y-auto">

--- a/web/src/pages/Events/components/EventStaff.tsx
+++ b/web/src/pages/Events/components/EventStaff.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react';
-import { Clock, Plus, Trash2, UserCog } from 'lucide-react';
+import { Clock, Crown, Plus, Trash2, UserCog, Users } from 'lucide-react';
 import type { AssignmentStatus, Staff } from '../../../types/entities';
-import { useStaffAvailability } from '@/hooks/queries/useStaffQueries';
+import { useStaffAvailability, useStaffTeams } from '@/hooks/queries/useStaffQueries';
+import { Modal } from '@/components/Modal';
 
 // Shape tracked in EventForm state — matches EventStaffAssignment but with
 // a deterministic row id so the list can be edited before the event has an
@@ -30,6 +31,10 @@ interface EventStaffProps {
   onAdd: () => void;
   onRemove: (index: number) => void;
   onChange: (index: number, field: keyof SelectedStaffAssignment, value: StaffFieldValue) => void;
+  // Ola 2 — block-add members de un equipo al form. Las filas expandidas
+  // respetan los fee/shift/status defaults (la UI ya se pueden editar fila a
+  // fila). El padre maneja la dedupe y el role_override del team.
+  onAddTeamMembers?: (rows: SelectedStaffAssignment[]) => void;
 }
 
 const STATUS_OPTIONS: { value: AssignmentStatus; label: string }[] = [
@@ -47,8 +52,51 @@ export const EventStaff: React.FC<EventStaffProps> = ({
   onAdd,
   onRemove,
   onChange,
+  onAddTeamMembers,
 }) => {
   const emptyCatalog = staffCatalog.length === 0;
+  const [teamPickerOpen, setTeamPickerOpen] = useState(false);
+  const { data: teams = [], isLoading: loadingTeams } = useStaffTeams();
+
+  const handlePickTeam = async (teamId: string) => {
+    if (!onAddTeamMembers) return;
+    // Evitamos el fetch por-id desde acá para no dependency-injectar un hook
+    // dinámico. Usamos el ListTeams (member_count) solo para el menú; al
+    // seleccionar delegamos el fetch-and-expand al padre vía callback con
+    // el id, pero por simplicidad buscamos miembros con un extra fetch en
+    // el padre. Para mantener este componente self-contained: resolvemos
+    // via fetch directo al service.
+    const { staffService } = await import('@/services/staffService');
+    try {
+      const team = await staffService.getTeam(teamId);
+      const members = [...(team.members ?? [])].sort((a, b) => a.position - b.position);
+      const existingIds = new Set(selectedStaff.map((s) => s.staff_id).filter(Boolean));
+      const rows: SelectedStaffAssignment[] = [];
+      for (const m of members) {
+        if (existingIds.has(m.staff_id)) continue;
+        const staff = staffCatalog.find((s) => s.id === m.staff_id);
+        // Si el staff del equipo no está en el catálogo local (p.ej. filtro),
+        // igual lo agregamos por id — el backend valida en el upsert.
+        const staffRole = staff?.role_label ?? null;
+        const teamRole = team.role_label ?? null;
+        const roleOverride = staffRole ? '' : teamRole ?? '';
+        rows.push({
+          staff_id: m.staff_id,
+          fee_amount: null,
+          role_override: roleOverride,
+          notes: '',
+          shift_start: null,
+          shift_end: null,
+          status: null,
+        });
+      }
+      if (rows.length > 0) onAddTeamMembers(rows);
+      setTeamPickerOpen(false);
+    } catch {
+      // El service/api ya muestra toasts globales para errores HTTP.
+      setTeamPickerOpen(false);
+    }
+  };
 
   // Availability — solo pedimos si tenemos fecha. El hook se skipea en caso contrario.
   const { data: availability = [] } = useStaffAvailability(eventDate || null);
@@ -247,16 +295,80 @@ export const EventStaff: React.FC<EventStaffProps> = ({
             );
           })}
 
-          <button
-            type="button"
-            onClick={onAdd}
-            className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-primary bg-primary/10 rounded-lg hover:bg-primary/20 transition-colors"
-          >
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Agregar colaborador
-          </button>
+          <div className="flex items-center gap-2 flex-wrap">
+            <button
+              type="button"
+              onClick={onAdd}
+              className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-primary bg-primary/10 rounded-lg hover:bg-primary/20 transition-colors"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Agregar colaborador
+            </button>
+            {onAddTeamMembers && (
+              <button
+                type="button"
+                onClick={() => setTeamPickerOpen(true)}
+                className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-text bg-surface-alt hover:bg-card border border-border rounded-lg transition-colors"
+              >
+                <Users className="h-4 w-4" aria-hidden="true" />
+                Agregar equipo completo
+              </button>
+            )}
+          </div>
         </>
       )}
+
+      <Modal
+        isOpen={teamPickerOpen}
+        onClose={() => setTeamPickerOpen(false)}
+        title="Seleccioná un equipo"
+        maxWidth="lg"
+      >
+        {loadingTeams ? (
+          <p className="text-sm text-text-secondary">Cargando equipos…</p>
+        ) : teams.length === 0 ? (
+          <div className="text-sm text-text-secondary space-y-2">
+            <p>Sin equipos todavía.</p>
+            <a
+              href="/staff/teams/new"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" /> Agregá tu primera cuadrilla
+            </a>
+          </div>
+        ) : (
+          <ul className="divide-y divide-border max-h-96 overflow-y-auto">
+            {teams.map((t) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  onClick={() => handlePickTeam(t.id)}
+                  className="w-full flex items-start justify-between gap-3 py-3 px-1 hover:bg-surface-alt/60 transition-colors text-left"
+                >
+                  <div className="min-w-0 flex items-start gap-3">
+                    <div
+                      className="h-9 w-9 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center text-primary shrink-0"
+                      aria-hidden="true"
+                    >
+                      <Users className="h-4 w-4" />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-text truncate">{t.name}</div>
+                      {t.role_label && (
+                        <div className="text-xs text-text-secondary truncate">{t.role_label}</div>
+                      )}
+                    </div>
+                  </div>
+                  <span className="shrink-0 inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-accent/10 text-accent dark:bg-accent/20">
+                    <Crown className="h-3 w-3" aria-hidden="true" />
+                    {t.member_count ?? 0}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Modal>
     </div>
   );
 };

--- a/web/src/pages/Staff/StaffList.tsx
+++ b/web/src/pages/Staff/StaffList.tsx
@@ -9,6 +9,7 @@ import {
   Mail,
   UserCog,
   Eye,
+  Users,
 } from "lucide-react";
 import { RowActionMenu } from "@/components/RowActionMenu";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
@@ -99,13 +100,22 @@ export const StaffList: React.FC = () => {
             Tu agenda de colaboradores: fotógrafos, DJs, meseros, coordinadores.
           </p>
         </div>
-        <Link
-          to="/staff/new"
-          className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold rounded-xl text-white premium-gradient shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30 transition-all hover:scale-[1.02]"
-        >
-          <Plus className="h-5 w-5 mr-2" aria-hidden="true" />
-          Nuevo colaborador
-        </Link>
+        <div className="flex items-center gap-2 flex-wrap">
+          <Link
+            to="/staff/teams"
+            className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-xl text-text bg-surface-alt hover:bg-card border border-border transition-colors"
+          >
+            <Users className="h-4 w-4 mr-2" aria-hidden="true" />
+            Equipos
+          </Link>
+          <Link
+            to="/staff/new"
+            className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold rounded-xl text-white premium-gradient shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30 transition-all hover:scale-[1.02]"
+          >
+            <Plus className="h-5 w-5 mr-2" aria-hidden="true" />
+            Nuevo colaborador
+          </Link>
+        </div>
       </div>
 
       <div className="relative max-w-md">

--- a/web/src/pages/Staff/Teams/StaffTeamDetails.tsx
+++ b/web/src/pages/Staff/Teams/StaffTeamDetails.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Crown, Edit, Mail, Phone, Trash2, UserCog, Users } from "lucide-react";
+import {
+  useDeleteStaffTeam,
+  useStaffTeam,
+} from "@/hooks/queries/useStaffQueries";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+
+export const StaffTeamDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: team, isLoading } = useStaffTeam(id);
+  const deleteMut = useDeleteStaffTeam();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  if (isLoading) return <div className="text-text-secondary">Cargando…</div>;
+  if (!team) {
+    return (
+      <div className="bg-card border border-border rounded-2xl p-6 text-text-secondary">
+        Equipo no encontrado.{" "}
+        <Link to="/staff/teams" className="text-primary hover:underline">
+          Volver al listado
+        </Link>
+        .
+      </div>
+    );
+  }
+
+  const members = [...(team.members ?? [])].sort((a, b) => a.position - b.position);
+
+  const onDelete = async () => {
+    setConfirmOpen(false);
+    await deleteMut.mutateAsync(team.id);
+    navigate("/staff/teams");
+  };
+
+  return (
+    <div className="space-y-6">
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Eliminar equipo"
+        description={`${team.name} se eliminará. Los colaboradores del equipo siguen en tu catálogo.`}
+        confirmText="Eliminar permanentemente"
+        cancelText="Cancelar"
+        onConfirm={onDelete}
+        onCancel={() => setConfirmOpen(false)}
+      />
+
+      <Link
+        to="/staff/teams"
+        className="inline-flex items-center text-sm text-primary hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" aria-hidden="true" /> Volver a Equipos
+      </Link>
+
+      <div className="bg-card border border-border rounded-2xl shadow-sm p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <div className="h-14 w-14 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center text-primary">
+              <Users className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-text tracking-tight">{team.name}</h1>
+              {team.role_label && (
+                <div className="text-sm text-text-secondary flex items-center gap-1 mt-1">
+                  <UserCog className="h-4 w-4" aria-hidden="true" />
+                  {team.role_label}
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              to={`/staff/teams/${team.id}/edit`}
+              className="inline-flex items-center justify-center px-3 py-2 text-sm font-medium rounded-xl text-text bg-surface-alt hover:bg-card border border-border transition-colors"
+            >
+              <Edit className="h-4 w-4 mr-2" aria-hidden="true" /> Editar
+            </Link>
+            <button
+              type="button"
+              onClick={() => setConfirmOpen(true)}
+              className="inline-flex items-center justify-center px-3 py-2 text-sm font-medium rounded-xl text-danger bg-danger/10 hover:bg-danger/20 border border-danger/20 transition-colors"
+            >
+              <Trash2 className="h-4 w-4 mr-2" aria-hidden="true" /> Eliminar
+            </button>
+          </div>
+        </div>
+
+        {team.notes && (
+          <div className="mt-6">
+            <dt className="text-xs font-semibold text-text-secondary uppercase tracking-wide">Notas</dt>
+            <dd className="mt-1 text-sm text-text whitespace-pre-wrap">{team.notes}</dd>
+          </div>
+        )}
+      </div>
+
+      <div className="bg-card border border-border rounded-2xl shadow-sm p-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Users className="h-5 w-5 text-primary" aria-hidden="true" />
+          <h2 className="text-lg font-semibold text-text">Miembros</h2>
+          <span className="ml-2 text-xs text-text-secondary">({members.length})</span>
+        </div>
+
+        {members.length === 0 ? (
+          <p className="text-sm text-text-secondary">
+            Este equipo no tiene miembros todavía. Editalo para agregarlos.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {members.map((m) => (
+              <li key={m.staff_id} className="py-3 flex items-start justify-between gap-4">
+                <div className="min-w-0 flex items-start gap-3">
+                  <div
+                    className="h-9 w-9 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center text-primary font-bold text-sm shrink-0"
+                    aria-hidden="true"
+                  >
+                    {(m.staff_name ?? "?").charAt(0).toUpperCase()}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-medium text-text truncate">
+                        {m.staff_name ?? "Colaborador"}
+                      </span>
+                      {m.is_lead && (
+                        <span
+                          className="inline-flex items-center gap-1 text-[11px] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary"
+                          title="Lidera el equipo"
+                        >
+                          <Crown className="h-3 w-3" aria-hidden="true" />
+                          Lidera el equipo
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-text-secondary mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5">
+                      {m.staff_role_label && <span>{m.staff_role_label}</span>}
+                      {m.staff_phone && (
+                        <span className="inline-flex items-center gap-1">
+                          <Phone className="h-3 w-3" aria-hidden="true" />
+                          {m.staff_phone}
+                        </span>
+                      )}
+                      {m.staff_email && (
+                        <span className="inline-flex items-center gap-1">
+                          <Mail className="h-3 w-3" aria-hidden="true" />
+                          {m.staff_email}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <Link
+                  to={`/staff/${m.staff_id}`}
+                  className="text-xs text-primary hover:underline shrink-0"
+                >
+                  Ver perfil
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/web/src/pages/Staff/Teams/StaffTeamForm.tsx
+++ b/web/src/pages/Staff/Teams/StaffTeamForm.tsx
@@ -1,0 +1,373 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ArrowLeft, ChevronDown, ChevronUp, Crown, Save, Search, Users, X } from "lucide-react";
+import {
+  useCreateStaffTeam,
+  useStaff,
+  useStaffTeam,
+  useUpdateStaffTeam,
+} from "@/hooks/queries/useStaffQueries";
+import { useToast } from "@/hooks/useToast";
+import type { StaffTeamInsert, StaffTeamMemberInput } from "@/types/entities";
+
+const schema = z.object({
+  name: z.string().trim().min(1, "El nombre es obligatorio.").max(255, "Máximo 255 caracteres."),
+  role_label: z
+    .string()
+    .trim()
+    .max(255, "Máximo 255 caracteres.")
+    .optional()
+    .or(z.literal("")),
+  notes: z
+    .string()
+    .trim()
+    .max(5000, "Máximo 5000 caracteres.")
+    .optional()
+    .or(z.literal("")),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+// Estado interno de cada miembro mientras editamos. position se persiste en
+// el submit a partir del orden del array — no se muestra en UI.
+interface MemberDraft {
+  staff_id: string;
+  is_lead: boolean;
+}
+
+export const StaffTeamForm: React.FC = () => {
+  const { id } = useParams<{ id?: string }>();
+  const isEdit = !!id;
+  const navigate = useNavigate();
+  const { addToast } = useToast();
+
+  const { data: existing, isLoading: loadingTeam } = useStaffTeam(isEdit ? id : undefined);
+  const { data: staffCatalog = [], isLoading: loadingStaff } = useStaff();
+  const createMut = useCreateStaffTeam();
+  const updateMut = useUpdateStaffTeam();
+
+  const [members, setMembers] = useState<MemberDraft[]>([]);
+  const [search, setSearch] = useState("");
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: "", role_label: "", notes: "" },
+  });
+
+  useEffect(() => {
+    if (existing) {
+      reset({
+        name: existing.name,
+        role_label: existing.role_label ?? "",
+        notes: existing.notes ?? "",
+      });
+      const sorted = [...(existing.members ?? [])].sort((a, b) => a.position - b.position);
+      setMembers(sorted.map((m) => ({ staff_id: m.staff_id, is_lead: m.is_lead })));
+    }
+  }, [existing, reset]);
+
+  const selectedIds = useMemo(() => new Set(members.map((m) => m.staff_id)), [members]);
+
+  const staffById = useMemo(() => {
+    const map = new Map<string, (typeof staffCatalog)[number]>();
+    for (const s of staffCatalog) map.set(s.id, s);
+    return map;
+  }, [staffCatalog]);
+
+  const filteredCatalog = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return staffCatalog;
+    return staffCatalog.filter(
+      (s) =>
+        s.name.toLowerCase().includes(term) ||
+        (s.role_label ?? "").toLowerCase().includes(term) ||
+        (s.email ?? "").toLowerCase().includes(term),
+    );
+  }, [staffCatalog, search]);
+
+  const toggleMember = (staffId: string) => {
+    setMembers((prev) => {
+      if (prev.some((m) => m.staff_id === staffId)) {
+        return prev.filter((m) => m.staff_id !== staffId);
+      }
+      return [...prev, { staff_id: staffId, is_lead: false }];
+    });
+  };
+
+  const toggleLead = (staffId: string) => {
+    setMembers((prev) =>
+      prev.map((m) => (m.staff_id === staffId ? { ...m, is_lead: !m.is_lead } : m)),
+    );
+  };
+
+  const moveMember = (index: number, direction: -1 | 1) => {
+    setMembers((prev) => {
+      const next = [...prev];
+      const target = index + direction;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const removeMember = (staffId: string) => {
+    setMembers((prev) => prev.filter((m) => m.staff_id !== staffId));
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    const payloadMembers: StaffTeamMemberInput[] = members.map((m, idx) => ({
+      staff_id: m.staff_id,
+      is_lead: m.is_lead,
+      position: idx,
+    }));
+
+    const payload: StaffTeamInsert = {
+      name: values.name.trim(),
+      role_label: values.role_label?.trim() || null,
+      notes: values.notes?.trim() || null,
+      members: payloadMembers,
+    };
+
+    try {
+      if (isEdit && id) {
+        await updateMut.mutateAsync({ id, data: payload });
+        addToast("Equipo actualizado.", "success");
+      } else {
+        await createMut.mutateAsync(payload);
+        addToast("Equipo creado.", "success");
+      }
+      navigate("/staff/teams");
+    } catch {
+      // Toast ya mostrado por el mutation onError.
+    }
+  };
+
+  if (isEdit && loadingTeam) {
+    return <div className="text-text-secondary">Cargando equipo…</div>;
+  }
+
+  const submitting = createMut.isPending || updateMut.isPending;
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <Link
+        to="/staff/teams"
+        className="inline-flex items-center text-sm text-primary hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" aria-hidden="true" /> Volver a Equipos
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-bold text-text tracking-tight">
+          {isEdit ? "Editar equipo" : "Crear equipo"}
+        </h1>
+        <p className="text-sm text-text-secondary mt-1">
+          Agrupá colaboradores en una cuadrilla para asignarla a un evento en un solo paso.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="bg-card border border-border rounded-2xl shadow-sm p-6 space-y-6"
+      >
+        <div>
+          <label htmlFor="team-name" className="block text-sm font-medium text-text">
+            Nombre <span className="text-danger">*</span>
+          </label>
+          <input
+            id="team-name"
+            type="text"
+            {...register("name")}
+            className="mt-1 block w-full rounded-xl border border-border bg-surface-alt px-3 py-2 text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
+            placeholder="Cuadrilla principal · Equipo fotografía"
+            aria-invalid={errors.name ? "true" : "false"}
+          />
+          {errors.name && <p className="mt-1 text-sm text-danger">{errors.name.message}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="team-role" className="block text-sm font-medium text-text">
+            Rol del equipo
+          </label>
+          <input
+            id="team-role"
+            type="text"
+            {...register("role_label")}
+            className="mt-1 block w-full rounded-xl border border-border bg-surface-alt px-3 py-2 text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
+            placeholder="Fotografía · Meseros · Coordinación"
+            aria-invalid={errors.role_label ? "true" : "false"}
+          />
+          {errors.role_label && (
+            <p className="mt-1 text-sm text-danger">{errors.role_label.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="team-notes" className="block text-sm font-medium text-text">
+            Notas
+          </label>
+          <textarea
+            id="team-notes"
+            rows={3}
+            {...register("notes")}
+            className="mt-1 block w-full rounded-xl border border-border bg-surface-alt px-3 py-2 text-text focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary"
+            placeholder="Tarifa habitual del equipo, indicaciones, lo que quieras recordar…"
+            aria-invalid={errors.notes ? "true" : "false"}
+          />
+          {errors.notes && <p className="mt-1 text-sm text-danger">{errors.notes.message}</p>}
+        </div>
+
+        <div className="space-y-4 pt-2 border-t border-border">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5 text-primary" aria-hidden="true" />
+            <h2 className="text-base font-semibold text-text">Miembros</h2>
+            <span className="text-xs text-text-secondary">({members.length})</span>
+          </div>
+
+          {members.length > 0 && (
+            <ul className="divide-y divide-border rounded-xl border border-border bg-surface-alt/40">
+              {members.map((m, idx) => {
+                const staff = staffById.get(m.staff_id);
+                return (
+                  <li
+                    key={m.staff_id}
+                    className="flex items-center gap-3 px-3 py-2"
+                  >
+                    <div className="flex flex-col gap-0.5">
+                      <button
+                        type="button"
+                        onClick={() => moveMember(idx, -1)}
+                        disabled={idx === 0}
+                        className="p-0.5 text-text-tertiary hover:text-text disabled:opacity-30"
+                        aria-label="Subir miembro"
+                      >
+                        <ChevronUp className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => moveMember(idx, 1)}
+                        disabled={idx === members.length - 1}
+                        className="p-0.5 text-text-tertiary hover:text-text disabled:opacity-30"
+                        aria-label="Bajar miembro"
+                      >
+                        <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    </div>
+                    <div
+                      className="h-9 w-9 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center text-primary font-bold text-sm shrink-0"
+                      aria-hidden="true"
+                    >
+                      {(staff?.name ?? "?").charAt(0).toUpperCase()}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium text-text truncate">
+                        {staff?.name ?? "Colaborador sin nombre"}
+                      </div>
+                      {staff?.role_label && (
+                        <div className="text-xs text-text-secondary truncate">{staff.role_label}</div>
+                      )}
+                    </div>
+                    <label className="inline-flex items-center gap-2 text-xs text-text-secondary cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={m.is_lead}
+                        onChange={() => toggleLead(m.staff_id)}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                      />
+                      <span className="inline-flex items-center gap-1">
+                        <Crown className="h-3.5 w-3.5" aria-hidden="true" />
+                        Lidera el equipo
+                      </span>
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => removeMember(m.staff_id)}
+                      className="p-1.5 rounded-lg text-danger hover:bg-danger/10 transition-colors"
+                      aria-label="Quitar del equipo"
+                    >
+                      <X className="h-4 w-4" aria-hidden="true" />
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          <div>
+            <div className="text-sm font-medium text-text mb-2">Agregar colaboradores</div>
+            <div className="relative max-w-md">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <Search className="h-4 w-4 text-text-secondary" aria-hidden="true" />
+              </div>
+              <input
+                type="search"
+                className="block w-full pl-9 pr-3 py-2 border border-border rounded-xl bg-card text-text placeholder-text-secondary focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary sm:text-sm"
+                placeholder="Buscar por nombre o rol…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+
+            <div className="mt-3 max-h-72 overflow-y-auto rounded-xl border border-border divide-y divide-border">
+              {loadingStaff ? (
+                <div className="p-3 text-sm text-text-secondary">Cargando colaboradores…</div>
+              ) : filteredCatalog.length === 0 ? (
+                <div className="p-3 text-sm text-text-secondary">
+                  No hay colaboradores que coincidan.
+                </div>
+              ) : (
+                filteredCatalog.map((s) => {
+                  const selected = selectedIds.has(s.id);
+                  return (
+                    <label
+                      key={s.id}
+                      className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-surface-alt/60 transition-colors"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={() => toggleMember(s.id)}
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-primary"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-text truncate">{s.name}</div>
+                        {s.role_label && (
+                          <div className="text-xs text-text-secondary truncate">{s.role_label}</div>
+                        )}
+                      </div>
+                    </label>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2 border-t border-border">
+          <Link
+            to="/staff/teams"
+            className="inline-flex items-center justify-center px-4 py-2 text-sm font-medium rounded-xl text-text-secondary bg-surface-alt hover:bg-card border border-border transition-colors"
+          >
+            Cancelar
+          </Link>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold rounded-xl text-white premium-gradient shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30 transition-all hover:scale-[1.02] disabled:opacity-60"
+          >
+            <Save className="h-4 w-4 mr-2" aria-hidden="true" />
+            {isEdit ? "Guardar cambios" : "Crear equipo"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/web/src/pages/Staff/Teams/StaffTeamList.tsx
+++ b/web/src/pages/Staff/Teams/StaffTeamList.tsx
@@ -1,0 +1,171 @@
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ArrowLeft, Edit, Eye, Plus, Trash2, Users } from "lucide-react";
+import { RowActionMenu } from "@/components/RowActionMenu";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import Empty from "@/components/Empty";
+import { SkeletonTable } from "@/components/Skeleton";
+import {
+  useDeleteStaffTeam,
+  useStaffTeams,
+} from "@/hooks/queries/useStaffQueries";
+
+export const StaffTeamList: React.FC = () => {
+  const navigate = useNavigate();
+  const { data: teams = [], isLoading } = useStaffTeams();
+  const deleteTeam = useDeleteStaffTeam();
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+
+  const requestDelete = (id: string) => {
+    setPendingDeleteId(id);
+    setConfirmOpen(true);
+  };
+  const confirmDelete = () => {
+    if (!pendingDeleteId) return;
+    const id = pendingDeleteId;
+    setConfirmOpen(false);
+    setPendingDeleteId(null);
+    deleteTeam.mutate(id);
+  };
+
+  return (
+    <div className="space-y-6">
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Eliminar equipo"
+        description="El equipo se eliminará. Los colaboradores del equipo siguen disponibles en tu catálogo."
+        confirmText="Eliminar permanentemente"
+        cancelText="Cancelar"
+        onConfirm={confirmDelete}
+        onCancel={() => {
+          setConfirmOpen(false);
+          setPendingDeleteId(null);
+        }}
+      />
+
+      <Link
+        to="/staff"
+        className="inline-flex items-center text-sm text-primary hover:underline"
+      >
+        <ArrowLeft className="h-4 w-4 mr-1" aria-hidden="true" /> Volver a Personal
+      </Link>
+
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-text tracking-tight">Equipos</h1>
+          <p className="text-sm text-text-secondary mt-1">
+            Agrupá cuadrillas de colaboradores para asignarlas a un evento en un solo paso.
+          </p>
+        </div>
+        <Link
+          to="/staff/teams/new"
+          className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold rounded-xl text-white premium-gradient shadow-md shadow-primary/20 hover:shadow-lg hover:shadow-primary/30 transition-all hover:scale-[1.02]"
+        >
+          <Plus className="h-5 w-5 mr-2" aria-hidden="true" />
+          Crear equipo
+        </Link>
+      </div>
+
+      <div className="bg-card shadow-sm overflow-hidden rounded-2xl border border-border">
+        {isLoading ? (
+          <SkeletonTable
+            rows={4}
+            columns={[{ width: "w-48" }, { width: "w-36" }, { width: "w-24" }, { width: "w-20" }]}
+          />
+        ) : teams.length === 0 ? (
+          <Empty
+            icon={Users}
+            title="Sin equipos todavía"
+            description="Agregá tu primera cuadrilla. Juntá fotógrafos, meseros o coordinadores y asignalos a un evento en un solo click."
+            action={
+              <Link
+                to="/staff/teams/new"
+                className="inline-flex items-center justify-center px-4 py-2 text-sm font-bold rounded-xl text-white premium-gradient shadow-md shadow-primary/20 hover:shadow-lg transition-all hover:scale-[1.02]"
+              >
+                <Plus className="h-5 w-5 mr-2" aria-hidden="true" />
+                Crear equipo
+              </Link>
+            }
+          />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border" aria-label="Tabla de equipos">
+              <caption className="sr-only">{teams.length} equipos</caption>
+              <thead className="bg-surface-alt">
+                <tr>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-semibold text-text-secondary">
+                    Nombre
+                  </th>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-semibold text-text-secondary">
+                    Rol
+                  </th>
+                  <th scope="col" className="px-6 py-3 text-left text-xs font-semibold text-text-secondary">
+                    Miembros
+                  </th>
+                  <th scope="col" className="relative px-6 py-3">
+                    <span className="sr-only">Acciones</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-card divide-y divide-border">
+                {teams.map((t) => (
+                  <tr
+                    key={t.id}
+                    className="group hover:bg-surface-alt/50 cursor-pointer transition-colors"
+                    onClick={() => navigate(`/staff/teams/${t.id}`)}
+                  >
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <div
+                          className="h-10 w-10 rounded-full bg-primary/10 dark:bg-primary/20 flex items-center justify-center text-primary font-bold"
+                          aria-hidden="true"
+                        >
+                          <Users className="h-5 w-5" />
+                        </div>
+                        <div className="ml-4 text-sm font-semibold text-text">{t.name}</div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-text-secondary">
+                      {t.role_label ?? "—"}
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-text">
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-accent/10 text-accent dark:bg-accent/20">
+                        {t.member_count ?? 0}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                      <div className="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                        <RowActionMenu
+                          items={[
+                            {
+                              label: "Ver detalle",
+                              icon: Eye,
+                              onClick: () => navigate(`/staff/teams/${t.id}`),
+                            },
+                            {
+                              label: "Editar",
+                              icon: Edit,
+                              onClick: () => navigate(`/staff/teams/${t.id}/edit`),
+                            },
+                            {
+                              label: "Eliminar",
+                              icon: Trash2,
+                              onClick: () => requestDelete(t.id),
+                              variant: "destructive" as const,
+                            },
+                          ]}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/web/src/services/staffService.ts
+++ b/web/src/services/staffService.ts
@@ -6,6 +6,9 @@ import type {
   Staff,
   StaffAvailability,
   StaffInsert,
+  StaffTeam,
+  StaffTeamInsert,
+  StaffTeamUpdate,
   StaffUpdate,
 } from '../types/entities';
 
@@ -53,5 +56,27 @@ export const staffService = {
     if (params.start) query.start = params.start;
     if (params.end) query.end = params.end;
     return api.get<StaffAvailability[]>('/staff/availability', query);
+  },
+
+  // ── Staff Teams (Ola 2) ──
+
+  async listTeams(): Promise<StaffTeam[]> {
+    return api.get<StaffTeam[]>('/staff/teams');
+  },
+
+  async getTeam(id: string): Promise<StaffTeam> {
+    return api.get<StaffTeam>(`/staff/teams/${id}`);
+  },
+
+  async createTeam(data: StaffTeamInsert): Promise<StaffTeam> {
+    return api.post<StaffTeam>('/staff/teams', data);
+  },
+
+  async updateTeam(id: string, data: StaffTeamUpdate): Promise<StaffTeam> {
+    return api.put<StaffTeam>(`/staff/teams/${id}`, data);
+  },
+
+  async deleteTeam(id: string): Promise<void> {
+    return api.delete(`/staff/teams/${id}`);
   },
 };

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -237,44 +237,44 @@ export interface EventStaffAssignment {
 // StaffTeamMember. `members` llega en GetByID/Create/Update; `member_count`
 // llega en ListTeams.
 export interface StaffTeamMember {
-    team_id: string;
-    staff_id: string;
-    is_lead: boolean;
-    position: number;
-    created_at: string;
+    team_id: string
+    staff_id: string
+    is_lead: boolean
+    position: number
+    created_at: string
     // Joined desde staff
-    staff_name?: string | null;
-    staff_role_label?: string | null;
-    staff_phone?: string | null;
-    staff_email?: string | null;
+    staff_name?: string | null
+    staff_role_label?: string | null
+    staff_phone?: string | null
+    staff_email?: string | null
 }
 
 export interface StaffTeam {
-    id: string;
-    user_id: string;
-    name: string;
-    role_label?: string | null;
-    notes?: string | null;
-    created_at: string;
-    updated_at: string;
-    members?: StaffTeamMember[];
-    member_count?: number | null;
+    id: string
+    user_id: string
+    name: string
+    role_label?: string | null
+    notes?: string | null
+    created_at: string
+    updated_at: string
+    members?: StaffTeamMember[]
+    member_count?: number | null
 }
 
 // Miembro del equipo tal como se envía al backend en create/update.
 // El backend deduplica por staff_id y respeta `position` para ordenar.
 export interface StaffTeamMemberInput {
-    staff_id: string;
-    is_lead?: boolean;
-    position?: number;
+    staff_id: string
+    is_lead?: boolean
+    position?: number
 }
 
 // Body del POST /api/staff/teams.
 export interface StaffTeamInsert {
-    name: string;
-    role_label?: string | null;
-    notes?: string | null;
-    members?: StaffTeamMemberInput[];
+    name: string
+    role_label?: string | null
+    notes?: string | null
+    members?: StaffTeamMemberInput[]
 }
 
 // Body del PUT /api/staff/teams/{id} — reemplaza miembros atómicamente.

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -230,6 +230,56 @@ export interface EventStaffAssignment {
     status?: AssignmentStatus | null
 }
 
+// ===== Staff Teams (Ola 2) =====
+// Backend: /api/staff/teams. Los teams son agrupaciones nombradas de
+// colaboradores que pueden block-asignarse a eventos con un solo click.
+// Alinea 1:1 con backend/internal/models/models.go::StaffTeam /
+// StaffTeamMember. `members` llega en GetByID/Create/Update; `member_count`
+// llega en ListTeams.
+export interface StaffTeamMember {
+    team_id: string;
+    staff_id: string;
+    is_lead: boolean;
+    position: number;
+    created_at: string;
+    // Joined desde staff
+    staff_name?: string | null;
+    staff_role_label?: string | null;
+    staff_phone?: string | null;
+    staff_email?: string | null;
+}
+
+export interface StaffTeam {
+    id: string;
+    user_id: string;
+    name: string;
+    role_label?: string | null;
+    notes?: string | null;
+    created_at: string;
+    updated_at: string;
+    members?: StaffTeamMember[];
+    member_count?: number | null;
+}
+
+// Miembro del equipo tal como se envía al backend en create/update.
+// El backend deduplica por staff_id y respeta `position` para ordenar.
+export interface StaffTeamMemberInput {
+    staff_id: string;
+    is_lead?: boolean;
+    position?: number;
+}
+
+// Body del POST /api/staff/teams.
+export interface StaffTeamInsert {
+    name: string;
+    role_label?: string | null;
+    notes?: string | null;
+    members?: StaffTeamMemberInput[];
+}
+
+// Body del PUT /api/staff/teams/{id} — reemplaza miembros atómicamente.
+export type StaffTeamUpdate = Partial<StaffTeamInsert>;
+
 // ===== Staff Availability (Ola 1) =====
 // GET /api/staff/availability?date=YYYY-MM-DD | ?start=...&end=...
 // Solo devuelve staff CON asignaciones en la ventana pedida.


### PR DESCRIPTION
## Summary

Ola 2 of the Personal feature expansion. Adds **staff teams** so the organizer can group collaborators into named crews (e.g. "Meseros Plata", "Cuadrilla de montaje") and assign the whole team to an event in one click. Scales the model to catering / waiter-service businesses without changing the base Staff catalog flow.

**Depends on Ola 1** (feat/personal-ola-1 — PR #82). Rebase after #82 merges, or merge #82 first.

### Changes

**Backend (migration 044)**
- `staff_teams` (user_id, name, role_label, notes, timestamps)
- `staff_team_members` (team_id, staff_id, is_lead, position) — composite PK; cascade both sides
- Teams carry NO fee / status — those live per-assignment on `event_staff` so the same team can be reused across events with different costs / RSVPs
- CRUD endpoints under `/api/staff/teams`
- Update replaces members atomically (no per-member state to preserve)
- Tenant isolation check before inserting each member (staff_id must belong to same user)

**Clients (iOS / Android / Web)**
- Dedicated Teams CRUD UI accessible from the Staff list (no new top-level nav)
- Create/edit form: name, role_label, notes + multi-select members from the existing catalog; `is_lead` toggle per member (crown badge)
- Event form gets **"Agregar equipo completo"** button that opens a team picker, expands the team's members into individual `event_staff` rows using the existing UPSERT (no new endpoint). Dedupes by staff_id. Falls back to team.role_label when staff.role_label is blank. Full Ola 1 per-row controls (fee / shift / status) preserved per expanded member.

**UX principles**
- Teams are an OPTIONAL layer. Existing Staff flows are untouched.
- Rioplatense Spanish: "Equipos", "Crear equipo", "Miembros", "Lidera el equipo", "Agregar equipo completo", "Seleccioná un equipo", "Sin equipos todavía".
- No new plan gating in this wave.

## Test plan

- [ ] Backend: `cd backend && go build ./... && go test ./...` passes
- [ ] iOS: `xcodebuild -scheme Solennix -destination 'platform=iOS Simulator,name=iPhone 16' build` passes
- [ ] Android: `cd android && JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew assembleDebug` passes
- [ ] Web: `cd web && npm run check && npm run build && npm run test:run` passes
- [ ] Migration 044 up/down are reversible
- [ ] Create a team, add 3 members with one as lead, assign to an event — all 3 appear as separate event_staff rows
- [ ] Reassigning the same team skips the already-assigned members (no duplicates)
- [ ] Deleting a team does NOT delete the underlying staff rows (only cascades the junction)
- [ ] Deleting a staff row that's part of a team cascades the member row but leaves the team intact

## Roadmap next

- **Ola 3** — `Product.staff_team_id` optional for sellable staff service with markup vs internal cost. Requires product decisions (snapshot vs dynamic team, margin display, Quote integration)
- **Phase 3** — collaborator login via `invited_user_id` (unchanged, still roadmap)

## Note on commit history

Commit `bf33361` reverts `51bf37c` — a sub-agent accidentally committed a duplicate PRD vault under `solennix/`. The revert removes those files cleanly without touching the actual Ola 2 work.