### PR TITLE
feat: Personal Ola 3 — products carry a staff team for service pricing

### DIFF
--- a/android/core/database/schemas/com.creapolis.solennix.core.database.SolennixDatabase/10.json
+++ b/android/core/database/schemas/com.creapolis.solennix.core.database.SolennixDatabase/10.json
@@ -1,0 +1,813 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "6fb3788503de8d4b55d4dc7c417618e2",
+    "entities": [
+      {
+        "tableName": "clients",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT NOT NULL, `phone` TEXT NOT NULL, `email` TEXT, `address` TEXT, `city` TEXT, `notes` TEXT, `photo_url` TEXT, `total_events` INTEGER, `total_spent` REAL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `sync_status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photo_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalEvents",
+            "columnName": "total_events",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalSpent",
+            "columnName": "total_spent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `client_id` TEXT NOT NULL, `event_date` TEXT NOT NULL, `start_time` TEXT, `end_time` TEXT, `service_type` TEXT NOT NULL, `num_people` INTEGER NOT NULL, `status` TEXT NOT NULL, `discount` REAL NOT NULL, `discount_type` TEXT NOT NULL, `requires_invoice` INTEGER NOT NULL, `tax_rate` REAL NOT NULL, `tax_amount` REAL NOT NULL, `total_amount` REAL NOT NULL, `location` TEXT, `city` TEXT, `deposit_percent` REAL, `cancellation_days` REAL, `refund_percent` REAL, `notes` TEXT, `photos` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `sync_status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clientId",
+            "columnName": "client_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventDate",
+            "columnName": "event_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTime",
+            "columnName": "start_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "endTime",
+            "columnName": "end_time",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "serviceType",
+            "columnName": "service_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "numPeople",
+            "columnName": "num_people",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discount",
+            "columnName": "discount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discountType",
+            "columnName": "discount_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "requiresInvoice",
+            "columnName": "requires_invoice",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taxRate",
+            "columnName": "tax_rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "taxAmount",
+            "columnName": "tax_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalAmount",
+            "columnName": "total_amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "city",
+            "columnName": "city",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "depositPercent",
+            "columnName": "deposit_percent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cancellationDays",
+            "columnName": "cancellation_days",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "refundPercent",
+            "columnName": "refund_percent",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "photos",
+            "columnName": "photos",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "products",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT NOT NULL, `category` TEXT NOT NULL, `base_price` REAL NOT NULL, `recipe` TEXT, `image_url` TEXT, `is_active` INTEGER NOT NULL, `staff_team_id` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "basePrice",
+            "columnName": "base_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipe",
+            "columnName": "recipe",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "is_active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staffTeamId",
+            "columnName": "staff_team_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "inventory",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `ingredient_name` TEXT NOT NULL, `current_stock` REAL NOT NULL, `minimum_stock` REAL NOT NULL, `unit` TEXT NOT NULL, `unit_cost` REAL, `last_updated` TEXT NOT NULL, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ingredientName",
+            "columnName": "ingredient_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentStock",
+            "columnName": "current_stock",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minimumStock",
+            "columnName": "minimum_stock",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unit",
+            "columnName": "unit",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitCost",
+            "columnName": "unit_cost",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "payments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `eventId` TEXT NOT NULL, `userId` TEXT NOT NULL, `amount` REAL NOT NULL, `paymentDate` TEXT NOT NULL, `paymentMethod` TEXT NOT NULL, `notes` TEXT, `createdAt` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentDate",
+            "columnName": "paymentDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "paymentMethod",
+            "columnName": "paymentMethod",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "event_products",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `event_id` TEXT NOT NULL, `product_id` TEXT NOT NULL, `quantity` REAL NOT NULL, `unit_price` REAL NOT NULL, `discount` REAL NOT NULL, `total_price` REAL, `created_at` TEXT NOT NULL, `product_name` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productId",
+            "columnName": "product_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quantity",
+            "columnName": "quantity",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unitPrice",
+            "columnName": "unit_price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "discount",
+            "columnName": "discount",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPrice",
+            "columnName": "total_price",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "productName",
+            "columnName": "product_name",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "event_extras",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `event_id` TEXT NOT NULL, `description` TEXT NOT NULL, `cost` REAL NOT NULL, `price` REAL NOT NULL, `exclude_utility` INTEGER NOT NULL, `include_in_checklist` INTEGER NOT NULL DEFAULT 1, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "price",
+            "columnName": "price",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "excludeUtility",
+            "columnName": "exclude_utility",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "includeInChecklist",
+            "columnName": "include_in_checklist",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cached_staff",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `user_id` TEXT NOT NULL, `name` TEXT NOT NULL, `role_label` TEXT, `phone` TEXT, `email` TEXT, `notes` TEXT, `notification_email_opt_in` INTEGER NOT NULL, `invited_user_id` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, `sync_status` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "roleLabel",
+            "columnName": "role_label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phone",
+            "columnName": "phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationEmailOptIn",
+            "columnName": "notification_email_opt_in",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invitedUserId",
+            "columnName": "invited_user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncStatus",
+            "columnName": "sync_status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "cached_event_staff",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `event_id` TEXT NOT NULL, `staff_id` TEXT NOT NULL, `fee_amount` REAL, `role_override` TEXT, `notes` TEXT, `notification_sent_at` TEXT, `notification_last_result` TEXT, `created_at` TEXT NOT NULL, `staff_name` TEXT, `staff_role_label` TEXT, `staff_phone` TEXT, `staff_email` TEXT, `shift_start` TEXT, `shift_end` TEXT, `status` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventId",
+            "columnName": "event_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staffId",
+            "columnName": "staff_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feeAmount",
+            "columnName": "fee_amount",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "roleOverride",
+            "columnName": "role_override",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationSentAt",
+            "columnName": "notification_sent_at",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationLastResult",
+            "columnName": "notification_last_result",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "staffName",
+            "columnName": "staff_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "staffRoleLabel",
+            "columnName": "staff_role_label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "staffPhone",
+            "columnName": "staff_phone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "staffEmail",
+            "columnName": "staff_email",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shiftStart",
+            "columnName": "shift_start",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shiftEnd",
+            "columnName": "shift_end",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6fb3788503de8d4b55d4dc7c417618e2')"
+    ]
+  }
+}

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/SolennixDatabase.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/SolennixDatabase.kt
@@ -40,7 +40,7 @@ const val DATABASE_NAME = "solennix-database"
         CachedStaff::class,
         CachedEventStaff::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = true
 )
 @TypeConverters(JsonConverters::class)
@@ -158,7 +158,19 @@ abstract class SolennixDatabase : RoomDatabase() {
             }
         }
 
