### PR TITLE
refactor(android): remove unused Events Paging3 pipeline

### DIFF
--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/EventRepository.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/EventRepository.kt
@@ -1,6 +1,5 @@
 package com.creapolis.solennix.core.data.repository
 
-import com.creapolis.solennix.core.data.paging.RemotePagingSource
 import com.creapolis.solennix.core.database.dao.EventDao
 import com.creapolis.solennix.core.database.dao.EventItemDao
 import com.creapolis.solennix.core.database.entity.asEntity
@@ -8,10 +7,6 @@ import com.creapolis.solennix.core.database.entity.asExternalModel
 import com.creapolis.solennix.core.database.entity.SyncStatus
 import com.creapolis.solennix.core.model.*
 import com.creapolis.solennix.core.network.*
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.map
 import io.ktor.util.reflect.typeInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -22,24 +17,6 @@ import javax.inject.Singleton
 
 interface EventRepository {
     fun getEvents(): Flow<List<Event>>
-    fun getEventsPaging(
-        query: String = "",
-        status: String? = null,
-        startDate: String? = null,
-        endDate: String? = null
-    ): Flow<PagingData<Event>>
-
-    /**
-     * Returns a [PagingData] stream that loads pages directly from the remote API
-     * using server-side pagination. Use this when online for fresh data with
-     * sort/order support.
-     */
-    fun getEventsRemotePaging(
-        sort: String = "event_date",
-        order: String = "desc",
-        status: String? = null,
-        query: String = ""
-    ): Flow<PagingData<Event>>
     fun getUpcomingEvents(limit: Int = 5): Flow<List<Event>>
     fun getEventCountForMonth(monthStart: String, monthEnd: String): Flow<Int>
     suspend fun getEvent(id: String): Event?
@@ -100,51 +77,6 @@ class OfflineFirstEventRepository @Inject constructor(
 
     override fun getEvents(): Flow<List<Event>> =
         eventDao.getEvents().map { it.map { entity -> entity.asExternalModel() } }
-
-    override fun getEventsPaging(
-        query: String, 
-        status: String?,
-        startDate: String?,
-        endDate: String?
-    ): Flow<PagingData<Event>> =
-        Pager(
-            config = PagingConfig(
-                pageSize = 20,
-                enablePlaceholders = true
-            ),
-            pagingSourceFactory = { eventDao.getEventsPaging(query, status, startDate, endDate) }
-        ).flow.map { pagingData ->
-            pagingData.map { it.asExternalModel() }
-        }
-
-    override fun getEventsRemotePaging(
-        sort: String,
-        order: String,
-        status: String?,
-        query: String
-    ): Flow<PagingData<Event>> {
-        val params = buildMap {
-            put("sort", sort)
-            put("order", order)
-            if (!status.isNullOrBlank()) put("status", status)
-            if (query.isNotBlank()) put("q", query)
-        }
-        return Pager(
-            config = PagingConfig(
-                pageSize = 20,
-                enablePlaceholders = true
-            ),
-            pagingSourceFactory = {
-                RemotePagingSource<Event>(
-                    apiService = apiService,
-                    endpoint = Endpoints.EVENTS,
-                    params = params,
-                    typeInfo = typeInfo<PaginatedResponse<Event>>(),
-                    pageSize = 20
-                )
-            }
-        ).flow
-    }
 
     override fun getUpcomingEvents(limit: Int): Flow<List<Event>> =
         eventDao.getUpcomingEvents(limit).map { it.map { entity -> entity.asExternalModel() } }

--- a/android/core/database/src/main/java/com/creapolis/solennix/core/database/dao/EventDao.kt
+++ b/android/core/database/src/main/java/com/creapolis/solennix/core/database/dao/EventDao.kt
@@ -1,6 +1,5 @@
 package com.creapolis.solennix.core.database.dao
 
-import androidx.paging.PagingSource
 import androidx.room.*
 import com.creapolis.solennix.core.database.entity.CachedEvent
 import kotlinx.coroutines.flow.Flow
@@ -12,27 +11,6 @@ interface EventDao {
 
     @Query("SELECT * FROM events ORDER BY event_date DESC")
     fun getEvents(): Flow<List<CachedEvent>>
-
-    @Transaction
-    @Query("""
-        SELECT * FROM events 
-        WHERE (:status IS NULL OR status = :status)
-        AND (:startDate IS NULL OR event_date >= :startDate)
-        AND (:endDate IS NULL OR event_date <= :endDate)
-        AND (
-            :query = '' OR 
-            service_type LIKE '%' || :query || '%' OR 
-            location LIKE '%' || :query || '%' OR 
-            city LIKE '%' || :query || '%'
-        )
-        ORDER BY event_date DESC
-    """)
-    fun getEventsPaging(
-        query: String = "", 
-        status: String? = null,
-        startDate: String? = null,
-        endDate: String? = null
-    ): PagingSource<Int, CachedEvent>
 
     @Query("SELECT * FROM events WHERE id = :id")
     suspend fun getEvent(id: String): CachedEvent?

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
@@ -16,8 +16,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
 import java.time.LocalDate
 
 private const val TAG = "EventListVM"
@@ -96,17 +94,6 @@ class EventListViewModel @Inject constructor(
             error = params[5] as String?
         )
     }
-
-    val pagedEvents: Flow<PagingData<Event>> = filterState
-        .debounce(300)
-        .flatMapLatest { filters ->
-            eventRepository.getEventsPaging(
-                query = filters.query,
-                status = filters.status?.name,
-                startDate = filters.startDate?.toString(),
-                endDate = filters.endDate?.toString()
-            )
-        }.cachedIn(viewModelScope)
 
     /// Bundle sort axis state with the ongoing updatingStatusEventId into a
     /// single upstream so the main `combine` stays under the 5-arg ceiling.


### PR DESCRIPTION
Closes #90

## What
- remove unused Events Paging3 flow from `EventListViewModel`
- remove unused paging API methods from `EventRepository`
- remove unused paged DAO query from `EventDao`

## Why
- Events list no longer consumes PagingData and uses in-memory sorted/filtered list instead
- keeping dead paging code increases maintenance cost and creates false architecture paths

## Scope
- [ ] Backend
- [ ] Web
- [ ] iOS
- [x] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: low; removes code paths not referenced by feature module
- Rollback: revert commit `c62089fd`
