### PR TITLE
refactor(web): move unavailable dates mutations to query hooks

### DIFF
--- a/web/src/hooks/queries/useUnavailableDatesQueries.ts
+++ b/web/src/hooks/queries/useUnavailableDatesQueries.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { unavailableDatesService } from '../../services/unavailableDatesService';
 import { queryKeys } from './queryKeys';
 
@@ -12,5 +12,28 @@ export function useUnavailableDatesByRange(start: string, end: string) {
     queryKey: queryKeys.unavailableDates.byRange(start, end),
     queryFn: () => unavailableDatesService.getDates(start, end),
     enabled: !!start && !!end,
+  });
+}
+
+export function useCreateUnavailableDates() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { start_date: string; end_date: string; reason?: string }) =>
+      unavailableDatesService.addDates(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.unavailableDates.all });
+    },
+  });
+}
+
+export function useDeleteUnavailableDate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => unavailableDatesService.removeDate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.unavailableDates.all });
+    },
   });
 }

--- a/web/src/pages/Calendar/CalendarView.tsx
+++ b/web/src/pages/Calendar/CalendarView.tsx
@@ -3,13 +3,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { DayPicker, type DayButtonProps } from "react-day-picker";
 import "react-day-picker/style.css";
 import { useTranslation } from "react-i18next";
-import {
-  unavailableDatesService,
-} from "../../services/unavailableDatesService";
 import { UnavailableDatesModal } from "./components/UnavailableDatesModal";
 import { Link, useNavigate } from "react-router-dom";
 import { useEventsByDateRange } from "../../hooks/queries/useEventQueries";
