### PR TITLE
fix(infra): align deploy environment name with Production

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,31 +1,47 @@
 platform:ios:
-  - "ios/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "ios/**"
 
 platform:android:
-  - "android/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "android/**"
 
 platform:web:
-  - "web/**"
-  - "remotion/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "web/**"
+          - "remotion/**"
 
 platform:backend:
-  - "backend/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "backend/**"
 
 platform:cross-platform:
-  - "docs/PRD/**"
-  - "openspec/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/PRD/**"
+          - "openspec/**"
 
 type:docs:
-  - "docs/**"
-  - "README.md"
-  - "AGENTS.md"
-  - "CLAUDE.md"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "README.md"
+          - "AGENTS.md"
+          - "CLAUDE.md"
 
 type:infra:
-  - ".github/**"
-  - "infra/**"
-  - "docker-compose.yml"
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "infra/**"
+          - "docker-compose.yml"
 
 type:test:
-  - "testsprite_tests/**"
-  - "**/*test*"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "testsprite_tests/**"
+          - "**/*test*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     timeout-minutes: 20
     environment:
-      name: production
+      name: Production
 
     steps:
       - name: Execute deployment script on VPS


### PR DESCRIPTION
Closes #156

## What
- update deploy workflow environment name from `production` to `Production`
- ensure deployment binds to the existing GitHub Environment configuration

## Why
- environment names are case-sensitive in GitHub Actions
- mismatch can bypass intended environment-scoped rules/secrets

## Scope
- [ ] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [x] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: minimal; workflow metadata change only
- Rollback: revert commit `d1b8fff0`
