### PR TITLE
chore(infra): add CI diagnostics workflow

### DIFF
--- a/.github/workflows/ci-diagnostics.yml
+++ b/.github/workflows/ci-diagnostics.yml
@@ -1,0 +1,57 @@
+name: CI Diagnostics
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ci-diagnostics-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stage-1-checkout:
+    name: Stage 1 - Checkout only
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: echo "stage-1 ok"
+
+  stage-2-node:
+    name: Stage 2 - Node setup
+    runs-on: ubuntu-latest
+    needs: stage-1-checkout
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+      - run: node --version
+
+  stage-3-go:
+    name: Stage 3 - Go setup
+    runs-on: ubuntu-latest
+    needs: stage-2-node
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+      - run: go version
+
+  stage-4-java-gradle:
+    name: Stage 4 - Java and Gradle setup
+    runs-on: ubuntu-latest
+    needs: stage-3-go
+    defaults:
+      run:
+        working-directory: ./android
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v6
+      - run: ./gradlew --version

--- a/.github/workflows/ci-diagnostics.yml
+++ b/.github/workflows/ci-diagnostics.yml
@@ -55,3 +55,43 @@ jobs:
           java-version: "17"
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew --version
+
+  stage-5-backend-smoke:
+    name: Stage 5 - Backend smoke
+    runs-on: ubuntu-latest
+    needs: stage-4-java-gradle
+    defaults:
+      run:
+        working-directory: ./backend
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+          cache-dependency-path: ./backend/go.sum
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+      - name: Validate OpenAPI spec
+        working-directory: .
+        run: npx --yes @redocly/cli@latest lint backend/docs/openapi.yaml
+      - run: go mod download
+      - run: go test -v ./...
+
+  stage-6-frontend-smoke:
+    name: Stage 6 - Frontend smoke
+    runs-on: ubuntu-latest
+    needs: stage-5-backend-smoke
+    defaults:
+      run:
+        working-directory: ./web
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ./web/package-lock.json
+      - run: npm ci --legacy-peer-deps
+      - run: npm run check
+      - run: npm run lint


### PR DESCRIPTION
## What
- Add `.github/workflows/ci-diagnostics.yml`.
- Introduce staged diagnostic jobs to isolate workflow validation failures incrementally:
  1. checkout only
  2. setup-node
  3. setup-go
  4. setup-java + setup-gradle

## Why
- Closes #173
- Existing full CI workflows fail in 0s with workflow-file issues and no job logs.
- Incremental diagnostics gives deterministic fault isolation before restoring full CI.

## Scope
- [x] Backend
- [x] Web
- [ ] iOS
- [x] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Adds extra temporary check noise while diagnostics are active.
- Rollback: Remove diagnostics workflow once root cause is fixed.