### PR TITLE
fix(cross-platform): align public form token status semantics

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -4798,18 +4798,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "409":
-          description: Link has already been used
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: link_already_used
-                  message:
-                    type: string
         "410":
           description: Link has expired or is no longer valid
           content:

--- a/backend/internal/handlers/event_form_handler.go
+++ b/backend/internal/handlers/event_form_handler.go
@@ -448,9 +448,9 @@ func (h *EventFormHandler) SubmitForm(w http.ResponseWriter, r *http.Request) {
 	// Mark link as used (atomic — prevents double submission)
 	if err := h.linkRepo.MarkUsedTx(r.Context(), tx, link.ID, event.ID, client.ID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeJSON(w, http.StatusConflict, map[string]string{
-				"error":   "link_already_used",
-				"message": "Este enlace ya fue utilizado.",
+			writeJSON(w, http.StatusGone, map[string]string{
+				"error":   "link_invalid",
+				"message": "Este enlace ya no es válido o ha expirado.",
 			})
 			return
 		}

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -8,7 +8,7 @@ aliases:
   - Estado Actual
   - Current Status
 date: 2026-03-20
-updated: 2026-04-27
+updated: 2026-04-28
 status: active
 ---
 
@@ -26,6 +26,13 @@ status: active
 
 > [!info] 2026-04-27 — Auditoría Web: paridad backend + UX/landing
 > Se auditó la app web contra el backend real y se documentó el estado en [[../Web/Auditoría Web 2026-04-27]]. Resultado: paridad funcional alta, pero contrato OpenAPI todavía parcial para formularios públicos, portal cliente y staff teams. La web funciona con tipos/manual fetch en esos flujos, pero no puede declararse 100% protegida por OpenAPI hasta cerrar el drift. Oportunidades principales: widgets Dashboard para `top-clients`, `product-demand`, `forecast`; hooks React Query para portal link/unavailable date mutations; landing más orientada al poder operativo real de Solennix.
+
+> [!info] 2026-04-28 — Fix semántica pública de formularios (issue #176)
+> Se unificó la semántica HTTP para links de formulario público en backend y web:
+> - **Backend** (`event_form_handler.go`): cuando `MarkUsedTx` detecta carrera de “ya usado” (`pgx.ErrNoRows`), ahora responde `410 Gone` con `error: link_invalid` (antes devolvía `409 link_already_used`).
+> - **Contrato OpenAPI**: removida respuesta `409` de `POST /api/public/event-forms/{token}`; estado inválido/expirado/usado consolidado en `410`.
+> - **Web** (`PublicEventFormPage` + `PublicFormExpired`): `GET` inicial ahora distingue `404` (link no encontrado) de `410` (inválido/expirado/usado) y muestra copy específica en ambos casos.
+> - **i18n**: nuevas claves `event_form.not_found.*` en `es/public.json` y `en/public.json`.
 
 > [!info] 2026-04-26 — Sprint 7.B: Paywalls mobile coherentes (iOS + Android)
 > Parseo del error 403 `plan_limit_exceeded` del backend como error tipado en ambas plataformas móviles, con UI de upgrade coherente en los 3 formularios de creación (Event/Client/Product). Paridad total con Web.

--- a/docs/Web/Auditoría Web 2026-04-27.md
+++ b/docs/Web/Auditoría Web 2026-04-27.md
@@ -135,18 +135,17 @@ La web consume 4 familias: KPIs, revenue chart, events-by-status y activity. Que
 **Severidad:** Media  
 **Categoría:** UX pública / semántica HTTP
 
-`PublicEventFormPage` marca cualquier `!res.ok` como `expired`. En submit sí distingue `410` y `409` como expirado/usado, pero en `GET` inicial no diferencia:
+`PublicEventFormPage` marcaba cualquier `!res.ok` como `expired`. Con el fix de semántica HTTP, submit usa `410` para link inválido/expirado/usado y `GET` inicial ahora diferencia `404` (no encontrado) vs `410` (inválido/expirado):
 
-- token inexistente
-- link expirado
-- link usado
-- error temporal del servidor
+- token inexistente (`404`)
+- link expirado/usado (`410`)
+- error temporal del servidor (fallback UX de no disponible)
 
-Esto coincide con la deuda backend H4: unificar `404` vs `410` para links públicos.
+Esto quedó alineado con backend H4 mediante issue #176.
 
 **Impacto:** un cliente puede ver un mensaje de link expirado aunque el problema sea un token incorrecto o una falla temporal. Para un flujo público, esa confusión pega directo en confianza.
 
-**Acción recomendada:** después del fix backend #102, ajustar la web para mostrar estados separados: “no encontrado”, “expirado/usado” y “no pudimos cargar, intentá de nuevo”.
+**Estado actual:** implementado en #176 para “no encontrado” vs “expirado/usado”. Queda como mejora futura separar explícitamente “no pudimos cargar, intentá de nuevo” cuando el error sea temporal de red/servidor.
 
 ---
 

--- a/web/src/i18n/locales/en/public.json
+++ b/web/src/i18n/locales/en/public.json
@@ -33,6 +33,10 @@
       "description": "This link has already been used or has expired. Contact the organizer to request a new one.",
       "security_note": "Form links are single-use and have an expiration date to protect your security."
     },
+    "not_found": {
+      "title": "Invalid link",
+      "description": "We couldn't find this link. Check the URL or ask the organizer to share it again."
+    },
     "errors": {
       "name_required": "Name is required",
       "phone_required": "Phone is required",

--- a/web/src/i18n/locales/es/public.json
+++ b/web/src/i18n/locales/es/public.json
@@ -33,6 +33,10 @@
       "description": "Este enlace ya fue utilizado o ha expirado. Contacta al organizador para solicitar uno nuevo.",
       "security_note": "Los enlaces de formulario son de un solo uso y tienen una fecha de expiración para proteger tu seguridad."
     },
+    "not_found": {
+      "title": "Enlace no válido",
+      "description": "No encontramos este enlace. Revisá el link o pedile al organizador que te lo vuelva a compartir."
+    },
     "errors": {
       "name_required": "El nombre es requerido",
       "phone_required": "El teléfono es requerido",

--- a/web/src/pages/PublicEventForm/PublicEventFormPage.tsx
+++ b/web/src/pages/PublicEventForm/PublicEventFormPage.tsx
@@ -66,7 +66,7 @@ export const PublicEventFormPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [formData, setFormData] = useState<FormData | null>(null);
-  const [expired, setExpired] = useState(false);
+  const [formUnavailableReason, setFormUnavailableReason] = useState<"expired" | "not_found" | null>(null);
   const [success, setSuccess] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [selectedProducts, setSelectedProducts] = useState<
@@ -98,7 +98,11 @@ export const PublicEventFormPage: React.FC = () => {
           { signal: controller.signal }
         );
         if (!res.ok) {
-          setExpired(true);
+          if (res.status === 404) {
+            setFormUnavailableReason("not_found");
+          } else {
+            setFormUnavailableReason("expired");
+          }
           return;
         }
         const data: FormData = await res.json();
@@ -107,7 +111,7 @@ export const PublicEventFormPage: React.FC = () => {
         // Ignore aborts from unmount/token change; surface everything else
         // as an expired/unavailable form.
         if ((err as { name?: string })?.name === "AbortError") return;
-        setExpired(true);
+        setFormUnavailableReason("expired");
       } finally {
         if (!controller.signal.aborted) {
           setLoading(false);
@@ -175,7 +179,7 @@ export const PublicEventFormPage: React.FC = () => {
       );
 
       if (res.status === 410 || res.status === 409) {
-        setExpired(true);
+        setFormUnavailableReason("expired");
         return;
       }
       if (!res.ok) {
@@ -203,8 +207,8 @@ export const PublicEventFormPage: React.FC = () => {
     );
   }
 
-  if (expired) {
-    return <PublicFormExpired />;
+  if (formUnavailableReason) {
+    return <PublicFormExpired reason={formUnavailableReason} />;
   }
 
   if (success) {
@@ -217,7 +221,7 @@ export const PublicEventFormPage: React.FC = () => {
   }
 
   if (!formData) {
-    return <PublicFormExpired />;
+    return <PublicFormExpired reason="expired" />;
   }
 
   // Group products by category

--- a/web/src/pages/PublicEventForm/components/PublicFormExpired.tsx
+++ b/web/src/pages/PublicEventForm/components/PublicFormExpired.tsx
@@ -2,8 +2,14 @@ import React from "react";
 import { Clock, AlertCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-export const PublicFormExpired: React.FC = () => {
+interface PublicFormExpiredProps {
+  reason?: "expired" | "not_found";
+}
+
+export const PublicFormExpired: React.FC<PublicFormExpiredProps> = ({ reason = "expired" }) => {
   const { t } = useTranslation("public");
+  const titleKey = reason === "not_found" ? "event_form.not_found.title" : "event_form.expired.title";
+  const descriptionKey = reason === "not_found" ? "event_form.not_found.description" : "event_form.expired.description";
 
   return (
     <div className="min-h-screen bg-bg flex items-center justify-center p-4">
@@ -14,10 +20,10 @@ export const PublicFormExpired: React.FC = () => {
 
         <div className="space-y-2">
           <h1 className="text-2xl font-bold text-text tracking-tight">
-            {t("event_form.expired.title")}
+            {t(titleKey)}
           </h1>
           <p className="text-text-secondary text-sm leading-relaxed">
-            {t("event_form.expired.description")}
+            {t(descriptionKey)}
           </p>
         </div>
 


### PR DESCRIPTION
## What
- Unify public event-form invalid-token semantics to `410 Gone` in backend submit flow race path (`MarkUsedTx` no-rows).
- Remove obsolete `409` response from OpenAPI contract for `POST /api/public/event-forms/{token}`.
- Update web public form UX to distinguish `404` (not found) vs `410` (expired/invalid) with dedicated copy.

## Why
- Public flows were inconsistent (`404`/`409`/`410`) for equivalent invalid-token states, causing ambiguous messaging and lower trust in lead capture UX.
- Closes #176 with a single cross-platform semantic contract.

## Scope
- [x] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [x] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Tests added/updated
- [x] CI green
- [x] Cross-platform parity reviewed
- [x] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Low. Behavioral change limited to invalid-token status mapping and public error copy.
- Rollback: Revert commit `7911abf5` to restore previous semantics.

Closes #176