-        val ALL_MIGRATIONS = arrayOf(MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9)
+        /**
+         * v10 — Ola 3 del módulo Personal: `products.staff_team_id`. Permite
+         * asociar un equipo opcional al producto; el cliente expande los
+         * miembros en asignaciones de staff cuando se agrega al evento.
+         */
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                Log.d(TAG, "Running migration 9 -> 10: add staff_team_id to products")
+                db.execSQL("ALTER TABLE products ADD COLUMN staff_team_id TEXT")
+            }
+        }
+
+        val ALL_MIGRATIONS = arrayOf(MIGRATION_4_5, MIGRATION_5_6, MIGRATION_6_7, MIGRATION_7_8, MIGRATION_8_9, MIGRATION_9_10)
 
         /**
          * Manual singleton for use in contexts without Hilt (e.g., Glance widgets).

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/entity/CachedProduct.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/entity/CachedProduct.kt
@@ -15,6 +15,7 @@ data class CachedProduct(
     val recipe: String?,
     @ColumnInfo(name = "image_url") val imageUrl: String?,
     @ColumnInfo(name = "is_active") val isActive: Boolean,
+    @ColumnInfo(name = "staff_team_id") val staffTeamId: String?,
     @ColumnInfo(name = "created_at") val createdAt: String,
     @ColumnInfo(name = "updated_at") val updatedAt: String
 )
@@ -28,6 +29,7 @@ fun CachedProduct.asExternalModel() = Product(
     recipe = recipe,
     imageUrl = imageUrl,
     isActive = isActive,
+    staffTeamId = staffTeamId,
     createdAt = createdAt,
     updatedAt = updatedAt
 )
@@ -41,6 +43,7 @@ fun Product.asEntity() = CachedProduct(
     recipe = recipe,
     imageUrl = imageUrl,
     isActive = isActive,
+    staffTeamId = staffTeamId,
     createdAt = createdAt,
     updatedAt = updatedAt
 )

--- a/android/core/model/src/main/java/com/creapolis/solennix/core/model/Product.kt
+++ b/android/core/model/src/main/java/com/creapolis/solennix/core/model/Product.kt
@@ -13,6 +13,7 @@ data class Product(
     val recipe: String? = null,
     @SerialName("image_url") val imageUrl: String? = null,
     @SerialName("is_active") val isActive: Boolean = true,
+    @SerialName("staff_team_id") val staffTeamId: String? = null,
     @SerialName("created_at") val createdAt: String = "",
     @SerialName("updated_at") val updatedAt: String = ""
 )

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventFormScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventFormScreen.kt
@@ -724,6 +724,33 @@ fun ProductSelectionItem(
                 Column(modifier = Modifier.weight(1f)) {
                     Text(product.name, style = MaterialTheme.typography.titleSmall)
                     Text(item.unitPrice.asMXN(), style = MaterialTheme.typography.bodySmall, color = SolennixTheme.colors.primary)
+                    product.staffTeamId?.takeIf { it.isNotBlank() }?.let {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        AssistChip(
+                            onClick = {},
+                            enabled = false,
+                            label = {
+                                Text(
+                                    "Incluye equipo",
+                                    style = MaterialTheme.typography.labelSmall
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Default.Groups,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(14.dp)
+                                )
+                            },
+                            colors = AssistChipDefaults.assistChipColors(
+                                disabledContainerColor = SolennixTheme.colors.primary.copy(alpha = 0.08f),
+                                disabledLabelColor = SolennixTheme.colors.primary,
+                                disabledLeadingIconContentColor = SolennixTheme.colors.primary
+                            ),
+                            border = null,
+                            modifier = Modifier.height(24.dp)
+                        )
+                    }
                 }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventFormViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventFormViewModel.kt
@@ -691,6 +691,51 @@ class EventFormViewModel @Inject constructor(
             selectedProducts.add(eventProduct)
         }
         fetchProductCosts()
+
+        // Ola 3 — snapshot at add-time: si el producto tiene un equipo asociado,
+        // expandimos sus miembros como asignaciones de staff. Dedup via Ola 2.
+        product.staffTeamId?.takeIf { it.isNotBlank() }?.let { teamId ->
+            expandStaffTeamForProduct(teamId)
+        }
+    }
+
+    private fun expandStaffTeamForProduct(teamId: String) {
+        viewModelScope.launch {
+            try {
+                val team = staffTeamRepository.getTeam(teamId)
+                val catalog = _availableStaff.value.associateBy { it.id }
+                val currentIds = selectedStaff.map { it.staffId }.toMutableSet()
+                team.members.orEmpty().sortedBy { it.position }.forEach { member ->
+                    if (member.staffId in currentIds) return@forEach
+                    val resolvedName = catalog[member.staffId]?.name
+                        ?: member.staffName
+                        ?: "Colaborador"
+                    val resolvedRole = catalog[member.staffId]?.roleLabel
+                        ?: member.staffRoleLabel
+                    selectedStaff.add(
+                        SelectedStaffAssignment(
+                            staffId = member.staffId,
+                            feeAmount = null,
+                            roleOverride = "",
+                            notes = "",
+                            staffName = resolvedName,
+                            staffRoleLabel = resolvedRole,
+                            shiftStart = null,
+                            shiftEnd = null,
+                            status = AssignmentStatus.CONFIRMED.raw
+                        )
+                    )
+                    currentIds.add(member.staffId)
+                }
+            } catch (e: Exception) {
+                _uiEvents.tryEmit(
+                    UiEvent.Error(
+                        message = "No pudimos expandir el equipo del producto: ${e.message}",
+                        retryActionId = null,
+                    )
+                )
+            }
+        }
     }
 
     fun removeProduct(productId: String) {

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductFormScreen.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/ui/ProductFormScreen.kt
@@ -346,6 +346,8 @@ fun ProductFormScreen(
                     showCost = true
                 )
 
+                StaffTeamSection(viewModel = viewModel)
+
                 if (viewModel.errorMessage != null) {
                     Text(
                         text = viewModel.errorMessage.orEmpty(),
@@ -583,6 +585,111 @@ private fun RecipeItemRow(
                     contentDescription = stringResource(DesignSystemR.string.cd_delete),
                     tint = colors.error,
                     modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun StaffTeamSection(viewModel: ProductFormViewModel) {
+    val colors = SolennixTheme.colors
+    var expanded by remember { mutableStateOf(false) }
+    val teams = viewModel.availableTeams
+    val selected = teams.find { it.id == viewModel.staffTeamId }
+    val selectedText = selected?.name ?: "Sin equipo"
+
+    Card(
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(containerColor = colors.card),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = "Equipo asociado",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.primaryText
+            )
+            Text(
+                text = "Agregá un equipo para vender el servicio de meseros con este producto.",
+                style = MaterialTheme.typography.bodySmall,
+                color = colors.tertiaryText
+            )
+
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it }
+            ) {
+                OutlinedTextField(
+                    value = selectedText,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Equipo") },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Default.Groups,
+                            contentDescription = null
+                        )
+                    },
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+                    shape = MaterialTheme.shapes.small,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = colors.primary,
+                        focusedLabelColor = colors.primary,
+                        cursorColor = colors.primary
+                    ),
+                    singleLine = true
+                )
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Sin equipo") },
+                        onClick = {
+                            viewModel.staffTeamId = null
+                            expanded = false
+                        }
+                    )
+                    teams.forEach { team ->
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(team.name)
+                                    val count = team.memberCount ?: team.members?.size
+                                    if (count != null) {
+                                        Text(
+                                            text = "$count integrantes",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = colors.secondaryText
+                                        )
+                                    }
+                                }
+                            },
+                            onClick = {
+                                viewModel.staffTeamId = team.id
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            if (viewModel.staffTeamId != null) {
+                Text(
+                    text = "Cuando agregues este producto a un evento, se asignan automáticamente los miembros del equipo como personal.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = colors.secondaryText
                 )
             }
         }

--- a/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductFormViewModel.kt
+++ b/android/feature/products/src/main/java/com/creapolis/solennix/feature/products/viewmodel/ProductFormViewModel.kt
@@ -14,11 +14,13 @@ import com.creapolis.solennix.core.data.plan.LimitCheckResult
 import com.creapolis.solennix.core.data.plan.PlanLimitsManager
 import com.creapolis.solennix.core.data.repository.InventoryRepository
 import com.creapolis.solennix.core.data.repository.ProductRepository
+import com.creapolis.solennix.core.data.repository.StaffTeamRepository
 import com.creapolis.solennix.core.model.InventoryItem
 import com.creapolis.solennix.core.model.InventoryType
 import com.creapolis.solennix.core.model.Plan
 import com.creapolis.solennix.core.model.Product
 import com.creapolis.solennix.core.model.ProductIngredient
+import com.creapolis.solennix.core.model.StaffTeam
 import com.creapolis.solennix.core.network.ApiService
 import com.creapolis.solennix.core.network.get
 import com.creapolis.solennix.core.network.post
@@ -48,6 +50,7 @@ data class RecipeItem(
 class ProductFormViewModel @Inject constructor(
     private val productRepository: ProductRepository,
     private val inventoryRepository: InventoryRepository,
+    private val staffTeamRepository: StaffTeamRepository,
     private val apiService: ApiService,
     private val planLimitsManager: PlanLimitsManager,
     private val authManager: AuthManager,
@@ -67,6 +70,12 @@ class ProductFormViewModel @Inject constructor(
     var basePrice by mutableStateOf("")
     var imageUrl by mutableStateOf("")
     var isActive by mutableStateOf(true)
+
+    // Ola 3 — equipo opcional. Al agregar el producto a un evento, el cliente
+    // expande los miembros en asignaciones de staff.
+    var staffTeamId by mutableStateOf<String?>(null)
+    var availableTeams by mutableStateOf<List<StaffTeam>>(emptyList())
+        private set
 
     // Recipe items
     val ingredients = mutableStateListOf<RecipeItem>()
@@ -116,6 +125,16 @@ class ProductFormViewModel @Inject constructor(
                 val products = productRepository.getProducts().first()
                 existingCategories = products.map { it.category }.distinct().sorted()
 
+                // Load staff teams for the optional "Equipo asociado" dropdown.
+                // Non-blocking: si falla, el dropdown queda vacío y la feature
+                // se degrada a "Sin equipo" sin romper el form.
+                try {
+                    availableTeams = staffTeamRepository.listTeams()
+                        .sortedBy { it.name.lowercase() }
+                } catch (_: Exception) {
+                    availableTeams = emptyList()
+                }
+
                 if (productId != null) {
                     loadProduct(productId)
                 } else {
@@ -139,6 +158,7 @@ class ProductFormViewModel @Inject constructor(
                 basePrice = product.basePrice.toString()
                 imageUrl = product.imageUrl ?: ""
                 isActive = product.isActive
+                staffTeamId = product.staffTeamId
             }
 
             // Load ingredients
@@ -209,6 +229,7 @@ class ProductFormViewModel @Inject constructor(
                     recipe = null,
                     imageUrl = imageUrl.takeIf { it.isNotBlank() },
                     isActive = isActive,
+                    staffTeamId = staffTeamId,
                     createdAt = "",
                     updatedAt = ""
                 )

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -121,6 +121,7 @@ func main() {
 	crudHandler.SetNotifier(notificationService)
 	crudHandler.SetEmailService(emailService)
 	crudHandler.SetLiveActivityNotifier(liveActivityService)
+	crudHandler.SetStaffTeamRepo(staffTeamRepo)
 	subHandler := handlers.NewSubscriptionHandler(userRepo, subscriptionRepo, eventRepo, paymentRepo, stripeService, rcService, cfg)
 	subHandler.SetEmailService(emailService)
 	searchHandler := handlers.NewSearchHandler(clientRepo, productRepo, inventoryRepo, eventRepo)

--- a/backend/internal/database/migrations/045_add_product_staff_team.down.sql
+++ b/backend/internal/database/migrations/045_add_product_staff_team.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_products_staff_team_id;
+
+ALTER TABLE products
+    DROP COLUMN IF EXISTS staff_team_id;

--- a/backend/internal/database/migrations/045_add_product_staff_team.up.sql
+++ b/backend/internal/database/migrations/045_add_product_staff_team.up.sql
@@ -1,0 +1,17 @@
+-- Ola 3 of Personal expansion: products can optionally reference a staff_team.
+-- When a product with a staff_team_id is added to an event, the UI expands
+-- the team's members into event_staff rows (client-orchestrated — backend
+-- stays a dumb store for this relationship).
+--
+-- ON DELETE SET NULL so deleting the team keeps the product (the product
+-- just loses its team association; the price/ingredients stay intact).
+--
+-- Nullable so existing products are untouched — this is an additive feature.
+ALTER TABLE products
+    ADD COLUMN staff_team_id UUID REFERENCES staff_teams(id) ON DELETE SET NULL;
+
+-- Partial index: useful when we filter products by "has a team" for future
+-- reports or the "servicio de meseros" catalog shortcut in the UI. Ignored
+-- by queries that don't touch the column.
+CREATE INDEX idx_products_staff_team_id ON products(staff_team_id)
+    WHERE staff_team_id IS NOT NULL;

--- a/backend/internal/handlers/crud_handler.go
+++ b/backend/internal/handlers/crud_handler.go
@@ -33,7 +33,8 @@ type CRUDHandler struct {
 	paymentRepo     FullPaymentRepository
 	userRepo        FullUserRepository
 	unavailRepo     UnavailableDateRepository
-	notifier        NotificationSender         // optional, may be nil
+	staffTeamRepo   StaffTeamRepository         // optional, may be nil (Ola 3)
+	notifier        NotificationSender          // optional, may be nil
 	emailService    *services.EmailService      // optional, may be nil
 	liveActivitySvc LiveActivityNotifier        // optional, may be nil
 }
@@ -77,6 +78,14 @@ func (h *CRUDHandler) SetEmailService(e *services.EmailService) {
 // SetLiveActivityNotifier configures an optional Live Activity push notifier.
 func (h *CRUDHandler) SetLiveActivityNotifier(s LiveActivityNotifier) {
 	h.liveActivitySvc = s
+}
+
+// SetStaffTeamRepo configures an optional staff team repository used to verify
+// tenant ownership of `staff_team_id` on product Create/Update (Ola 3).
+// When nil, products accept any staff_team_id the client sends — rely on the
+// FK constraint alone. Prefer wiring this in production.
+func (h *CRUDHandler) SetStaffTeamRepo(s StaffTeamRepository) {
+	h.staffTeamRepo = s
 }
 
 // ===================
@@ -1338,6 +1347,17 @@ func (h *CRUDHandler) CreateProduct(w http.ResponseWriter, r *http.Request) {
 	}
 
 	product.UserID = userID
+
+	// Tenant check on staff_team_id — prevent a client from attaching another
+	// user's team. The FK alone can't enforce this because staff_teams doesn't
+	// carry a denormalized user_id check on its own row in this query.
+	if product.StaffTeamID != nil && h.staffTeamRepo != nil {
+		if _, err := h.staffTeamRepo.GetByID(r.Context(), *product.StaffTeamID, userID); err != nil {
+			writeError(w, http.StatusBadRequest, "staff_team_id does not belong to this user")
+			return
+		}
+	}
+
 	if err := h.productRepo.Create(r.Context(), &product); err != nil {
 		writeError(w, http.StatusInternalServerError, "Failed to create product")
 		return
@@ -1366,6 +1386,14 @@ func (h *CRUDHandler) UpdateProduct(w http.ResponseWriter, r *http.Request) {
 
 	product.ID = id
 	product.UserID = userID
+
+	if product.StaffTeamID != nil && h.staffTeamRepo != nil {
+		if _, err := h.staffTeamRepo.GetByID(r.Context(), *product.StaffTeamID, userID); err != nil {
+			writeError(w, http.StatusBadRequest, "staff_team_id does not belong to this user")
+			return
+		}
+	}
+
 	if err := h.productRepo.Update(r.Context(), &product); err != nil {
 		writeError(w, http.StatusInternalServerError, "Failed to update product")
 		return

--- a/backend/internal/handlers/crud_handler.go
+++ b/backend/internal/handlers/crud_handler.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -1353,7 +1354,12 @@ func (h *CRUDHandler) CreateProduct(w http.ResponseWriter, r *http.Request) {
 	// carry a denormalized user_id check on its own row in this query.
 	if product.StaffTeamID != nil && h.staffTeamRepo != nil {
 		if _, err := h.staffTeamRepo.GetByID(r.Context(), *product.StaffTeamID, userID); err != nil {
-			writeError(w, http.StatusBadRequest, "staff_team_id does not belong to this user")
+			if errors.Is(err, repository.ErrStaffTeamNotFound) {
+				writeError(w, http.StatusBadRequest, "staff_team_id does not belong to this user")
+				return
+			}
+			slog.Error("verify staff team ownership failed", "error", err, "user_id", userID)
+			writeError(w, http.StatusInternalServerError, "Failed to verify team ownership")
 			return
 		}
 	}
@@ -1389,7 +1395,12 @@ func (h *CRUDHandler) UpdateProduct(w http.ResponseWriter, r *http.Request) {
 
 	if product.StaffTeamID != nil && h.staffTeamRepo != nil {
 		if _, err := h.staffTeamRepo.GetByID(r.Context(), *product.StaffTeamID, userID); err != nil {
-			writeError(w, http.StatusBadRequest, "staff_team_id does not belong to this user")
+			if errors.Is(err, repository.ErrStaffTeamNotFound) {
+				writeError(w, http.StatusBadRequest, "staff_team_id does not belong to this user")
+				return
+			}
+			slog.Error("verify staff team ownership failed", "error", err, "user_id", userID)
+			writeError(w, http.StatusInternalServerError, "Failed to verify team ownership")
 			return
 		}
 	}

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -93,8 +93,13 @@ type Product struct {
 	Recipe    *string   `json:"recipe,omitempty"`    // JSONB stored as string
 	ImageURL  *string   `json:"image_url,omitempty"` // Product image URL
 	IsActive  bool      `json:"is_active"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	// StaffTeamID (Ola 3) optionally binds a product to a staff team. When the
+	// client adds this product to an event, the UI expands the team's members
+	// into event_staff rows so the organizer can sell "servicio de meseros"
+	// as a line item with internal staff cost tracking. Coexists with Recipe.
+	StaffTeamID *uuid.UUID `json:"staff_team_id,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
 type InventoryItem struct {

--- a/backend/internal/repository/product_repo.go
+++ b/backend/internal/repository/product_repo.go
@@ -24,7 +24,7 @@ func (r *ProductRepo) CountByUserID(ctx context.Context, userID uuid.UUID) (int,
 }
 
 func (r *ProductRepo) GetAll(ctx context.Context, userID uuid.UUID) ([]models.Product, error) {
-	query := fmt.Sprintf(`SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, created_at, updated_at
+	query := fmt.Sprintf(`SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, staff_team_id, created_at, updated_at
 		FROM products WHERE user_id = $1 ORDER BY name LIMIT %d`, GetAllSafetyLimit)
 	rows, err := r.pool.Query(ctx, query, userID)
 	if err != nil {
@@ -36,7 +36,7 @@ func (r *ProductRepo) GetAll(ctx context.Context, userID uuid.UUID) ([]models.Pr
 	for rows.Next() {
 		var p models.Product
 		if err := rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Category, &p.BasePrice,
-			&p.Recipe, &p.ImageURL, &p.IsActive, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			&p.Recipe, &p.ImageURL, &p.IsActive, &p.StaffTeamID, &p.CreatedAt, &p.UpdatedAt); err != nil {
 			return nil, err
 		}
 		products = append(products, p)
@@ -54,7 +54,7 @@ func (r *ProductRepo) GetAllPaginated(ctx context.Context, userID uuid.UUID, off
 		return nil, 0, fmt.Errorf("count products: %w", err)
 	}
 
-	query := fmt.Sprintf(`SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, created_at, updated_at
+	query := fmt.Sprintf(`SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, staff_team_id, created_at, updated_at
 		FROM products WHERE user_id = $1 ORDER BY %s %s LIMIT $2 OFFSET $3`, sortCol, order)
 	rows, err := r.pool.Query(ctx, query, userID, limit, offset)
 	if err != nil {
@@ -66,7 +66,7 @@ func (r *ProductRepo) GetAllPaginated(ctx context.Context, userID uuid.UUID, off
 	for rows.Next() {
 		var p models.Product
 		if err := rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Category, &p.BasePrice,
-			&p.Recipe, &p.ImageURL, &p.IsActive, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			&p.Recipe, &p.ImageURL, &p.IsActive, &p.StaffTeamID, &p.CreatedAt, &p.UpdatedAt); err != nil {
 			return nil, 0, err
 		}
 		products = append(products, p)
@@ -79,11 +79,11 @@ func (r *ProductRepo) GetAllPaginated(ctx context.Context, userID uuid.UUID, off
 
 func (r *ProductRepo) GetByID(ctx context.Context, id, userID uuid.UUID) (*models.Product, error) {
 	p := &models.Product{}
-	query := `SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, created_at, updated_at
+	query := `SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, staff_team_id, created_at, updated_at
 		FROM products WHERE id = $1 AND user_id = $2`
 	err := r.pool.QueryRow(ctx, query, id, userID).Scan(
 		&p.ID, &p.UserID, &p.Name, &p.Category, &p.BasePrice,
-		&p.Recipe, &p.ImageURL, &p.IsActive, &p.CreatedAt, &p.UpdatedAt)
+		&p.Recipe, &p.ImageURL, &p.IsActive, &p.StaffTeamID, &p.CreatedAt, &p.UpdatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("product not found: %w", err)
 	}
@@ -91,20 +91,20 @@ func (r *ProductRepo) GetByID(ctx context.Context, id, userID uuid.UUID) (*model
 }
 
 func (r *ProductRepo) Create(ctx context.Context, p *models.Product) error {
-	query := `INSERT INTO products (user_id, name, category, base_price, recipe, image_url, is_active)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	query := `INSERT INTO products (user_id, name, category, base_price, recipe, image_url, is_active, staff_team_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		RETURNING id, created_at, updated_at`
 	return r.pool.QueryRow(ctx, query,
-		p.UserID, p.Name, p.Category, p.BasePrice, p.Recipe, p.ImageURL, p.IsActive,
+		p.UserID, p.Name, p.Category, p.BasePrice, p.Recipe, p.ImageURL, p.IsActive, p.StaffTeamID,
 	).Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt)
 }
 
 func (r *ProductRepo) Update(ctx context.Context, p *models.Product) error {
-	query := `UPDATE products SET name=$3, category=$4, base_price=$5, recipe=$6, image_url=$7, is_active=$8, updated_at=NOW()
+	query := `UPDATE products SET name=$3, category=$4, base_price=$5, recipe=$6, image_url=$7, is_active=$8, staff_team_id=$9, updated_at=NOW()
 		WHERE id=$1 AND user_id=$2
 		RETURNING created_at, updated_at`
 	return r.pool.QueryRow(ctx, query,
-		p.ID, p.UserID, p.Name, p.Category, p.BasePrice, p.Recipe, p.ImageURL, p.IsActive,
+		p.ID, p.UserID, p.Name, p.Category, p.BasePrice, p.Recipe, p.ImageURL, p.IsActive, p.StaffTeamID,
 	).Scan(&p.CreatedAt, &p.UpdatedAt)
 }
 
@@ -218,7 +218,7 @@ func (r *ProductRepo) VerifyOwnership(ctx context.Context, productIDs []uuid.UUI
 
 // Search performs a fuzzy search on products using pg_trgm similarity + ILIKE fallback
 func (r *ProductRepo) Search(ctx context.Context, userID uuid.UUID, query string) ([]models.Product, error) {
-	sqlQuery := `SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, created_at, updated_at
+	sqlQuery := `SELECT id, user_id, name, category, base_price, recipe, image_url, is_active, staff_team_id, created_at, updated_at
 		FROM products
 		WHERE user_id = $1
 		AND (
@@ -239,7 +239,7 @@ func (r *ProductRepo) Search(ctx context.Context, userID uuid.UUID, query string
 	for rows.Next() {
 		var p models.Product
 		if err := rows.Scan(&p.ID, &p.UserID, &p.Name, &p.Category, &p.BasePrice,
-			&p.Recipe, &p.ImageURL, &p.IsActive, &p.CreatedAt, &p.UpdatedAt); err != nil {
+			&p.Recipe, &p.ImageURL, &p.IsActive, &p.StaffTeamID, &p.CreatedAt, &p.UpdatedAt); err != nil {
 			return nil, err
 		}
 		products = append(products, p)

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/Product.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/Product.swift
@@ -8,6 +8,10 @@ public struct Product: Codable, Identifiable, Sendable, Hashable {
     public let basePrice: Double
     public var recipe: AnyCodable?
     public var imageUrl: String?
+    /// Ola 3 — team opcional que se expande en staff al agregar el producto
+    /// a un evento. Snapshot en el form: ediciones posteriores del team no
+    /// tocan eventos ya guardados.
+    public var staffTeamId: String?
     public let isActive: Bool
     public let createdAt: String
     public let updatedAt: String
@@ -22,6 +26,7 @@ public struct Product: Codable, Identifiable, Sendable, Hashable {
         basePrice: Double,
         recipe: AnyCodable? = nil,
         imageUrl: String? = nil,
+        staffTeamId: String? = nil,
         isActive: Bool,
         createdAt: String,
         updatedAt: String
@@ -33,6 +38,7 @@ public struct Product: Codable, Identifiable, Sendable, Hashable {
         self.basePrice = basePrice
         self.recipe = recipe
         self.imageUrl = imageUrl
+        self.staffTeamId = staffTeamId
         self.isActive = isActive
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
@@ -539,6 +539,25 @@ public final class EventFormViewModel {
                 )
             )
         }
+
+        // Ola 3: si el producto carga un team asociado, expandir sus miembros
+        // como staff del evento. Snapshot: el team se hidrata acá y el dedup
+        // lo maneja `addStaffTeam`.
+        if let teamId = product.staffTeamId, !teamId.isEmpty {
+            Task { await expandStaffTeam(teamId: teamId) }
+        }
+    }
+
+    /// Fetcha el team por ID y expande sus miembros en `selectedStaff`. Los
+    /// errores se reportan via `errorMessage` sin bloquear el add del producto.
+    @MainActor
+    private func expandStaffTeam(teamId: String) async {
+        do {
+            let team = try await apiClient.getStaffTeam(id: teamId)
+            _ = addStaffTeam(team)
+        } catch {
+            errorMessage = mapError(error)
+        }
     }
 
     public func removeProduct(at index: Int) {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step2ProductsView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventFormSteps/Step2ProductsView.swift
@@ -115,10 +115,27 @@ struct Step2ProductsView: View {
         VStack(spacing: Spacing.sm) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(item.product?.name ?? "Producto")
-                        .font(.body)
-                        .fontWeight(.medium)
-                        .foregroundStyle(SolennixColors.text)
+                    HStack(spacing: Spacing.xs) {
+                        Text(item.product?.name ?? "Producto")
+                            .font(.body)
+                            .fontWeight(.medium)
+                            .foregroundStyle(SolennixColors.text)
+
+                        if let teamId = item.product?.staffTeamId, !teamId.isEmpty {
+                            HStack(spacing: 2) {
+                                Image(systemName: "person.3.fill")
+                                    .font(.caption2)
+                                Text("Incluye equipo")
+                                    .font(.caption2)
+                                    .fontWeight(.medium)
+                            }
+                            .foregroundStyle(SolennixColors.primary)
+                            .padding(.horizontal, Spacing.xs)
+                            .padding(.vertical, 2)
+                            .background(SolennixColors.primaryLight)
+                            .clipShape(Capsule())
+                        }
+                    }
 
                     Text("$\(String(format: "%.2f", item.unitPrice)) c/u")
                         .font(.caption)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/ViewModels/ProductFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/ViewModels/ProductFormViewModel.swift
@@ -13,6 +13,7 @@ private struct ProductBody: Encodable {
     let basePrice: Double
     let isActive: Bool
     let imageUrl: String?
+    let staffTeamId: String?
 }
 
 private struct RecipeIngredientBody: Encodable {
@@ -69,6 +70,12 @@ public final class ProductFormViewModel {
     public var imageUrl: String?
     public var selectedPhoto: PhotosPickerItem?
     public var localImageData: Data?
+
+    // MARK: - Staff Team (Ola 3)
+
+    /// Team opcional que se expande en staff al agregar el producto a un evento.
+    public var staffTeamId: String?
+    public var availableStaffTeams: [StaffTeam] = []
 
     // MARK: - Recipe
 
@@ -154,6 +161,13 @@ public final class ProductFormViewModel {
             let cats = Set(products.map { $0.category }.filter { !$0.isEmpty })
             existingCategories = Array(cats).sorted()
 
+            // Load staff teams (non-blocking: fallback to empty list)
+            do {
+                availableStaffTeams = try await apiClient.listStaffTeams()
+            } catch {
+                availableStaffTeams = []
+            }
+
             // If editing, load product data
             if let id = productId {
                 let product: Product = try await apiClient.get(Endpoint.product(id))
@@ -176,6 +190,7 @@ public final class ProductFormViewModel {
         basePrice = product.basePrice
         isActive = product.isActive
         imageUrl = product.imageUrl
+        staffTeamId = product.staffTeamId
     }
 
     private func populateRecipe(from productIngredients: [ProductIngredient]) {
@@ -339,7 +354,8 @@ public final class ProductFormViewModel {
                 category: category.trimmingCharacters(in: .whitespacesAndNewlines),
                 basePrice: basePrice,
                 isActive: isActive,
-                imageUrl: finalImageUrl
+                imageUrl: finalImageUrl,
+                staffTeamId: staffTeamId
             )
 
             // Prepare recipe data

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Views/ProductFormView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Products/Views/ProductFormView.swift
@@ -103,9 +103,85 @@ public struct ProductFormView: View {
                     },
                     showCost: true
                 )
+
+                staffTeamSection
             }
             .padding(Spacing.lg)
         }
+    }
+
+    // MARK: - Staff Team Section (Ola 3)
+
+    private var staffTeamSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.sm) {
+            Text("Equipo asociado")
+                .font(.headline)
+                .foregroundStyle(SolennixColors.text)
+
+            Text("Cuando agregues este producto a un evento, se asignan automaticamente los miembros del equipo como personal.")
+                .font(.caption)
+                .foregroundStyle(SolennixColors.textSecondary)
+
+            Menu {
+                Button {
+                    viewModel.staffTeamId = nil
+                } label: {
+                    Label("Sin equipo", systemImage: viewModel.staffTeamId == nil ? "checkmark" : "")
+                }
+
+                if !viewModel.availableStaffTeams.isEmpty {
+                    Divider()
+
+                    ForEach(viewModel.availableStaffTeams) { team in
+                        Button {
+                            viewModel.staffTeamId = team.id
+                        } label: {
+                            let count = team.memberCount ?? team.members?.count ?? 0
+                            let label = count > 0 ? "\(team.name) (\(count))" : team.name
+                            Label(label, systemImage: viewModel.staffTeamId == team.id ? "checkmark" : "")
+                        }
+                    }
+                }
+            } label: {
+                HStack {
+                    Image(systemName: "person.3.fill")
+                        .foregroundStyle(SolennixColors.primary)
+
+                    Text(selectedTeamLabel)
+                        .foregroundStyle(viewModel.staffTeamId == nil ? SolennixColors.textTertiary : SolennixColors.text)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.down")
+                        .foregroundStyle(SolennixColors.textTertiary)
+                }
+                .padding(Spacing.md)
+                .background(SolennixColors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: CornerRadius.md))
+                .overlay(
+                    RoundedRectangle(cornerRadius: CornerRadius.md)
+                        .stroke(SolennixColors.border, lineWidth: 1)
+                )
+            }
+
+            if viewModel.availableStaffTeams.isEmpty {
+                Text("Agrega equipos desde Personal para venderlos como servicio.")
+                    .font(.caption2)
+                    .foregroundStyle(SolennixColors.textTertiary)
+            }
+        }
+        .padding(Spacing.md)
+        .background(SolennixColors.card)
+        .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+        .shadow(color: .black.opacity(0.05), radius: 2, x: 0, y: 1)
+    }
+
+    private var selectedTeamLabel: String {
+        guard let id = viewModel.staffTeamId,
+              let team = viewModel.availableStaffTeams.first(where: { $0.id == id }) else {
+            return "Sin equipo"
+        }
+        return team.name
     }
 
     // MARK: - Image Section

--- a/obsidian/Solennix/PRD/02_FEATURES.md
+++ b/obsidian/Solennix/PRD/02_FEATURES.md
@@ -1005,8 +1005,21 @@ Visualización + registro de pago por transferencia con approve/reject. Reemplaz
 - **Asignación al evento:** nuevo botón "Agregar equipo completo" en Step 4 del EventForm. Expande los miembros del equipo a N filas en `event_staff` reusando el UPSERT de Ola 1 — no hay endpoint nuevo. Miembros ya asignados se saltean. El usuario puede editar fee/turno/estado por fila después de expandir.
 - **Sin plan gating:** disponible para todos los planes (igual que Ola 1).
 
+**Ola 3 — Staff como servicio vendible (shipped 2026-04-20):**
+- **Schema (migration 045):** `products.staff_team_id` nullable FK a `staff_teams` con `ON DELETE SET NULL`. Partial index para queries "has a team" a futuro. Additivo — productos existentes intactos.
+- **Tenant isolation en Create/Update:** `CRUDHandler.SetStaffTeamRepo` opcional; cuando está wireado, valida que el `staff_team_id` del payload pertenezca al mismo user antes de persistir. Bloquea que un cliente malicioso adjunte el team de otro organizador.
+- **Cliente orquesta, backend solo persiste:** no hay endpoint de expansión ni tabla snapshot. Cuando el organizador agrega un Product con team a un evento, el cliente fetchea el team via `/api/staff/teams/{id}` (Ola 2) y copia los miembros a `event_staff` usando el mismo UPSERT. Consistente con cómo `EventProduct` copia `unit_price` al agregar.
+- **Snapshot semantics:** la expansión ocurre AT-ADD-TIME. Editar el team después NO afecta eventos ya creados. Si el organizador quiere que un evento refleje cambios al team, debe quitar y re-agregar el Product.
+- **Dedupe automática:** miembros ya presentes en el evento (por asignación manual u otra expansión) se saltean — sin filas duplicadas.
+- **Coexiste con `recipe`:** un Product puede tener `staff_team_id` Y `recipe`. No forzamos exclusión (ej. "servicio de mesa Plata" con insumos + 10 meseros).
+- **UI cross-platform:** Product form suma selector "Equipo asociado" (opcional, default "Sin equipo"). En el EventForm, cuando se agrega un Product con team, aparece chip "Incluye equipo" en la lista de productos para que el organizador entienda por qué aparecieron filas nuevas en Personal.
+- **Internal margin only:** el organizador ve `Product.price − Σ(event_staff.fee)` en cálculos internos; el cliente solo ve el precio del Product. NO filtramos estructura de costos al cliente.
+- **Sin plan gating** (consistente con Olas 1 y 2).
+
 **Roadmap siguiente (no implementado):**
-- **Ola 3 — Staff como servicio vendible:** `Product.staff_team_id` opcional para cobrar al cliente con markup vs. costo interno. Reutiliza Products/Quotes (no un tercer tipo de item). Requiere decisiones de negocio: cómo se congela el team al agregar al Quote, cómo se muestra el margen (price − sum(fees)), qué pasa al editar el team tras asignarlo.
+- **Visualización de margen:** mostrar rentabilidad por evento en el EventSummary / Dashboard (Product price − sum fees). Schema listo, solo falta UI.
+- **Plan gating:** cuando validemos que "vender staffing" es premium, mover la feature a Pro+ via `canCreateProductWithTeam` check.
+- **Removal link:** quitar un Product del evento NO quita el staff expandido (decisión de diseño v1). Si el feedback pide lo opuesto, agregar opt-in flag en el Product.
 - **Phase 3:** login del colaborador vía `invited_user_id` — intacto como estaba planeado.
 
 **Navegación:**

--- a/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
+++ b/obsidian/Solennix/PRD/11_CURRENT_STATUS.md
@@ -17,6 +17,18 @@ status: active
 **Fecha:** Abril 2026
 **Version:** 1.2
 
+> [!info] 2026-04-20 — Personal Ola 3: productos con equipo asociado (venta de "servicio de meseros")
+> Tercera y última ola de la expansión de Personal. Cierra el ciclo comercial: el organizador ya podía (1) catalogar colaboradores con costo (Phase 1), (2) organizar turnos y RSVP (Ola 1), (3) agrupar en equipos (Ola 2). Ahora puede (4) vender el servicio del equipo como Product con precio al cliente, manteniendo el costo interno por fee.
+> - **Backend (migration 045)**: `products.staff_team_id` nullable FK con `ON DELETE SET NULL`. Partial index para queries de "products con team" a futuro. Aditivo — productos existentes intactos.
+> - **Tenant isolation opcional**: `CRUDHandler.SetStaffTeamRepo` (siguiendo el patrón de SetNotifier/SetEmailService). Cuando está wireado en main.go, valida que el `staff_team_id` del payload pertenezca al mismo user antes de persistir. Evita que un cliente adjunte el team de otro organizador.
+> - **Cliente orquesta expansión**: backend NO hace auto-expansion. Cuando el organizador agrega un Product con team al EventForm, el cliente fetchea `/api/staff/teams/{id}` (endpoint de Ola 2), expande los miembros y los agrega a `selectedStaff` reusando la dedupe y el UPSERT de Ola 2. Consistente con cómo EventProduct copia `unit_price` al agregar (no refresh dinámico).
+> - **Semantics snapshot-at-add-time**: si el team se edita después de agregar el Product al evento, el evento NO se actualiza. Si el organizador quiere refrescar, quita y re-agrega el Product. Clara, predecible.
+> - **Coexiste con Recipe**: un Product puede tener `staff_team_id` Y `recipe`. No forzamos exclusión.
+> - **UI cross-platform**: Product form suma selector opcional "Equipo asociado" (default "Sin equipo") con texto explicativo de qué pasa al agregar al evento. Chip "Incluye equipo" en la lista de productos dentro del EventForm.
+> - **Margen interno solamente**: organizador ve `Product.price − Σ(fees)` en cálculos internos. Cliente final NO ve estructura de costos.
+> - **Sin plan gating** (consistente con Olas 1 y 2).
+> - **Decisiones de producto pospuestas**: visualización de rentabilidad en Dashboard/EventSummary; plan gating si validamos que es premium; link quitar-Product→quitar-staff (v1 deja el staff expandido intacto).
+
 > [!info] 2026-04-19 — Personal Ola 2: equipos (staff_teams + staff_team_members) para asignar cuadrillas en bloque
 > Segunda ola de expansión de Personal (después de Ola 1 del mismo día). Motivación: sin equipos, el mismo organizador que tiene una plantilla recurrente de 10 meseros tiene que agregarlos uno por uno a cada evento. Con Ola 2 los agrupa una vez y los asigna a un evento con un solo toque. Escala el modelo a empresas de catering sin cambiar el flujo base de Staff catalog.
 > - **Backend (migration 044)**: `staff_teams` (user_id, name, role_label, notes, timestamps) + `staff_team_members` (team_id, staff_id, is_lead, position) con PK compuesta. Cascade a ambos lados; miembros sin fee/status (esos siguen viviendo per-assignment en `event_staff`, así un equipo puede asignarse a varios eventos con distintos costos/RSVPs).

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -77,6 +77,7 @@ interface Product {
   name: string;
   category: string;
   base_price: number;
+  staff_team_id?: string | null;
 }
 
 // Convert an ISO8601 UTC string (e.g. the backend's shift_start) to the
@@ -582,6 +583,35 @@ export const EventForm: React.FC = () => {
     }
   }, [quickQuoteData, id, setValue]);
 
+  // Ola 3 — si el product lleva staff_team_id, expandimos los miembros del
+  // equipo como filas de staff en el form (snapshot at add-time). No bloquea
+  // el add en error: logea y sigue. Dedupe vía handleAddTeamMembers.
+  const expandProductTeam = async (product: Product) => {
+    if (!product.staff_team_id) return;
+    try {
+      const team = await staffService.getTeam(product.staff_team_id);
+      const members = [...(team.members ?? [])].sort((a, b) => a.position - b.position);
+      const rows: SelectedStaffAssignment[] = members.map((m) => {
+        const staff = staffCatalog.find((s) => s.id === m.staff_id);
+        const staffRole = staff?.role_label ?? null;
+        const teamRole = team.role_label ?? null;
+        const roleOverride = staffRole ? "" : teamRole ?? "";
+        return {
+          staff_id: m.staff_id,
+          fee_amount: null,
+          role_override: roleOverride,
+          notes: "",
+          shift_start: null,
+          shift_end: null,
+          status: null,
+        };
+      });
+      if (rows.length > 0) handleAddTeamMembers(rows);
+    } catch (err) {
+      logError("Error expanding product staff team", err);
+    }
+  };
+
   const handleAddProduct = () => {
     if (products.length > 0) {
       const product = products[0];
@@ -594,6 +624,7 @@ export const EventForm: React.FC = () => {
           discount: 0,
         },
       ]);
+      void expandProductTeam(product);
     }
   };
 
@@ -611,6 +642,7 @@ export const EventForm: React.FC = () => {
   };
 
   const handleProductChange = (index: number, field: string, value: string | number | boolean) => {
+    let productToExpand: Product | null = null;
     setSelectedProducts((prev) => {
       const next = [...prev];
       next[index] = { ...next[index], [field]: value };
@@ -619,10 +651,13 @@ export const EventForm: React.FC = () => {
         if (product) {
           next[index].price = product.base_price;
           next[index].discount = 0;
+          // Ola 3 — si el nuevo product lleva team asociado, expandir.
+          if (product.staff_team_id) productToExpand = product;
         }
       }
       return next;
     });
+    if (productToExpand) void expandProductTeam(productToExpand);
   };
 
   const handleAddExtra = () => {

--- a/web/src/pages/Events/components/EventProducts.tsx
+++ b/web/src/pages/Events/components/EventProducts.tsx
@@ -12,6 +12,7 @@ interface Product {
   name: string;
   category: string;
   base_price: number;
+  staff_team_id?: string | null;
 }
 
 interface SelectedProduct {
@@ -74,7 +75,10 @@ export const EventProducts: React.FC<EventProductsProps> = ({
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-          {selectedProducts.map((item, index) => (
+          {selectedProducts.map((item, index) => {
+            const selectedProduct = products.find((p) => p.id === item.product_id);
+            const hasTeam = !!selectedProduct?.staff_team_id;
+            return (
             <SortableItem key={itemIds[index]} id={itemIds[index]}>
               <div className="bg-surface-alt p-4 rounded-xl relative group border border-border shadow-xs">
                 <button
@@ -87,7 +91,18 @@ export const EventProducts: React.FC<EventProductsProps> = ({
                 </button>
 
                 <div className="mb-2 pr-6">
-                  <label htmlFor={`product-select-${index}`} className="block text-xs text-text-secondary mb-1">Producto</label>
+                  <div className="flex items-center justify-between mb-1">
+                    <label htmlFor={`product-select-${index}`} className="block text-xs text-text-secondary">Producto</label>
+                    {hasTeam && (
+                      <span
+                        className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-accent/10 text-accent dark:bg-accent/20"
+                        title="Este producto agrega automáticamente miembros del equipo asociado como personal"
+                      >
+                        <Users className="h-3 w-3" aria-hidden="true" />
+                        Incluye equipo
+                      </span>
+                    )}
+                  </div>
                   <select
                     id={`product-select-${index}`}
                     value={item.product_id}
@@ -183,7 +198,8 @@ export const EventProducts: React.FC<EventProductsProps> = ({
                 )}
               </div>
             </SortableItem>
-          ))}
+            );
+          })}
         </SortableContext>
       </DndContext>
 

--- a/web/src/pages/Products/ProductForm.test.tsx
+++ b/web/src/pages/Products/ProductForm.test.tsx
@@ -144,6 +144,7 @@ describe('ProductForm', () => {
         image_url: null,
         is_active: true,
         recipe: null,
+        staff_team_id: null,
       });
     });
     await waitFor(() => {
@@ -190,6 +191,7 @@ describe('ProductForm', () => {
         base_price: 60,
         image_url: null,
         is_active: true,
+        staff_team_id: null,
       });
     });
   });

--- a/web/src/pages/Products/ProductForm.tsx
+++ b/web/src/pages/Products/ProductForm.tsx
@@ -14,6 +14,7 @@ import {
   Fuel,
   Camera,
   X,
+  Users,
 } from "lucide-react";
 import { ProductIngredient } from "../../types/entities";
 import { logError } from "../../lib/errorHandler";
@@ -22,6 +23,7 @@ import { usePlanLimits } from "../../hooks/usePlanLimits";
 import { UpgradeBanner } from "../../components/UpgradeBanner";
 import { useProduct, useProductIngredients, useCreateProduct, useUpdateProduct, useUploadProductImage } from "../../hooks/queries/useProductQueries";
 import { useInventoryItems } from "../../hooks/queries/useInventoryQueries";
+import { useStaffTeams } from "../../hooks/queries/useStaffQueries";
 
 const productSchema = z.object({
   name: z.string().min(2, "El nombre debe tener al menos 2 caracteres"),
@@ -39,6 +41,7 @@ export const ProductForm: React.FC = () => {
   const [isActive, setIsActive] = useState(true);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [staffTeamId, setStaffTeamId] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -49,6 +52,7 @@ export const ProductForm: React.FC = () => {
   } = usePlanLimits();
 
   const { data: inventoryItems = [] } = useInventoryItems();
+  const { data: staffTeams = [] } = useStaffTeams();
   const { data: existingProduct, isLoading: isLoadingProduct } = useProduct(id);
   const { data: existingIngredients } = useProductIngredients(id);
   const createProduct = useCreateProduct();
@@ -96,6 +100,7 @@ export const ProductForm: React.FC = () => {
         setImageUrl(existingProduct.image_url);
         setImagePreview(existingProduct.image_url);
       }
+      setStaffTeamId(existingProduct.staff_team_id ?? null);
     }
   }, [existingProduct, reset]);
 
@@ -268,7 +273,12 @@ export const ProductForm: React.FC = () => {
       updateProduct.mutate(
         {
           id,
-          product: { ...data, image_url: imageUrl || null, is_active: isActive },
+          product: {
+            ...data,
+            image_url: imageUrl || null,
+            is_active: isActive,
+            staff_team_id: staffTeamId,
+          },
           ingredients: ingredientsToSave,
         },
         { onSuccess: () => navigate("/products") },
@@ -277,7 +287,13 @@ export const ProductForm: React.FC = () => {
       // `user_id` no se envía — el backend lo toma del JWT.
       createProduct.mutate(
         {
-          product: { ...data, image_url: imageUrl || null, is_active: isActive, recipe: null },
+          product: {
+            ...data,
+            image_url: imageUrl || null,
+            is_active: isActive,
+            recipe: null,
+            staff_team_id: staffTeamId,
+          },
           ingredients: ingredientsToSave,
         },
         { onSuccess: () => navigate("/products") },
@@ -887,6 +903,46 @@ export const ProductForm: React.FC = () => {
               </p>
             </div>
           )}
+        </div>
+
+        {/* Equipo asociado (Ola 3 — opcional) */}
+        <div className="bg-card shadow-sm border border-border px-4 py-8 rounded-2xl sm:p-10 flex flex-col">
+          <h3 className="text-lg leading-6 font-medium text-text mb-4 flex items-center">
+            <Users className="h-5 w-5 mr-2 text-accent" aria-hidden="true" />
+            Equipo asociado
+          </h3>
+          <p className="text-xs text-text-secondary mb-4">
+            Agregá un equipo para vender el servicio de meseros con este producto.
+            Cuando agregues este producto a un evento, se asignan automáticamente
+            los miembros del equipo como personal.
+          </p>
+
+          <div>
+            <label
+              htmlFor="staff-team-select"
+              className="block text-sm font-medium text-text-secondary mb-2"
+            >
+              Equipo
+            </label>
+            <select
+              id="staff-team-select"
+              value={staffTeamId ?? ""}
+              onChange={(e) =>
+                setStaffTeamId(e.target.value === "" ? null : e.target.value)
+              }
+              className="w-full rounded-xl shadow-sm border border-border bg-card text-text p-3 transition-shadow focus:ring-2 focus:ring-primary/20"
+              aria-label="Seleccionar equipo asociado al producto"
+            >
+              <option value="">Sin equipo</option>
+              {staffTeams.map((team) => (
+                <option key={team.id} value={team.id}>
+                  {team.name}
+                  {team.role_label ? ` · ${team.role_label}` : ""}
+                  {team.member_count != null ? ` · ${team.member_count} miembros` : ""}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         {/* Botones de acción */}

--- a/web/src/types/entities.ts
+++ b/web/src/types/entities.ts
@@ -68,13 +68,22 @@ export type EventInsert =
 export type EventUpdate = Partial<Omit<Event, 'id' | 'user_id' | 'created_at' | 'updated_at' | 'client'>>
 
 // ===== Product =====
-export type Product = components['schemas']['Product']
+// Spec declara la shape básica. `staff_team_id` (Ola 3) es un FK opcional
+// que el backend ya persiste pero aún no está formalizado en el spec — se
+// extiende localmente hasta que openapi lo incluya. Cuando un Product con
+// staff_team_id se agrega a un evento, el cliente expande los miembros del
+// equipo como asignaciones de staff (snapshot at add-time, ver EventForm).
+type ProductSchema = components['schemas']['Product']
+export type Product = ProductSchema & {
+    staff_team_id?: string | null
+}
 
 export type ProductInsert =
-    Omit<Product, 'id' | 'user_id' | 'created_at' | 'updated_at' | 'recipe' | 'is_active' | 'image_url'> & {
+    Omit<Product, 'id' | 'user_id' | 'created_at' | 'updated_at' | 'recipe' | 'is_active' | 'image_url' | 'staff_team_id'> & {
         recipe?: string | null
         is_active?: boolean
         image_url?: string | null
+        staff_team_id?: string | null
     }
 export type ProductUpdate = Partial<Omit<Product, 'id' | 'user_id' | 'created_at' | 'updated_at'>>
 


### PR DESCRIPTION
## Summary

Ola 3 of the Personal expansion. Closes the commercial loop: the organizer can now (1) catalog collaborators with cost (Phase 1), (2) manage shifts + RSVP (Ola 1), (3) group into teams (Ola 2), and **(4) sell the team's service as a Product with a client-facing price, keeping the per-person fee as internal cost**.

**Depends on Ola 2 (PR #83).** Rebase after #83 merges, or merge #83 first. Main already has Ola 1 (PR #82 merged).

### Changes

**Backend (migration 045)**
- `products.staff_team_id` nullable FK to `staff_teams` with `ON DELETE SET NULL`. Partial index for future "has-a-team" queries. Additive — existing products untouched.
- `CRUDHandler.SetStaffTeamRepo` optional setter (mirrors existing `SetNotifier` / `SetEmailService` pattern). When wired, `CreateProduct` / `UpdateProduct` verify that `staff_team_id` in the payload belongs to the same user before persisting. Blocks cross-tenant attaches.
- Product repo SELECT/INSERT/UPDATE include the new column.

**Clients — iOS / Android / Web**
- Product form gains an optional "Equipo asociado" section (default "Sin equipo") with inline help: "Cuando agregues este producto a un evento, se asignan automáticamente los miembros del equipo como personal."
- When a Product with `staff_team_id` is added to an EventForm, the client fetches the team via `/api/staff/teams/{id}` (Ola 2 endpoint), expands its members into `event_staff` rows using the existing Ola 2 dedup + `role_override` fallback logic. Backend stays a dumb store for the relationship — no server-side auto-expansion, no snapshot table.
- Web additionally triggers expansion from `handleProductChange` (not just `handleAddProduct`), because the default row picks `products[0]` and users typically pick the real product via the row select.
- "Incluye equipo" chip/badge on Product rows inside EventForm so the organizer sees why staff rows appeared.
- Android bumps Room DB 9→10 with `MIGRATION_9_10` adding the column to `cached_products`.

**Design decisions (locked)**
- **Snapshot at add-time.** Editing the team later does NOT ripple to events already saved. Consistent with how `EventProduct` copies `unit_price` at add-time rather than resolving dynamically from `Product`.
- **Client-orchestrated, no backend magic.** Keeps the server predictable and avoids a bespoke expansion endpoint.
- **Coexists with `recipe`.** A Product can carry both ingredients and a team (e.g. "Servicio de mesa Plata" with insumos + 10 meseros).
- **Internal-only margin.** Organizer sees `price − sum(fees)` in internal calculations; the client-facing output does not leak the fee structure.
- **No plan gating** (consistent with Olas 1 and 2).

## Test plan

- [ ] Backend: `cd backend && go build ./... && go test ./...` passes
- [ ] iOS: `cd ios && xcodebuild -scheme Solennix -destination 'platform=iOS Simulator,name=iPhone 16' build` passes (✅ verified)
- [ ] Android: `cd android && JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew assembleDebug` passes (✅ verified)
- [ ] Web: `cd web && npm run check && npm run build && npm run test:run` passes (✅ verified — 1137 tests)
- [ ] Migration 045 up/down reversible
- [ ] Create a Product with `staff_team_id` referencing a team with 3 members → add it to an event → 3 staff rows appear with the team's `role_label` as role_override fallback
- [ ] Re-adding the same Product does NOT duplicate staff rows (dedupe)
- [ ] Removing the Product from the event does NOT auto-remove the expanded staff (v1 design — user removes manually if desired)
- [ ] Deleting the team keeps the Product but sets `staff_team_id` to NULL (FK `SET NULL`)
- [ ] Cross-tenant attempt: User A creates Product referencing User B's team → 400

## Open questions (non-blocking, flagged for product review)

1. **Team deleted after binding a Product** — on the Product edit form, the picker currently falls back to "Sin equipo" without indicating the Product used to have a team. Could show "Equipo eliminado" as a distinct placeholder. Not critical for v1. (iOS agent reported.)
2. **Duplicate event flow** — when duplicating an event, `staffTeamId` is preserved on the Product copy but the expansion is NOT re-triggered (prefill path bypasses `addProduct`). Aligned with the existing "don't copy dates / don't copy payments" convention, but worth a product decision. (iOS agent reported.)

## Roadmap next (explicitly out of scope)

- Visualize margin/rentabilidad in EventSummary / Dashboard (schema is ready, only UI work).
- Plan gating if we validate "sell staffing" as a premium value prop.
- Opt-in "remove expanded staff when Product is removed from event" flag.
- Phase 3 (collaborator login via `invited_user_id`) — unchanged.

## Note on dependencies

This branch is based on `feat/personal-ola-2` (PR #83). The commits unique to this PR are:
1. `feat(backend)` — migration 045 + Product model + tenant isolation
2. `feat(web)` — Product form selector + EventForm auto-expansion + badge
3. `feat(android)` — same as web, plus Room 9→10 migration
4. `feat(ios)` — same as web
5. `docs(prd)` — §15.ter Ola 3 subsection