### PR TITLE
chore(infra): add CI Pipeline v2 and restore deploy binding

### DIFF
--- a/.github/workflows/ci-v2.yml
+++ b/.github/workflows/ci-v2.yml
@@ -1,0 +1,203 @@
+name: CI Pipeline v2
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ci-v2-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./backend
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+          cache-dependency-path: ./backend/go.sum
+
+      - name: Set up Node (for OpenAPI linter)
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Validate OpenAPI spec
+        working-directory: .
+        run: npx --yes @redocly/cli@latest lint backend/docs/openapi.yaml
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run Go tests
+        run: go test -v -coverprofile=coverage.out ./...
+
+      - name: Upload coverage reports
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./backend/coverage.out
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ./web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Generate OpenAPI types
+        run: npm run openapi:types
+
+      - name: Verify OpenAPI types are committed and up to date
+        run: |
+          if ! git diff --exit-code src/types/api.ts; then
+            echo "::error::web/src/types/api.ts is out of sync with backend/docs/openapi.yaml."
+            echo "::error::Run 'npm run openapi:types' in web/ and commit the result."
+            exit 1
+          fi
+
+      - name: Type check
+        run: npm run check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run unit tests with coverage
+        run: npm run test:coverage || npm run test:run
+
+      - name: Upload coverage reports
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v6
+        with:
+          directory: ./web/coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Build frontend
+        run: npm run build
+
+  frontend-e2e:
+    name: Frontend E2E Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ./web/package-lock.json
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_API_URL: http://localhost:8080/api
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v5
+        if: ${{ always() && hashFiles('web/playwright-report/**') != '' }}
+        with:
+          name: playwright-report
+          path: ./web/playwright-report/
+          retention-days: 7
+
+  android:
+    name: Android Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./android
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Create google-services.json placeholder
+        run: |
+          cat > app/google-services.json <<'JSON'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "ci-placeholder",
+              "storage_bucket": "ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000",
+                  "android_client_info": { "package_name": "com.solennix.app" }
+                },
+                "oauth_client": [],
+                "api_key": [ { "current_key": "ci-placeholder-key" } ],
+                "services": { "appinvite_service": { "other_platform_oauth_client": [] } }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Build debug APK
+        run: ./gradlew :app:assembleDebug
+
+      - name: Upload test reports
+        uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: android-test-reports
+          path: |
+            ./android/**/build/reports/tests/
+            ./android/**/build/test-results/
+          retention-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ name: Deploy to production
 
 on:
   workflow_run:
-    workflows: ["CI Pipeline"]
+    workflows: ["CI Pipeline v2"]
     types:
       - completed
     branches:


### PR DESCRIPTION
## What
- Add a new full CI workflow at `.github/workflows/ci-v2.yml` with workflow name `CI Pipeline v2`.
- Keep job matrix equivalent to current CI (backend, frontend, frontend-e2e, android).
- Update deploy trigger to listen to `CI Pipeline v2` completion.

## Why
- Closes #171
- Existing CI registration is inconsistent (`ci.yml` deleted/disabled history, `ci-pipeline.yml` failing in 0s).
- A fresh workflow name/path gives a clean Actions registration and restores deterministic deploy chaining.

## Scope
- [x] Backend
- [x] Web
- [ ] iOS
- [x] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Temporary duplicate CI-like workflows during migration period.
- Rollback: Revert this PR and keep bootstrap workflow only while re-planning migration.