### PR TITLE
refactor(web): migrate event public link flow to React Query hooks

### DIFF
--- a/web/src/hooks/queries/queryKeys.ts
+++ b/web/src/hooks/queries/queryKeys.ts
@@ -72,6 +72,10 @@ export const queryKeys = {
   eventFormLinks: {
     all: ['eventFormLinks'] as const,
   },
+  eventPublicLinks: {
+    all: ['eventPublicLinks'] as const,
+    byEvent: (eventId: string) => ['eventPublicLinks', 'event', eventId] as const,
+  },
   unavailableDates: {
     all: ['unavailableDates'] as const,
     byRange: (start: string, end: string) =>

--- a/web/src/hooks/queries/useEventPublicLinkQueries.ts
+++ b/web/src/hooks/queries/useEventPublicLinkQueries.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { eventPublicLinkService } from '@/services/eventPublicLinkService'
+import { queryKeys } from './queryKeys'
+
+export function useEventPublicLink(eventId: string) {
+    return useQuery({
+        queryKey: queryKeys.eventPublicLinks.byEvent(eventId),
+        queryFn: () => eventPublicLinkService.getActiveOrNull(eventId),
+        enabled: !!eventId,
+    })
+}
+
+export function useCreateOrRotateEventPublicLink(eventId: string) {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: ({ ttlDays }: { ttlDays?: number } = {}) => eventPublicLinkService.createOrRotate(eventId, ttlDays),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: queryKeys.eventPublicLinks.byEvent(eventId) })
+        },
+    })
+}
+
+export function useRevokeEventPublicLink(eventId: string) {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async (_: void) => eventPublicLinkService.revoke(eventId),
+        onSuccess: () => {
+            queryClient.setQueryData(queryKeys.eventPublicLinks.byEvent(eventId), null)
+            queryClient.invalidateQueries({ queryKey: queryKeys.eventPublicLinks.byEvent(eventId) })
+        },
+    })
+}

--- a/web/src/pages/Events/components/ClientPortalShareCard.tsx
+++ b/web/src/pages/Events/components/ClientPortalShareCard.tsx
@@ -1,6 +1,10 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Share2, Copy, CheckCircle2, RefreshCw, Link2Off, Loader2, ExternalLink } from "lucide-react";
-import { eventPublicLinkService, EventPublicLink } from "../../../services/eventPublicLinkService";
+import {
+  useCreateOrRotateEventPublicLink,
+  useEventPublicLink,
+  useRevokeEventPublicLink,
+} from "../../../hooks/queries/useEventPublicLinkQueries";
 import { useToast } from "../../../hooks/useToast";
 import { logError } from "../../../lib/errorHandler";
 
@@ -19,39 +23,20 @@ interface Props {
  * yet) is treated as a normal state, not an error.
  */
 export const ClientPortalShareCard: React.FC<Props> = ({ eventId }) => {
-  const [link, setLink] = useState<EventPublicLink | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [busy, setBusy] = useState(false);
+  const { data: link, isLoading: loading } = useEventPublicLink(eventId);
+  const createOrRotate = useCreateOrRotateEventPublicLink(eventId);
+  const revokeLink = useRevokeEventPublicLink(eventId);
+
+  const busy = createOrRotate.isPending || revokeLink.isPending;
   const [copied, setCopied] = useState(false);
   const { addToast } = useToast();
 
-  const refresh = useCallback(async () => {
-    try {
-      const l = await eventPublicLinkService.getActive(eventId);
-      setLink(l);
-    } catch {
-      // 404 = no active link yet. Any other failure is already toast-ed
-      // by the api interceptor; nothing extra to do here.
-      setLink(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [eventId]);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
-
   const handleGenerate = async () => {
     try {
-      setBusy(true);
-      const l = await eventPublicLinkService.createOrRotate(eventId);
-      setLink(l);
+      await createOrRotate.mutateAsync({});
       addToast("Enlace generado. Compartilo con tu cliente.", "success");
     } catch (err) {
       logError("ClientPortalShareCard:generate", err);
-    } finally {
-      setBusy(false);
     }
   };
 
@@ -64,14 +49,10 @@ export const ClientPortalShareCard: React.FC<Props> = ({ eventId }) => {
       return;
     }
     try {
-      setBusy(true);
-      const l = await eventPublicLinkService.createOrRotate(eventId);
-      setLink(l);
+      await createOrRotate.mutateAsync({});
       addToast("Enlace rotado. El anterior ya no funciona.", "success");
     } catch (err) {
       logError("ClientPortalShareCard:rotate", err);
-    } finally {
-      setBusy(false);
     }
   };
 
@@ -84,14 +65,10 @@ export const ClientPortalShareCard: React.FC<Props> = ({ eventId }) => {
       return;
     }
     try {
-      setBusy(true);
-      await eventPublicLinkService.revoke(eventId);
-      setLink(null);
+      await revokeLink.mutateAsync(undefined);
       addToast("Enlace deshabilitado.", "info");
     } catch (err) {
       logError("ClientPortalShareCard:revoke", err);
-    } finally {
-      setBusy(false);
     }
   };
 

--- a/web/src/services/eventPublicLinkService.ts
+++ b/web/src/services/eventPublicLinkService.ts
@@ -30,6 +30,19 @@ export const eventPublicLinkService = {
   },
 
   /**
+   * Same as getActive, but returns null for the expected "no link yet" state.
+   * Useful for React Query consumers that model absence as data, not error.
+   */
+  getActiveOrNull: async (eventId: string): Promise<EventPublicLink | null> => {
+    try {
+      return await api.get<EventPublicLink>(`/events/${eventId}/public-link`);
+    } catch (err) {
+      if (isNotFoundError(err)) return null;
+      throw err;
+    }
+  },
+
+  /**
    * Creates a new active link, revoking any previous one. Use this for
    * both first-time creation and rotation — same endpoint either way.
    * Omit `ttlDays` to create a link that never expires (the organizer
@@ -50,3 +63,9 @@ export const eventPublicLinkService = {
     await api.delete<void>(`/events/${eventId}/public-link`);
   },
 };
+
+function isNotFoundError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return msg.includes("404") || msg.includes("not found");
+}


### PR DESCRIPTION
Closes #181

## What
- migrate event public-link fetch/create/revoke flow to dedicated React Query hooks
- centralize query keys and success/error handling for the share card interactions
- keep service surface aligned with hook-based consumers

## Why
- reduce ad-hoc request/state logic in UI and standardize server-state handling in the web layer

## Scope
- [ ] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Tests added/updated
- [x] CI green
- [x] Cross-platform parity reviewed
- [x] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: low (UI orchestration refactor without contract changes)
- Rollback: revert commit `aa128886`