### PR TITLE
chore(infra): bootstrap CI workflow to recover Actions

### DIFF
--- a/.github/workflows/ci-bootstrap.yml
+++ b/.github/workflows/ci-bootstrap.yml
@@ -1,0 +1,25 @@
+name: CI Bootstrap
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ci-bootstrap-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bootstrap:
+    name: Bootstrap Sanity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validate runner execution
+        run: |
+          echo "CI bootstrap workflow is active"
+          echo "Repository: ${{ github.repository }}"
+          echo "Ref: ${{ github.ref }}"


### PR DESCRIPTION
## What
- Add a minimal workflow `.github/workflows/ci-bootstrap.yml`.
- Trigger on `push` and `pull_request` to `main`/`develop`.
- Run a single sanity job to verify GitHub Actions execution path.

## Why
- Closes #169
- Existing CI workflows are currently failing before job scheduling with a workflow file issue.
- A minimal bootstrap workflow restores observability and confirms workflow registration/runner execution.

## Scope
- [x] Backend
- [x] Web
- [x] iOS
- [x] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Adds one extra check while temporary recovery is in progress.
- Rollback: Remove `.github/workflows/ci-bootstrap.yml` once full CI is stable again.