-import { useUnavailableDatesByRange } from "../../hooks/queries/useUnavailableDatesQueries";
+import {
+  useCreateUnavailableDates,
+  useDeleteUnavailableDate,
+  useUnavailableDatesByRange,
+} from "../../hooks/queries/useUnavailableDatesQueries";
 import { queryKeys } from "../../hooks/queries/queryKeys";
 import {
   Calendar,
@@ -119,6 +120,8 @@ export const CalendarView: React.FC = () => {
     useEventsByDateRange(rangeStart, rangeEnd);
   const { data: unavailableData, isLoading: unavailableLoading, isFetching: unavailableFetching, error: unavailableError } =
     useUnavailableDatesByRange(rangeStart, rangeEnd);
+  const createUnavailableDates = useCreateUnavailableDates();
+  const deleteUnavailableDate = useDeleteUnavailableDate();
 
   const events = useMemo(
     () => ((eventsData as EventWithClient[] | undefined) ?? []),
@@ -214,7 +217,7 @@ export const CalendarView: React.FC = () => {
   const handleUnblock = async () => {
     if (!selectedUnavailable) return;
     try {
-      await unavailableDatesService.removeDate(selectedUnavailable.id);
+      await deleteUnavailableDate.mutateAsync(selectedUnavailable.id);
       refreshUnavailableRange();
       addToast(t("unblock.confirm"), "success");
       setSelectedDate(undefined);
@@ -696,6 +699,8 @@ export const CalendarView: React.FC = () => {
         onDelete={() => {
           refreshUnavailableRange();
         }}
+        createUnavailableDates={createUnavailableDates.mutateAsync}
+        deleteUnavailableDate={deleteUnavailableDate.mutateAsync}
         initialDate={contextMenuDate}
       />
 

--- a/web/src/pages/Calendar/components/UnavailableDatesModal.tsx
+++ b/web/src/pages/Calendar/components/UnavailableDatesModal.tsx
@@ -21,6 +21,8 @@ interface UnavailableDatesModalProps {
   onClose: () => void;
   onSave: (date: UnavailableDate) => void;
   onDelete: (id: string) => void;
+  createUnavailableDates?: (data: { start_date: string; end_date: string; reason?: string }) => Promise<UnavailableDate>;
+  deleteUnavailableDate?: (id: string) => Promise<void>;
   initialDate?: string; // yyyy-MM-dd, pre-fills the add form (e.g. from right-click)
 }
 
@@ -29,6 +31,8 @@ export const UnavailableDatesModal: React.FC<UnavailableDatesModalProps> = ({
   onClose,
   onSave,
   onDelete,
+  createUnavailableDates,
+  deleteUnavailableDate,
   initialDate,
 }) => {
   const { t, i18n } = useTranslation('calendar');
@@ -70,7 +74,11 @@ export const UnavailableDatesModal: React.FC<UnavailableDatesModalProps> = ({
   const handleDelete = async (id: string) => {
     setDeletingId(id);
     try {
-      await unavailableDatesService.removeDate(id);
+      if (deleteUnavailableDate) {
+        await deleteUnavailableDate(id);
+      } else {
+        await unavailableDatesService.removeDate(id);
+      }
       setBlocks((prev) => prev.filter((b) => b.id !== id));
       onDelete(id);
       addToast(t('action.delete'), 'success');
@@ -86,7 +94,9 @@ export const UnavailableDatesModal: React.FC<UnavailableDatesModalProps> = ({
     e.preventDefault();
     try {
       setLoading(true);
-      const newDate = await unavailableDatesService.addDates(formData);
+      const newDate = createUnavailableDates
+        ? await createUnavailableDates(formData)
+        : await unavailableDatesService.addDates(formData);
       addToast(t('block.save'), 'success');
       setBlocks((prev) => [...prev, newDate].sort((a, b) => a.start_date.localeCompare(b.start_date)));
       onSave(newDate);

--- a/web/src/pages/Events/EventForm.tsx
+++ b/web/src/pages/Events/EventForm.tsx
@@ -51,7 +51,7 @@ import {
   ProductIngredient,
 } from "@/types/entities";
 import { UpgradeBanner } from "@/components/UpgradeBanner";
-import { unavailableDatesService } from "@/services/unavailableDatesService";
+import { useUnavailableDatesByRange } from "@/hooks/queries/useUnavailableDatesQueries";
 import { parseEventDate } from "@/lib/dateUtils";
 
 // Local types to avoid Supabase dependency
@@ -64,13 +64,6 @@ interface Client {
   city?: string | null;
   total_events: number | null;
   total_spent: number | null;
-}
-
-interface UnavailableDate {
-  id: string;
-  start_date: string;
-  end_date: string;
-  reason?: string;
 }
 
 interface Product {
@@ -258,8 +251,14 @@ export const EventForm: React.FC = () => {
   } = usePlanLimits();
 
   // Unavailable Dates
-  const [unavailableDates, setUnavailableDates] = useState<UnavailableDate[]>(
-    [],
+  const endOfNextYear = useMemo(() => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() + 1);
+    return d.toISOString().split("T")[0];
+  }, []);
+  const { data: unavailableDates = [] } = useUnavailableDatesByRange(
+    "2020-01-01",
+    endOfNextYear,
   );
 
   // Local state for items
@@ -391,15 +390,6 @@ export const EventForm: React.FC = () => {
     }).catch(() => { /* empty list on error — parity with equipment */ });
     return () => { cancelled = true; };
   }, [id]);
-
-  // Load unavailable dates (kept as direct call — small, calendar-specific)
-  useEffect(() => {
-    const endOfNextYear = new Date();
-    endOfNextYear.setFullYear(endOfNextYear.getFullYear() + 1);
-    unavailableDatesService.getDates("2020-01-01", endOfNextYear.toISOString().split("T")[0])
-      .then(setUnavailableDates)
-      .catch((err) => logError("Error loading unavailable dates", err));
-  }, []);
 
   useEffect(() => {
     const clientIdParam = searchParams.get("clientId");


### PR DESCRIPTION
Closes #179

## What
- move unavailable-date create/delete operations into React Query mutation hooks
- wire calendar and event form consumers to use the shared mutation layer
- keep modal wiring backward-compatible while reducing duplicated async state code

## Why
- consolidate server-state behavior (invalidations/retries/error handling) and remove duplicated mutation orchestration in pages/components

## Scope
- [ ] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Tests added/updated
- [x] CI green
- [x] Cross-platform parity reviewed
- [x] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: low (refactor of mutation wiring)
- Rollback: revert commit `2da6f7fb`