### PR TITLE
refactor(web): clean hooks warnings in EventSummary and auth usage

### DIFF
--- a/web/src/components/AppleSignInButton.tsx
+++ b/web/src/components/AppleSignInButton.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from "react";
 import { api } from "../lib/api";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { useNavigate } from "react-router-dom";
 
 const APPLE_CLIENT_ID = import.meta.env.VITE_APPLE_CLIENT_ID || "";

--- a/web/src/components/GoogleSignInButton.tsx
+++ b/web/src/components/GoogleSignInButton.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from "react";
 import { api } from "../lib/api";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { useNavigate } from "react-router-dom";
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || "";

--- a/web/src/components/OnboardingChecklist.tsx
+++ b/web/src/components/OnboardingChecklist.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 import { CheckCircle2, Circle, X, Users, Package, CalendarPlus, ChevronRight } from 'lucide-react';
 import { useClients } from '../hooks/queries/useClientQueries';
 import { useProducts } from '../hooks/queries/useProductQueries';

--- a/web/src/components/ProtectedRoute.tsx
+++ b/web/src/components/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 
 export const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, loading } = useAuth();

--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
-import { AuthProvider, useAuth } from './AuthContext';
+import { AuthProvider } from './AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 import { api } from '../lib/api';
 import { logError } from '../lib/errorHandler';
 

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -3,10 +3,7 @@ import { api } from '@/lib/api';
 import { logError } from '@/lib/errorHandler';
 import { User } from '@/types/auth';
 import { AuthContext } from './AuthContextInstance';
-import { useAuth } from '@/hooks/useAuth';
 import i18n from '@/i18n/config';
-
-export { AuthContext, useAuth };
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -97,7 +97,7 @@ export function useKeyboardShortcuts() {
       e.preventDefault();
       shortcut.action();
     }
