### PR TITLE
chore(infra): clean CI/deploy warnings from actions and artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,16 @@ jobs:
         working-directory: ./backend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25.x"
           cache-dependency-path: ./backend/go.sum
 
       - name: Set up Node (for OpenAPI linter)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -43,7 +43,8 @@ jobs:
         run: go test -v -coverprofile=coverage.out ./...
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v6
         with:
           files: ./backend/coverage.out
           fail_ci_if_error: false
@@ -57,10 +58,10 @@ jobs:
         working-directory: ./web
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -90,7 +91,8 @@ jobs:
         run: npm run test:coverage || npm run test:run
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v6
         with:
           directory: ./web/coverage
           fail_ci_if_error: false
@@ -107,10 +109,10 @@ jobs:
         working-directory: ./web
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"
@@ -131,8 +133,8 @@ jobs:
         run: npm run test:e2e
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: always()
+        uses: actions/upload-artifact@v5
+        if: ${{ always() && hashFiles('web/playwright-report/**') != '' }}
         with:
           name: playwright-report
           path: ./web/playwright-report/
@@ -146,16 +148,16 @@ jobs:
         working-directory: ./android
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "17"
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
@@ -194,7 +196,7 @@ jobs:
         run: ./gradlew :app:assembleDebug
 
       - name: Upload test reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: failure()
         with:
           name: android-test-reports

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Resolve deploy scope
         id: scope
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const eventName = context.eventName;


### PR DESCRIPTION
## What
- Upgrade GitHub Actions versions in CI/deploy workflows to current majors (`checkout`, `setup-go`, `setup-node`, `setup-java`, `setup-gradle`, `upload-artifact`, `github-script`).
- Skip Codecov upload steps when `CODECOV_TOKEN` is not configured.
- Upload Playwright report artifact only when files exist.

## Why
- Closes #163
- Recent successful runs still produced avoidable warning noise (Node20 deprecation + missing artifact + tokenless Codecov warnings).
- Cleaner annotations improve signal-to-noise for real incidents.

## Scope
- [x] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Major action version changes can alter behavior.
- Rollback: Revert this PR to restore previous workflow versions.