-  }, [currentSection, navigate, shortcuts]);
+  }, [shortcuts]);
 
   useEffect(() => {
     document.addEventListener('keydown', handleKeyDown);

--- a/web/src/hooks/usePlanLimits.ts
+++ b/web/src/hooks/usePlanLimits.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 import { startOfMonth, endOfMonth, format } from 'date-fns';
 import { useEventsByDateRange } from './queries/useEventQueries';
 import { useClients } from './queries/useClientQueries';

--- a/web/src/pages/Clients/ClientForm.tsx
+++ b/web/src/pages/Clients/ClientForm.tsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
-import { useAuth } from "../../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { ArrowLeft, Save, Camera, X } from "lucide-react";
 import { Breadcrumb } from "../../components/Breadcrumb";
 import { logError } from "../../lib/errorHandler";

--- a/web/src/pages/Clients/ClientForm.tsx
+++ b/web/src/pages/Clients/ClientForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useForm } from "react-hook-form";
+import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
@@ -46,11 +46,13 @@ export const ClientForm: React.FC = () => {
     register,
     handleSubmit,
     reset,
-    watch,
+    control,
     formState: { errors },
   } = useForm<ClientFormData>({
     resolver: zodResolver(clientSchema),
   });
+
+  const watchedName = useWatch({ control, name: "name" });
 
   useEffect(() => {
     if (existingClient) {
@@ -151,7 +153,7 @@ export const ClientForm: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <Breadcrumb items={[{ label: t("clients:title"), href: '/clients' }, { label: id ? (watch("name") || t("clients:details.edit")) : t("clients:new_client") }]} />
+      <Breadcrumb items={[{ label: t("clients:title"), href: '/clients' }, { label: id ? (watchedName || t("clients:details.edit")) : t("clients:new_client") }]} />
       <div className="flex items-center justify-between">
         <div className="flex items-center">
           <button

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -5,7 +5,7 @@ import { Dashboard } from './Dashboard';
 import { eventService } from '../services/eventService';
 import { inventoryService } from '../services/inventoryService';
 import { paymentService } from '../services/paymentService';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 import { productService } from '../services/productService';
 import { clientService } from '../services/clientService';
 

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { Event, Payment, InventoryItem } from "../types/entities";
 import { addDays, format, startOfMonth, endOfMonth } from "date-fns";
 import { es, enUS } from "date-fns/locale";

--- a/web/src/pages/Events/EventSummary.tsx
+++ b/web/src/pages/Events/EventSummary.tsx
@@ -71,7 +71,7 @@ import { queryKeys } from "@/hooks/queries/queryKeys";
 import clsx from "clsx";
 import { ContractTemplateError, renderContractTemplate } from "@/lib/contractTemplate";
 import { renderFormattedReact } from "@/lib/inlineFormatting";
-import type { Event, Client, User, EventExtra, EventEquipment, EventSupply, EventStaff as EventStaffType, ProductIngredient } from "@/types/entities";
+import type { Event, Client, User, EventExtra, EventEquipment, EventSupply, EventStaff as EventStaffType, ProductIngredient, Payment } from "@/types/entities";
 import { aggregateIngredients } from "./lib/aggregateIngredients";
 
 // API response types — backend returns `client` (singular)
@@ -105,7 +105,12 @@ type ProductIngredientWithInventory = ProductIngredient & {
   inventory?: { ingredient_name?: string; unit?: string; unit_cost?: number; current_stock?: number } | null;
 };
 
+type EventPhotoItem = { id: string; url: string };
+
 type ViewMode = "summary" | "ingredients" | "contract" | "payments" | "photos" | "checklist";
+
+const EMPTY_ARRAY: never[] = [];
+const asArray = <T,>(value: unknown): T[] => (Array.isArray(value) ? (value as T[]) : (EMPTY_ARRAY as T[]));
 
 
 export const EventSummary: React.FC = () => {
@@ -119,22 +124,22 @@ export const EventSummary: React.FC = () => {
   // ── 6 parallel queries via React Query ──
   const { data: eventRaw = null, isLoading: eventLoading } = useEvent(id);
   const event = eventRaw as EventWithClient | null;
-  const { data: productsRaw = [], isLoading: productsLoading } = useEventProducts(id);
-  const products = Array.isArray(productsRaw) ? productsRaw : [];
-  const { data: extrasRaw = [] } = useEventExtras(id);
-  const extras = Array.isArray(extrasRaw) ? extrasRaw : [];
-  const { data: equipmentRaw = [] } = useEventEquipment(id);
-  const equipment = Array.isArray(equipmentRaw) ? equipmentRaw : [];
-  const { data: suppliesRaw = [] } = useEventSupplies(id);
-  const supplies = Array.isArray(suppliesRaw) ? suppliesRaw : [];
-  const { data: eventPhotosRaw = [] } = useEventPhotos(id);
-  const eventPhotos = Array.isArray(eventPhotosRaw) ? eventPhotosRaw : [];
-  const { data: eventStaffRaw = [] } = useEventStaff(id);
-  const eventStaff = Array.isArray(eventStaffRaw) ? eventStaffRaw : [];
+  const { data: productsRaw = EMPTY_ARRAY, isLoading: productsLoading } = useEventProducts(id);
+  const products = asArray<EventProductWithDetails>(productsRaw);
+  const { data: extrasRaw = EMPTY_ARRAY } = useEventExtras(id);
+  const extras = asArray<EventExtra>(extrasRaw);
+  const { data: equipmentRaw = EMPTY_ARRAY } = useEventEquipment(id);
+  const equipment = asArray<EventEquipment>(equipmentRaw);
+  const { data: suppliesRaw = EMPTY_ARRAY } = useEventSupplies(id);
+  const supplies = asArray<EventSupply>(suppliesRaw);
+  const { data: eventPhotosRaw = EMPTY_ARRAY } = useEventPhotos(id);
+  const eventPhotos = asArray<EventPhotoItem>(eventPhotosRaw);
+  const { data: eventStaffRaw = EMPTY_ARRAY } = useEventStaff(id);
+  const eventStaff = asArray<EventStaffType>(eventStaffRaw);
   const addEventPhotoMutation = useAddEventPhoto(id);
   const deleteEventPhotoMutation = useDeleteEventPhoto(id);
-  const { data: paymentsRaw = [] } = usePaymentsByEvent(id);
-  const payments = Array.isArray(paymentsRaw) ? paymentsRaw : [];
+  const { data: paymentsRaw = EMPTY_ARRAY } = usePaymentsByEvent(id);
+  const payments = asArray<Payment>(paymentsRaw);
   const deleteEventMutation = useDeleteEvent();
 
   const loading = eventLoading || productsLoading;
@@ -166,13 +171,13 @@ export const EventSummary: React.FC = () => {
   }, [products]);
 
   // ── Dependent query: fetch all ingredients for event products ──
-  const { data: allProdIngredientsRaw = [], error: allProdIngredientsError } = useQuery({
+  const { data: allProdIngredientsRaw = EMPTY_ARRAY, error: allProdIngredientsError } = useQuery({
     queryKey: queryKeys.products.ingredientsBatch(productIdsSorted),
     queryFn: () => productService.getIngredientsForProducts(productIdsSorted),
     enabled: productIdsSorted.length > 0,
   });
 
-  const allProdIngredients = Array.isArray(allProdIngredientsRaw) ? allProdIngredientsRaw : [];
+  const allProdIngredients = asArray<ProductIngredientWithInventory>(allProdIngredientsRaw);
 
   useEffect(() => {
     if (allProdIngredientsError) {
@@ -182,7 +187,7 @@ export const EventSummary: React.FC = () => {
 
   // ── Derived: aggregated ingredients (pure computation, no fetch) ──
   const ingredients = useMemo(
-    () => aggregateIngredients(allProdIngredients as ProductIngredientWithInventory[], productQuantities),
+    () => aggregateIngredients(allProdIngredients, productQuantities),
     [allProdIngredients, productQuantities],
   );
 
@@ -203,7 +208,7 @@ export const EventSummary: React.FC = () => {
 
     // Product ingredients with bring_to_event (from already-cached allProdIngredients)
     const aggregated: Record<string, { name: string; quantity: number; unit: string }> = {};
-    (allProdIngredients || [])
+    allProdIngredients
       .filter((ing: ProductIngredientWithInventory) => ing.type === "ingredient" && ing.bring_to_event)
       .forEach((ing: ProductIngredientWithInventory) => {
         const key = ing.inventory_id;
@@ -526,7 +531,7 @@ export const EventSummary: React.FC = () => {
                       const productQuantities = new Map<string, number>();
                       products.forEach((p: EventProductWithDetails) => productQuantities.set(p.product_id, p.quantity || 0));
                       // Use cached ingredients from React Query instead of refetching
-                      const allIngredients = allProdIngredients || [];
+                      const allIngredients = allProdIngredients;
                       const aggregated: Record<string, { name: string; quantity: number; unit: string }> = {};
                       (allIngredients || [])
                         .filter((ing: ProductIngredientWithInventory) => ing.type === 'ingredient' && ing.bring_to_event)

--- a/web/src/pages/Events/components/Payments.tsx
+++ b/web/src/pages/Events/components/Payments.tsx
@@ -24,7 +24,6 @@ interface PaymentsProps {
 export const Payments: React.FC<PaymentsProps> = ({
   eventId,
   totalAmount,
-  userId: _userId,
   eventStatus,
   onStatusChange,
   eventData,

--- a/web/src/pages/Events/components/QuickClientModal.test.tsx
+++ b/web/src/pages/Events/components/QuickClientModal.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { QuickClientModal } from './QuickClientModal';
 import { clientService } from '../../../services/clientService';
 import { logError } from '../../../lib/errorHandler';
-import { useAuth } from '../../../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 
 vi.mock('../../../services/clientService', () => ({
   clientService: {

--- a/web/src/pages/Events/components/QuickClientModal.tsx
+++ b/web/src/pages/Events/components/QuickClientModal.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
 import { Save, Loader2 } from "lucide-react";
 import { clientService } from "../../../services/clientService";
-import { useAuth } from "../../../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { Modal } from "../../../components/Modal";
 
 import { logError } from "../../../lib/errorHandler";

--- a/web/src/pages/Inventory/InventoryForm.tsx
+++ b/web/src/pages/Inventory/InventoryForm.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useForm, Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { useAuth } from "../../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { ArrowLeft, Save } from "lucide-react";
 import { Breadcrumb } from "../../components/Breadcrumb";
 import { usePlanLimits } from "../../hooks/usePlanLimits";

--- a/web/src/pages/Inventory/InventoryForm.tsx
+++ b/web/src/pages/Inventory/InventoryForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useForm, Resolver } from "react-hook-form";
+import { useForm, Resolver, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useAuth } from "@/hooks/useAuth";
@@ -77,7 +77,7 @@ export const InventoryForm: React.FC = () => {
     handleSubmit,
     reset,
     setValue,
-    watch,
+    control,
     formState: { errors },
   } = useForm<InventoryFormData>({
     resolver: zodResolver(inventorySchema) as Resolver<InventoryFormData>,
@@ -89,6 +89,8 @@ export const InventoryForm: React.FC = () => {
       unit_cost: 0,
     },
   });
+
+  const watchedIngredientName = useWatch({ control, name: "ingredient_name" });
 
   useEffect(() => {
     if (existingItem) {
@@ -174,7 +176,7 @@ export const InventoryForm: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <Breadcrumb items={[{ label: t("inventory:title"), href: '/inventory' }, { label: id ? (watch("ingredient_name") || title) : title }]} />
+      <Breadcrumb items={[{ label: t("inventory:title"), href: '/inventory' }, { label: id ? (watchedIngredientName || title) : title }]} />
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div className="flex items-center">
           <button

--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Login } from './Login';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '../hooks/useTheme';
 import { api } from '../lib/api';
 

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
 import { api } from "../lib/api";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import {
   Lock,
   Mail,

--- a/web/src/pages/Pricing.tsx
+++ b/web/src/pages/Pricing.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Shield, Zap, CheckCircle, ArrowRight, Star, Building2 } from 'lucide-react';
 import { subscriptionService } from '../services/subscriptionService';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '@/hooks/useAuth';
 import { logError } from '../lib/errorHandler';
 import { useTranslation } from 'react-i18next';
 

--- a/web/src/pages/Products/ProductForm.tsx
+++ b/web/src/pages/Products/ProductForm.tsx
@@ -4,7 +4,7 @@ import { useForm, Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
-import { useAuth } from "../../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import {
   ArrowLeft,
   Save,

--- a/web/src/pages/Products/ProductForm.tsx
+++ b/web/src/pages/Products/ProductForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useForm, Resolver } from "react-hook-form";
+import { useForm, Resolver, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
@@ -79,7 +79,7 @@ export const ProductForm: React.FC = () => {
     register,
     handleSubmit,
     reset,
-    watch,
+    control,
     formState: { errors },
   } = useForm<ProductFormData>({
     resolver: zodResolver(productSchema) as Resolver<ProductFormData>,
@@ -89,6 +89,8 @@ export const ProductForm: React.FC = () => {
       base_price: 0,
     },
   });
+
+  const watchedProductName = useWatch({ control, name: "name" });
 
   useEffect(() => {
     if (existingProduct) {
@@ -346,7 +348,7 @@ export const ProductForm: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <Breadcrumb items={[{ label: t("products:title"), href: '/products' }, { label: id ? (watch("name") || title) : title }]} />
+      <Breadcrumb items={[{ label: t("products:title"), href: '/products' }, { label: id ? (watchedProductName || title) : title }]} />
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div className="flex items-center">
           <button

--- a/web/src/pages/Register.tsx
+++ b/web/src/pages/Register.tsx
@@ -5,7 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useTranslation } from "react-i18next";
 import { api } from "../lib/api";
-import { useAuth } from "../contexts/AuthContext";
+import { useAuth } from "@/hooks/useAuth";
 import { GoogleSignInButton } from "../components/GoogleSignInButton";
 import { AppleSignInButton } from "../components/AppleSignInButton";
 import {


### PR DESCRIPTION
## What
- Stabilize array defaults in `EventSummary` to avoid hook dependency churn (`asArray` + shared empty fallback).
- Remove unused `userId` prop binding in `Payments`.
- Simplify `useKeyboardShortcuts` callback dependencies to the actual stable source (`shortcuts`).
- Stop re-exporting `useAuth` from `AuthContext` and migrate call sites to `@/hooks/useAuth`.

## Why
- Closes #164
- CI warnings in frontend annotations were adding noise (hooks deps + unused var + fast-refresh mixed export concern).
- Consolidating auth hook imports reduces coupling and avoids context file mixed export warnings.

## Scope
- [ ] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Broad import-path updates could miss an edge usage.
- Rollback: Revert this PR commit to restore prior import/export wiring.