### PR TITLE
feat(#187): OpenAPI sync and Web generated types for public flows

### DIFF
--- a/.agent/skills/_shared/engram-convention.md
+++ b/.agent/skills/_shared/engram-convention.md
@@ -1,0 +1,140 @@
+# Engram Artifact Convention (reference documentation)
+
+> **NOTE**: Critical engram calls (`mem_search`, `mem_save`, `mem_get_observation`) are now inlined directly in each skill's SKILL.md file. This document is supplementary reference — sub-agents do NOT need to read it to function correctly.
+
+## Naming Rules
+
+ALL SDD artifacts persisted to Engram MUST follow this deterministic naming:
+
+```
+title:     sdd/{change-name}/{artifact-type}
+topic_key: sdd/{change-name}/{artifact-type}
+type:      architecture
+project:   {detected or current project name}
+scope:     project
+```
+
+### Artifact Types (exact strings)
+
+| Artifact Type | Produced By | Description |
+|---------------|-------------|-------------|
+| `explore` | sdd-explore | Exploration analysis |
+| `proposal` | sdd-propose | Change proposal |
+| `spec` | sdd-spec | Delta specifications (all domains concatenated) |
+| `design` | sdd-design | Technical design |
+| `tasks` | sdd-tasks | Task breakdown |
+| `apply-progress` | sdd-apply | Implementation progress (one per batch) |
+| `verify-report` | sdd-verify | Verification report |
+| `archive-report` | sdd-archive | Archive closure with lineage |
+| `state` | orchestrator | DAG state for recovery after compaction |
+
+**Exception**: `sdd-init` uses `sdd-init/{project-name}` as both title and topic_key (it's project-scoped, not change-scoped).
+
+### State Artifact
+
+The orchestrator persists DAG state after each phase transition to enable recovery after context compaction:
+
+```
+mem_save(
+  title: "sdd/{change-name}/state",
+  topic_key: "sdd/{change-name}/state",
+  type: "architecture",
+  project: "{project}",
+  content: "change: {change-name}\nphase: {last-phase}\nartifact_store: engram\nartifacts:\n  proposal: true\n  specs: true\n  design: false\n  tasks: false\ntasks_progress:\n  completed: []\n  pending: []\nlast_updated: {ISO date}"
+)
+```
+
+Recovery: `mem_search("sdd/{change-name}/state")` → `mem_get_observation(id)` → parse YAML → restore orchestrator state.
+
+### Example
+
+```
+mem_save(
+  title: "sdd/add-dark-mode/proposal",
+  topic_key: "sdd/add-dark-mode/proposal",
+  type: "architecture",
+  project: "my-app",
+  content: "# Proposal: Add Dark Mode\n\n..."
+)
+```
+
+## Recovery Protocol (2 steps)
+
+To retrieve an artifact, use this two-step process:
+
+```
+Step 1: Search by topic_key pattern
+  mem_search(query: "sdd/{change-name}/{artifact-type}", project: "{project}")
+  → Returns a truncated preview (300 chars) with an observation ID
+
+Step 2: Get full content (when you need the complete artifact)
+  mem_get_observation(id: {observation-id from step 1})
+  → Returns complete, untruncated content
+```
+
+The preview from `mem_search` is useful for identifying whether the result is what you're looking for. When you need the full content (e.g., reading SDD dependencies), ALWAYS call `mem_get_observation`.
+
+### Retrieving Multiple Artifacts
+
+When a skill needs multiple artifacts as required dependencies (e.g., sdd-tasks needs proposal + spec + design), group all searches first, then all retrievals:
+
+```
+STEP A — SEARCH (get IDs only — content is truncated):
+  1. mem_search(query: "sdd/{change-name}/proposal", project: "{project}") → save ID
+  2. mem_search(query: "sdd/{change-name}/spec", project: "{project}") → save ID
+  3. mem_search(query: "sdd/{change-name}/design", project: "{project}") → save ID
+
+STEP B — RETRIEVE FULL CONTENT (mandatory for required dependencies):
+  4. mem_get_observation(id: {proposal_id}) → full proposal
+  5. mem_get_observation(id: {spec_id}) → full spec
+  6. mem_get_observation(id: {design_id}) → full design
+```
+
+### Loading Project Context
+
+```
+mem_search(query: "sdd-init/{project}", project: "{project}") → get ID
+mem_get_observation(id) → full project context
+```
+
+### Browsing All Artifacts for a Change
+
+```
+mem_search(query: "sdd/{change-name}/", project: "{project}")
+→ Returns all artifacts for that change
+```
+
+## Writing Artifacts
+
+### Standard Write (new artifact)
+
+```
+mem_save(
+  title: "sdd/{change-name}/{artifact-type}",
+  topic_key: "sdd/{change-name}/{artifact-type}",
+  type: "architecture",
+  project: "{project}",
+  content: "{full markdown content}"
+)
+```
+
+### Update Existing Artifact
+
+When updating an artifact you already retrieved (e.g., marking tasks complete):
+
+```
+mem_update(
+  id: {observation-id},
+  content: "{updated full content}"
+)
+```
+
+Use `mem_update` when you have the exact observation ID. Use `mem_save` with the same `topic_key` for upserts (Engram deduplicates by topic_key).
+
+## Why This Convention Exists
+
+- **Deterministic titles** → recovery works by exact match, not fuzzy search
+- **`topic_key`** → enables upserts (updating same artifact without creating duplicates)
+- **`sdd/` prefix** → namespaces all SDD artifacts away from other Engram observations
+- **Two-step recovery** → `mem_search` previews are always truncated; `mem_get_observation` is the only way to get full content
+- **Lineage** → archive-report includes all observation IDs for complete traceability

--- a/.agent/skills/_shared/openspec-convention.md
+++ b/.agent/skills/_shared/openspec-convention.md
@@ -1,0 +1,105 @@
+# OpenSpec File Convention (shared across all SDD skills)
+
+## Directory Structure
+
+```
+openspec/
+├── config.yaml              <- Project-specific SDD config
+├── specs/                   <- Source of truth (main specs)
+│   └── {domain}/
+│       └── spec.md
+└── changes/                 <- Active changes
+    ├── archive/             <- Completed changes (YYYY-MM-DD-{change-name}/)
+    └── {change-name}/       <- Active change folder
+        ├── state.yaml       <- DAG state (orchestrator, survives compaction)
+        ├── exploration.md   <- (optional) from sdd-explore
+        ├── proposal.md      <- from sdd-propose
+        ├── specs/           <- from sdd-spec
+        │   └── {domain}/
+        │       └── spec.md  <- Delta spec
+        ├── design.md        <- from sdd-design
+        ├── tasks.md         <- from sdd-tasks (updated by sdd-apply)
+        └── verify-report.md <- from sdd-verify
+```
+
+## Artifact File Paths
+
+| Skill | Creates / Reads | Path |
+|-------|----------------|------|
+| orchestrator | Creates/Updates | `openspec/changes/{change-name}/state.yaml` (DAG state for compaction recovery) |
+| sdd-init | Creates | `openspec/config.yaml`, `openspec/specs/`, `openspec/changes/`, `openspec/changes/archive/` |
+| sdd-explore | Creates (optional) | `openspec/changes/{change-name}/exploration.md` |
+| sdd-propose | Creates | `openspec/changes/{change-name}/proposal.md` |
+| sdd-spec | Creates | `openspec/changes/{change-name}/specs/{domain}/spec.md` |
+| sdd-design | Creates | `openspec/changes/{change-name}/design.md` |
+| sdd-tasks | Creates | `openspec/changes/{change-name}/tasks.md` |
+| sdd-apply | Updates | `openspec/changes/{change-name}/tasks.md` (marks `[x]`) |
+| sdd-verify | Creates | `openspec/changes/{change-name}/verify-report.md` |
+| sdd-archive | Moves | `openspec/changes/{change-name}/` → `openspec/changes/archive/YYYY-MM-DD-{change-name}/` |
+| sdd-archive | Updates | `openspec/specs/{domain}/spec.md` (merges deltas into main specs) |
+
+## Reading Artifacts
+
+Each skill reads its dependencies from the filesystem:
+
+```
+Proposal:  openspec/changes/{change-name}/proposal.md
+Specs:     openspec/changes/{change-name}/specs/  (all domain subdirectories)
+Design:    openspec/changes/{change-name}/design.md
+Tasks:     openspec/changes/{change-name}/tasks.md
+Verify:    openspec/changes/{change-name}/verify-report.md
+Config:    openspec/config.yaml
+Main specs: openspec/specs/{domain}/spec.md
+```
+
+## Writing Rules
+
+- ALWAYS create the change directory (`openspec/changes/{change-name}/`) before writing artifacts
+- If a file already exists, READ it first and UPDATE it (don't overwrite blindly)
+- If the change directory already exists with artifacts, the change is being CONTINUED
+- Use the `openspec/config.yaml` `rules` section to apply project-specific constraints per phase
+
+## Config File Reference
+
+```yaml
+# openspec/config.yaml
+schema: spec-driven
+
+context: |
+  Tech stack: {detected}
+  Architecture: {detected}
+  Testing: {detected}
+  Style: {detected}
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+  specs:
+    - Use Given/When/Then for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+  tasks:
+    - Group by phase, use hierarchical numbering
+    - Keep tasks completable in one session
+  apply:
+    - Follow existing code patterns
+    tdd: false           # Set to true to enable RED-GREEN-REFACTOR
+    test_command: ""     # e.g., "npm test", "pytest"
+  verify:
+    test_command: ""     # Override for verification
+    build_command: ""    # Override for build check
+    coverage_threshold: 0  # Set > 0 to enable coverage check
+  archive:
+    - Warn before merging destructive deltas
+```
+
+## Archive Structure
+
+When archiving, the change folder moves to:
+```
+openspec/changes/archive/YYYY-MM-DD-{change-name}/
+```
+
+Use today's date in ISO format. The archive is an AUDIT TRAIL — never delete or modify archived changes.

--- a/.agent/skills/_shared/persistence-contract.md
+++ b/.agent/skills/_shared/persistence-contract.md
@@ -1,0 +1,141 @@
+# Persistence Contract (shared across all SDD skills)
+
+## Mode Resolution
+
+The orchestrator passes `artifact_store.mode` with one of: `engram | openspec | hybrid | none`.
+
+Default resolution (when orchestrator does not explicitly set a mode):
+1. If Engram is available → use `engram`
+2. Otherwise → use `none`
+
+`openspec` and `hybrid` are NEVER used by default — only when the orchestrator explicitly passes them.
+
+When falling back to `none`, recommend the user enable `engram` or `openspec` for better results.
+
+## Behavior Per Mode
+
+| Mode | Read from | Write to | Project files |
+|------|-----------|----------|---------------|
+| `engram` | Engram (see `engram-convention.md`) | Engram | Never |
+| `openspec` | Filesystem (see `openspec-convention.md`) | Filesystem | Yes |
+| `hybrid` | Engram (primary) + Filesystem (fallback) | Both Engram AND Filesystem | Yes |
+| `none` | Orchestrator prompt context | Nowhere | Never |
+
+### Hybrid Mode
+
+`hybrid` persists every artifact to BOTH Engram and OpenSpec simultaneously. This provides:
+- **Engram**: cross-session recovery, compaction survival, deterministic search
+- **OpenSpec**: human-readable files in the project, version-controllable artifacts
+
+**Read priority**: Engram first (faster, survives compaction). Fall back to filesystem if Engram returns no results.
+
+**Write behavior**: Write to Engram (per `engram-convention.md`) AND to filesystem (per `openspec-convention.md`) for every artifact. Both writes MUST succeed for the operation to be considered complete.
+
+**Token cost warning**: Hybrid mode consumes MORE tokens per operation than either single backend, because every read/write hits both stores. Use it when you need both cross-session persistence AND local file artifacts. If you only need one benefit, prefer `engram` or `openspec` alone.
+
+## State Persistence (Orchestrator)
+
+The orchestrator persists DAG state after each phase transition. This enables SDD recovery after context compaction.
+
+| Mode | Persist State | Recover State |
+|------|--------------|---------------|
+| `engram` | `mem_save(topic_key: "sdd/{change-name}/state")` | `mem_search("sdd/*/state")` → `mem_get_observation(id)` |
+| `openspec` | Write `openspec/changes/{change-name}/state.yaml` | Read `openspec/changes/{change-name}/state.yaml` |
+| `hybrid` | Both: `mem_save` AND write `state.yaml` | Engram first; filesystem fallback |
+| `none` | Not possible — state lives only in context | Not possible — warn user |
+
+## Common Rules
+
+- If mode is `none`, do NOT create or modify any project files. Return results inline only.
+- If mode is `engram`, do NOT write any project files. Persist to Engram and return observation IDs.
+- If mode is `openspec`, write files ONLY to the paths defined in `openspec-convention.md`.
+- If mode is `hybrid`, persist to BOTH Engram AND filesystem. Follow both `engram-convention.md` and `openspec-convention.md` for each artifact.
+- NEVER force `openspec/` creation unless the orchestrator explicitly passed `openspec` or `hybrid` mode.
+- If you are unsure which mode to use, default to `none`.
+
+## Sub-Agent Context Rules
+
+Sub-agents launch with a fresh context and NO access to the orchestrator's instructions or memory protocol. The orchestrator controls what context they receive and sub-agents are responsible for persisting what they produce.
+
+### Who reads, who writes
+
+| Context | Who reads from backend | Who writes to backend |
+|---------|----------------------|----------------------|
+| Non-SDD (general task) | **Orchestrator** searches engram, passes summary in prompt | **Sub-agent** saves discoveries/decisions via `mem_save` |
+| SDD (phase with dependencies) | **Sub-agent** reads artifacts directly from backend | **Sub-agent** saves its artifact |
+| SDD (phase without dependencies, e.g. explore) | Nobody | **Sub-agent** saves its artifact |
+
+### Why this split
+
+- **Orchestrator reads for non-SDD**: It already has the engram protocol loaded. It knows what context is relevant. Sub-agents doing their own searches waste tokens on potentially irrelevant results.
+- **Sub-agents read for SDD**: SDD artifacts are large (specs, designs). The orchestrator should NOT inline them — it passes artifact references (topic keys or file paths) and the sub-agent retrieves the full content.
+- **Sub-agents always write**: They have the complete detail. By the time results flow back to the orchestrator, nuance is lost. Persist at the source.
+
+### Orchestrator prompt instructions for sub-agents
+
+When launching a sub-agent, the orchestrator MUST include persistence instructions in the prompt:
+
+**Non-SDD**:
+```
+PERSISTENCE (MANDATORY):
+If you make important discoveries, decisions, or fix bugs, you MUST save them
+to engram before returning:
+  mem_save(title: "{short description}", type: "{decision|bugfix|discovery|pattern}",
+           project: "{project}", content: "{What, Why, Where, Learned}")
+Do NOT return without saving what you learned. This is how the team builds
+persistent knowledge across sessions.
+```
+
+**SDD (with dependencies)**:
+```
+Artifact store mode: {engram|openspec|hybrid|none}
+Read these artifacts before starting (two-step — search returns truncated previews):
+  mem_search(query: "sdd/{change-name}/{type}", project: "{project}") → get ID
+  mem_get_observation(id: {id}) → full content (REQUIRED for SDD dependencies)
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST call:
+  mem_save(
+    title: "sdd/{change-name}/{artifact-type}",
+    topic_key: "sdd/{change-name}/{artifact-type}",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full artifact markdown}"
+  )
+If you return without calling mem_save, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
+```
+
+**SDD (no dependencies)**:
+```
+Artifact store mode: {engram|openspec|hybrid|none}
+
+PERSISTENCE (MANDATORY — do NOT skip):
+After completing your work, you MUST call:
+  mem_save(
+    title: "sdd/{change-name}/{artifact-type}",
+    topic_key: "sdd/{change-name}/{artifact-type}",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full artifact markdown}"
+  )
+If you return without calling mem_save, the next phase CANNOT find your artifact
+and the pipeline BREAKS.
+```
+
+## Skill Registry
+
+The orchestrator pre-resolves skill paths and passes them in the launch prompt. Sub-agents do NOT search for the skill registry.
+
+### How to generate/update
+
+Run the `skill-registry` skill, or run `sdd-init` (which includes registry generation).
+
+### Sub-agent skill loading
+
+When the orchestrator launches you, it includes a `SKILL: Load \`{path}\`` instruction if a skill is relevant. Load that file and follow it. If no skill path was provided, proceed without loading additional skills — this is not an error.
+
+## Detail Level
+
+The orchestrator may also pass `detail_level`: `concise | standard | deep`.
+This controls output verbosity but does NOT affect what gets persisted — always persist the full artifact.

--- a/.agent/skills/_shared/sdd-phase-common.md
+++ b/.agent/skills/_shared/sdd-phase-common.md
@@ -1,0 +1,44 @@
+# SDD Phase — Common Protocol
+
+This file contains boilerplate that is **identical** across all SDD phase skills (explore, propose, spec, design, tasks, apply, verify, archive). Sub-agents should load this alongside their phase-specific SKILL.md.
+
+---
+
+## Skill Registry
+
+The orchestrator pre-resolves skill paths before launching you. You receive a `SKILL: Load \`{path}\`` instruction in your launch prompt. Load that file — do NOT search for the skill registry yourself.
+
+If no skill path was provided in your launch prompt, proceed without loading additional skills (not an error).
+
+---
+
+## Engram Upsert Note
+
+When saving artifacts with `mem_save`, always set `topic_key` to the artifact's canonical key (e.g., `sdd/{change-name}/proposal`).
+
+`topic_key` enables upserts — saving again updates, not duplicates.
+
+---
+
+## Return Envelope
+
+Every phase MUST return a structured envelope to the orchestrator. Include ALL of these fields:
+
+| Field | Description |
+|-------|-------------|
+| `status` | `success`, `partial`, or `blocked` |
+| `executive_summary` | 1-3 sentence summary of what was done |
+| `detailed_report` | (optional) Full phase output, or omit if already inline |
+| `artifacts` | List of artifact keys/paths written |
+| `next_recommended` | The next SDD phase to run, or "none" |
+| `risks` | Risks discovered, or "None" |
+
+Example:
+
+```markdown
+**Status**: success
+**Summary**: Proposal created for `{change-name}`. Defined scope, approach, and rollback plan.
+**Artifacts**: Engram `sdd/{change-name}/proposal` | `openspec/changes/{change-name}/proposal.md`
+**Next**: sdd-spec or sdd-design
+**Risks**: None
+```

--- a/.agent/skills/branch-pr/SKILL.md
+++ b/.agent/skills/branch-pr/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: branch-pr
+description: >
+  PR creation workflow for Agent Teams Lite following the issue-first enforcement system.
+  Trigger: When creating a pull request, opening a PR, or preparing changes for review.
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## When to Use
+
+Use this skill when:
+- Creating a pull request for any change
+- Preparing a branch for submission
+- Helping a contributor open a PR
+
+---
+
+## Critical Rules
+
+1. **Every PR MUST link an approved issue** — no exceptions
+2. **Every PR MUST have exactly one `type:*` label**
+3. **Automated checks must pass** before merge is possible
+4. **Blank PRs without issue linkage will be blocked** by GitHub Actions
+
+---
+
+## Workflow
+
+```
+1. Verify issue has `status:approved` label
+2. Create branch: type/description (see Branch Naming below)
+3. Implement changes with conventional commits
+4. Run shellcheck on modified scripts
+5. Open PR using the template
+6. Add exactly one type:* label
+7. Wait for automated checks to pass
+```
+
+---
+
+## Branch Naming
+
+Branch names MUST match this regex:
+
+```
+^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)\/[a-z0-9._-]+$
+```
+
+**Format:** `type/description` — lowercase, no spaces, only `a-z0-9._-` in description.
+
+| Type | Branch pattern | Example |
+|------|---------------|---------|
+| Feature | `feat/<description>` | `feat/user-login` |
+| Bug fix | `fix/<description>` | `fix/zsh-glob-error` |
+| Chore | `chore/<description>` | `chore/update-ci-actions` |
+| Docs | `docs/<description>` | `docs/installation-guide` |
+| Style | `style/<description>` | `style/format-scripts` |
+| Refactor | `refactor/<description>` | `refactor/extract-shared-logic` |
+| Performance | `perf/<description>` | `perf/reduce-startup-time` |
+| Test | `test/<description>` | `test/add-setup-coverage` |
+| Build | `build/<description>` | `build/update-shellcheck` |
+| CI | `ci/<description>` | `ci/add-branch-validation` |
+| Revert | `revert/<description>` | `revert/broken-setup-change` |
+
+---
+
+## PR Body Format
+
+The PR template is at `.github/PULL_REQUEST_TEMPLATE.md`. Every PR body MUST contain:
+
+### 1. Linked Issue (REQUIRED)
+
+```markdown
+Closes #<issue-number>
+```
+
+Valid keywords: `Closes #N`, `Fixes #N`, `Resolves #N` (case insensitive).
+The linked issue MUST have the `status:approved` label.
+
+### 2. PR Type (REQUIRED)
+
+Check exactly ONE in the template and add the matching label:
+
+| Checkbox | Label to add |
+|----------|-------------|
+| Bug fix | `type:bug` |
+| New feature | `type:feature` |
+| Documentation only | `type:docs` |
+| Code refactoring | `type:refactor` |
+| Maintenance/tooling | `type:chore` |
+| Breaking change | `type:breaking-change` |
+
+### 3. Summary
+
+1-3 bullet points of what the PR does.
+
+### 4. Changes Table
+
+```markdown
+| File | Change |
+|------|--------|
+| `path/to/file` | What changed |
+```
+
+### 5. Test Plan
+
+```markdown
+- [x] Scripts run without errors: `shellcheck scripts/*.sh`
+- [x] Manually tested the affected functionality
+- [x] Skills load correctly in target agent
+```
+
+### 6. Contributor Checklist
+
+All boxes must be checked:
+- Linked an approved issue
+- Added exactly one `type:*` label
+- Ran shellcheck on modified scripts
+- Skills tested in at least one agent
+- Docs updated if behavior changed
+- Conventional commit format
+- No `Co-Authored-By` trailers
+
+---
+
+## Automated Checks (all must pass)
+
+| Check | Job name | What it verifies |
+|-------|----------|-----------------|
+| PR Validation | `Check Issue Reference` | Body contains `Closes/Fixes/Resolves #N` |
+| PR Validation | `Check Issue Has status:approved` | Linked issue has `status:approved` |
+| PR Validation | `Check PR Has type:* Label` | PR has exactly one `type:*` label |
+| CI | `Shellcheck` | Shell scripts pass `shellcheck` |
+
+---
+
+## Conventional Commits
+
+Commit messages MUST match this regex:
+
+```
+^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9\._-]+\))?!?: .+
+```
+
+**Format:** `type(scope): description` or `type: description`
+
+- `type` — required, one of: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- `(scope)` — optional, lowercase with `a-z0-9._-`
+- `!` — optional, indicates breaking change
+- `description` — required, starts after `: `
+
+Type-to-label mapping:
+
+| Commit type | PR label |
+|-------------|----------|
+| `feat` | `type:feature` |
+| `fix` | `type:bug` |
+| `docs` | `type:docs` |
+| `refactor` | `type:refactor` |
+| `chore` | `type:chore` |
+| `style` | `type:chore` |
+| `perf` | `type:feature` |
+| `test` | `type:chore` |
+| `build` | `type:chore` |
+| `ci` | `type:chore` |
+| `revert` | `type:bug` |
+| `feat!` / `fix!` | `type:breaking-change` |
+
+Examples:
+```
+feat(scripts): add Codex support to setup.sh
+fix(skills): correct topic key format in sdd-apply
+docs(readme): update multi-model configuration guide
+refactor(skills): extract shared persistence logic
+chore(ci): add shellcheck to PR validation workflow
+perf(scripts): reduce setup.sh execution time
+style(skills): fix markdown formatting
+test(scripts): add setup.sh integration tests
+ci(workflows): add branch name validation
+revert: undo broken setup change
+feat!: redesign skill loading system
+```
+
+---
+
+## Commands
+
+```bash
+# Create branch
+git checkout -b feat/my-feature main
+
+# Run shellcheck before pushing
+shellcheck scripts/*.sh
+
+# Push and create PR
+git push -u origin feat/my-feature
+gh pr create --title "feat(scope): description" --body "Closes #N"
+
+# Add type label to PR
+gh pr edit <pr-number> --add-label "type:feature"
+```

--- a/.agent/skills/issue-creation/SKILL.md
+++ b/.agent/skills/issue-creation/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: issue-creation
+description: >
+  Issue creation workflow for Agent Teams Lite following the issue-first enforcement system.
+  Trigger: When creating a GitHub issue, reporting a bug, or requesting a feature.
+license: Apache-2.0
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## When to Use
+
+Use this skill when:
+- Creating a GitHub issue (bug report or feature request)
+- Helping a contributor file an issue
+- Triaging or approving issues as a maintainer
+
+---
+
+## Critical Rules
+
+1. **Blank issues are disabled** — MUST use a template (bug report or feature request)
+2. **Every issue gets `status:needs-review` automatically** on creation
+3. **A maintainer MUST add `status:approved`** before any PR can be opened
+4. **Questions go to [Discussions](https://github.com/Gentleman-Programming/agent-teams-lite/discussions)**, not issues
+
+---
+
+## Workflow
+
+```
+1. Search existing issues for duplicates
+2. Choose the correct template (Bug Report or Feature Request)
+3. Fill in ALL required fields
+4. Check pre-flight checkboxes
+5. Submit → issue gets status:needs-review automatically
+6. Wait for maintainer to add status:approved
+7. Only then open a PR linking this issue
+```
+
+---
+
+## Issue Templates
+
+### Bug Report
+
+Template: `.github/ISSUE_TEMPLATE/bug_report.yml`
+Auto-labels: `bug`, `status:needs-review`
+
+#### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| **Pre-flight Checks** | Checkboxes: no duplicate + understands approval workflow |
+| **Bug Description** | Clear description of the bug |
+| **Steps to Reproduce** | Numbered steps to reproduce |
+| **Expected Behavior** | What should have happened |
+| **Actual Behavior** | What happened instead (include errors/logs) |
+| **Operating System** | Dropdown: macOS, Linux variants, Windows, WSL |
+| **Agent / Client** | Dropdown: Claude Code, OpenCode, Gemini CLI, Cursor, Windsurf, Codex, Other |
+| **Shell** | Dropdown: bash, zsh, fish, Other |
+
+#### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| **Relevant Logs** | Log output (auto-formatted as code block) |
+| **Additional Context** | Screenshots, workarounds, extra info |
+
+#### Example — Bug Report via CLI
+
+```bash
+gh issue create --template "bug_report.yml" \
+  --title "fix(scripts): setup.sh fails on zsh with glob error" \
+  --body "
+### Pre-flight Checks
+- [x] I have searched existing issues and this is not a duplicate
+- [x] I understand this issue needs status:approved before a PR can be opened
+
+### Bug Description
+Running setup.sh on zsh throws a glob error when no matching files exist.
+
+### Steps to Reproduce
+1. Clone the repo
+2. Run \`./scripts/setup.sh\` in zsh
+3. See error: \`zsh: no matches found: skills/*\`
+
+### Expected Behavior
+The script should handle missing glob matches gracefully.
+
+### Actual Behavior
+Script crashes with glob error.
+
+### Operating System
+macOS
+
+### Agent / Client
+Claude Code
+
+### Shell
+zsh
+
+### Relevant Logs
+\`\`\`
+zsh: no matches found: skills/*
+\`\`\`
+"
+```
+
+---
+
+### Feature Request
+
+Template: `.github/ISSUE_TEMPLATE/feature_request.yml`
+Auto-labels: `enhancement`, `status:needs-review`
+
+#### Required Fields
+
+| Field | Description |
+|-------|-------------|
+| **Pre-flight Checks** | Checkboxes: no duplicate + understands approval workflow |
+| **Problem Description** | The pain point this feature solves |
+| **Proposed Solution** | How it should work from the user's perspective |
+| **Affected Area** | Dropdown: Scripts, Skills, Examples, Documentation, CI/Workflows, Other |
+
+#### Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| **Alternatives Considered** | Other approaches or workarounds |
+| **Additional Context** | Mockups, examples, references |
+
+#### Example — Feature Request via CLI
+
+```bash
+gh issue create --template "feature_request.yml" \
+  --title "feat(scripts): add Codex support to setup.sh" \
+  --body "
+### Pre-flight Checks
+- [x] I have searched existing issues and this is not a duplicate
+- [x] I understand this issue needs status:approved before a PR can be opened
+
+### Problem Description
+The setup script only configures Claude Code, Gemini CLI, and OpenCode. Codex users have to manually copy skills.
+
+### Proposed Solution
+Add a Codex option to setup.sh that links skills to the .codex/ directory.
+
+Example:
+\`\`\`bash
+./scripts/setup.sh --agent codex
+\`\`\`
+
+### Affected Area
+Scripts (setup, installation)
+
+### Alternatives Considered
+Manually symlinking, but that defeats the purpose of the setup script.
+"
+```
+
+---
+
+## Label System
+
+### Applied Automatically on Issue Creation
+
+| Template | Labels added |
+|----------|-------------|
+| Bug Report | `bug`, `status:needs-review` |
+| Feature Request | `enhancement`, `status:needs-review` |
+
+### Applied by Maintainers
+
+| Label | When to apply |
+|-------|--------------|
+| `status:approved` | Issue accepted for implementation — PRs can now be opened |
+| `priority:high` | Critical bug or urgent feature |
+| `priority:medium` | Important but not blocking |
+| `priority:low` | Nice to have |
+
+---
+
+## Maintainer Approval Workflow
+
+```
+1. New issue arrives with status:needs-review
+2. Review the issue — is it valid, clear, and in scope?
+3. If YES → add status:approved label
+4. If NO → comment with reason, close if needed
+5. Contributor can now open a PR linking this issue
+```
+
+---
+
+## Decision Tree
+
+```
+Is it a bug?                    → Use Bug Report template
+Is it a new feature/improvement? → Use Feature Request template
+Is it a question?               → Use Discussions, NOT issues
+Is it a duplicate?              → Link to existing issue, close
+```
+
+---
+
+## Commands
+
+```bash
+# Search existing issues before creating
+gh issue list --search "keyword"
+
+# Create bug report
+gh issue create --template "bug_report.yml" --title "fix(scope): description"
+
+# Create feature request
+gh issue create --template "feature_request.yml" --title "feat(scope): description"
+
+# Maintainer: approve an issue
+gh issue edit <number> --add-label "status:approved"
+
+# Maintainer: add priority
+gh issue edit <number> --add-label "priority:high"
+```

--- a/.agent/skills/remotion/SKILL.md
+++ b/.agent/skills/remotion/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: remotion-best-practices
+description: Best practices for Remotion - Video creation in React
+metadata:
+  tags: remotion, video, react, animation, composition
+---
+
+## When to use
+
+Use this skills whenever you are dealing with Remotion code to obtain the domain-specific knowledge.
+
+## Captions
+
+When dealing with captions or subtitles, load the [./rules/subtitles.md](./rules/subtitles.md) file for more information.
+
+## Using FFmpeg
+
+For some video operations, such as trimming videos or detecting silence, FFmpeg should be used. Load the [./rules/ffmpeg.md](./rules/ffmpeg.md) file for more information.
+
+## Audio visualization
+
+When needing to visualize audio (spectrum bars, waveforms, bass-reactive effects), load the [./rules/audio-visualization.md](./rules/audio-visualization.md) file for more information.
+
+## Sound effects
+
+When needing to use sound effects, load the [./rules/sound-effects.md](./rules/sound-effects.md) file for more information.
+
+## How to use
+
+Read individual rule files for detailed explanations and code examples:
+
+- [rules/3d.md](rules/3d.md) - 3D content in Remotion using Three.js and React Three Fiber
+- [rules/animations.md](rules/animations.md) - Fundamental animation skills for Remotion
+- [rules/assets.md](rules/assets.md) - Importing images, videos, audio, and fonts into Remotion
+- [rules/audio.md](rules/audio.md) - Using audio and sound in Remotion - importing, trimming, volume, speed, pitch
+- [rules/calculate-metadata.md](rules/calculate-metadata.md) - Dynamically set composition duration, dimensions, and props
+- [rules/can-decode.md](rules/can-decode.md) - Check if a video can be decoded by the browser using Mediabunny
+- [rules/charts.md](rules/charts.md) - Chart and data visualization patterns for Remotion (bar, pie, line, stock charts)
+- [rules/compositions.md](rules/compositions.md) - Defining compositions, stills, folders, default props and dynamic metadata
+- [rules/extract-frames.md](rules/extract-frames.md) - Extract frames from videos at specific timestamps using Mediabunny
+- [rules/fonts.md](rules/fonts.md) - Loading Google Fonts and local fonts in Remotion
+- [rules/get-audio-duration.md](rules/get-audio-duration.md) - Getting the duration of an audio file in seconds with Mediabunny
+- [rules/get-video-dimensions.md](rules/get-video-dimensions.md) - Getting the width and height of a video file with Mediabunny
+- [rules/get-video-duration.md](rules/get-video-duration.md) - Getting the duration of a video file in seconds with Mediabunny
+- [rules/gifs.md](rules/gifs.md) - Displaying GIFs synchronized with Remotion's timeline
+- [rules/images.md](rules/images.md) - Embedding images in Remotion using the Img component
+- [rules/light-leaks.md](rules/light-leaks.md) - Light leak overlay effects using @remotion/light-leaks
+- [rules/lottie.md](rules/lottie.md) - Embedding Lottie animations in Remotion
+- [rules/measuring-dom-nodes.md](rules/measuring-dom-nodes.md) - Measuring DOM element dimensions in Remotion
+- [rules/measuring-text.md](rules/measuring-text.md) - Measuring text dimensions, fitting text to containers, and checking overflow
+- [rules/sequencing.md](rules/sequencing.md) - Sequencing patterns for Remotion - delay, trim, limit duration of items
+- [rules/tailwind.md](rules/tailwind.md) - Using TailwindCSS in Remotion
+- [rules/text-animations.md](rules/text-animations.md) - Typography and text animation patterns for Remotion
+- [rules/timing.md](rules/timing.md) - Interpolation curves in Remotion - linear, easing, spring animations
+- [rules/transitions.md](rules/transitions.md) - Scene transition patterns for Remotion
+- [rules/transparent-videos.md](rules/transparent-videos.md) - Rendering out a video with transparency
+- [rules/trimming.md](rules/trimming.md) - Trimming patterns for Remotion - cut the beginning or end of animations
+- [rules/videos.md](rules/videos.md) - Embedding videos in Remotion - trimming, volume, speed, looping, pitch
+- [rules/parameters.md](rules/parameters.md) - Make a video parametrizable by adding a Zod schema
+- [rules/maps.md](rules/maps.md) - Add a map using Mapbox and animate it
+- [rules/voiceover.md](rules/voiceover.md) - Adding AI-generated voiceover to Remotion compositions using ElevenLabs TTS

--- a/.agent/skills/remotion/rules/3d.md
+++ b/.agent/skills/remotion/rules/3d.md
@@ -1,0 +1,86 @@
+---
+name: 3d
+description: 3D content in Remotion using Three.js and React Three Fiber.
+metadata:
+  tags: 3d, three, threejs
+---
+
+# Using Three.js and React Three Fiber in Remotion
+
+Follow React Three Fiber and Three.js best practices.  
+Only the following Remotion-specific rules need to be followed:
+
+## Prerequisites
+
+First, the `@remotion/three` package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/three # If project uses npm
+bunx remotion add @remotion/three # If project uses bun
+yarn remotion add @remotion/three # If project uses yarn
+pnpm exec remotion add @remotion/three # If project uses pnpm
+```
+
+## Using ThreeCanvas
+
+You MUST wrap 3D content in `<ThreeCanvas>` and include proper lighting.  
+`<ThreeCanvas>` MUST have a `width` and `height` prop.
+
+```tsx
+import { ThreeCanvas } from "@remotion/three";
+import { useVideoConfig } from "remotion";
+
+const { width, height } = useVideoConfig();
+
+<ThreeCanvas width={width} height={height}>
+  <ambientLight intensity={0.4} />
+  <directionalLight position={[5, 5, 5]} intensity={0.8} />
+  <mesh>
+    <sphereGeometry args={[1, 32, 32]} />
+    <meshStandardMaterial color="red" />
+  </mesh>
+</ThreeCanvas>;
+```
+
+## No animations not driven by `useCurrentFrame()`
+
+Shaders, models etc MUST NOT animate by themselves.  
+No animations are allowed unless they are driven by `useCurrentFrame()`.  
+Otherwise, it will cause flickering during rendering.
+
+Using `useFrame()` from `@react-three/fiber` is forbidden.
+
+## Animate using `useCurrentFrame()`
+
+Use `useCurrentFrame()` to perform animations.
+
+```tsx
+const frame = useCurrentFrame();
+const rotationY = frame * 0.02;
+
+<mesh rotation={[0, rotationY, 0]}>
+  <boxGeometry args={[2, 2, 2]} />
+  <meshStandardMaterial color="#4a9eff" />
+</mesh>;
+```
+
+## Using `<Sequence>` inside `<ThreeCanvas>`
+
+The `layout` prop of any `<Sequence>` inside a `<ThreeCanvas>` must be set to `none`.
+
+```tsx
+import { Sequence } from "remotion";
+import { ThreeCanvas } from "@remotion/three";
+
+const { width, height } = useVideoConfig();
+
+<ThreeCanvas width={width} height={height}>
+  <Sequence layout="none">
+    <mesh>
+      <boxGeometry args={[2, 2, 2]} />
+      <meshStandardMaterial color="#4a9eff" />
+    </mesh>
+  </Sequence>
+</ThreeCanvas>;
+```

--- a/.agent/skills/remotion/rules/animations.md
+++ b/.agent/skills/remotion/rules/animations.md
@@ -1,0 +1,27 @@
+---
+name: animations
+description: Fundamental animation skills for Remotion
+metadata:
+  tags: animations, transitions, frames, useCurrentFrame
+---
+
+All animations MUST be driven by the `useCurrentFrame()` hook.  
+Write animations in seconds and multiply them by the `fps` value from `useVideoConfig()`.
+
+```tsx
+import { useCurrentFrame } from "remotion";
+
+export const FadeIn = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const opacity = interpolate(frame, [0, 2 * fps], [0, 1], {
+    extrapolateRight: "clamp",
+  });
+
+  return <div style={{ opacity }}>Hello World!</div>;
+};
+```
+
+CSS transitions or animations are FORBIDDEN - they will not render correctly.  
+Tailwind animation class names are FORBIDDEN - they will not render correctly.

--- a/.agent/skills/remotion/rules/assets.md
+++ b/.agent/skills/remotion/rules/assets.md
@@ -1,0 +1,78 @@
+---
+name: assets
+description: Importing images, videos, audio, and fonts into Remotion
+metadata:
+  tags: assets, staticFile, images, fonts, public
+---
+
+# Importing assets in Remotion
+
+## The public folder
+
+Place assets in the `public/` folder at your project root.
+
+## Using staticFile()
+
+You MUST use `staticFile()` to reference files from the `public/` folder:
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Img src={staticFile("logo.png")} />;
+};
+```
+
+The function returns an encoded URL that works correctly when deploying to subdirectories.
+
+## Using with components
+
+**Images:**
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+<Img src={staticFile("photo.png")} />;
+```
+
+**Videos:**
+
+```tsx
+import { Video } from "@remotion/media";
+import { staticFile } from "remotion";
+
+<Video src={staticFile("clip.mp4")} />;
+```
+
+**Audio:**
+
+```tsx
+import { Audio } from "@remotion/media";
+import { staticFile } from "remotion";
+
+<Audio src={staticFile("music.mp3")} />;
+```
+
+**Fonts:**
+
+```tsx
+import { staticFile } from "remotion";
+
+const fontFamily = new FontFace("MyFont", `url(${staticFile("font.woff2")})`);
+await fontFamily.load();
+document.fonts.add(fontFamily);
+```
+
+## Remote URLs
+
+Remote URLs can be used directly without `staticFile()`:
+
+```tsx
+<Img src="https://example.com/image.png" />
+<Video src="https://remotion.media/video.mp4" />
+```
+
+## Important notes
+
+- Remotion components (`<Img>`, `<Video>`, `<Audio>`) ensure assets are fully loaded before rendering
+- Special characters in filenames (`#`, `?`, `&`) are automatically encoded

--- a/.agent/skills/remotion/rules/assets/charts-bar-chart.tsx
+++ b/.agent/skills/remotion/rules/assets/charts-bar-chart.tsx
@@ -1,0 +1,173 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const {fontFamily} = loadFont();
+
+const COLOR_BAR = '#D4AF37';
+const COLOR_TEXT = '#ffffff';
+const COLOR_MUTED = '#888888';
+const COLOR_BG = '#0a0a0a';
+const COLOR_AXIS = '#333333';
+
+// Ideal composition size: 1280x720
+
+const Title: React.FC<{children: React.ReactNode}> = ({children}) => (
+	<div style={{textAlign: 'center', marginBottom: 40}}>
+		<div style={{color: COLOR_TEXT, fontSize: 48, fontWeight: 600}}>
+			{children}
+		</div>
+	</div>
+);
+
+const YAxis: React.FC<{steps: number[]; height: number}> = ({
+	steps,
+	height,
+}) => (
+	<div
+		style={{
+			display: 'flex',
+			flexDirection: 'column',
+			justifyContent: 'space-between',
+			height,
+			paddingRight: 16,
+		}}
+	>
+		{steps
+			.slice()
+			.reverse()
+			.map((step) => (
+				<div
+					key={step}
+					style={{
+						color: COLOR_MUTED,
+						fontSize: 20,
+						textAlign: 'right',
+					}}
+				>
+					{step.toLocaleString()}
+				</div>
+			))}
+	</div>
+);
+
+const Bar: React.FC<{
+	height: number;
+	progress: number;
+}> = ({height, progress}) => (
+	<div
+		style={{
+			flex: 1,
+			display: 'flex',
+			flexDirection: 'column',
+			justifyContent: 'flex-end',
+		}}
+	>
+		<div
+			style={{
+				width: '100%',
+				height,
+				backgroundColor: COLOR_BAR,
+				borderRadius: '8px 8px 0 0',
+				opacity: progress,
+			}}
+		/>
+	</div>
+);
+
+const XAxis: React.FC<{
+	children: React.ReactNode;
+	labels: string[];
+	height: number;
+}> = ({children, labels, height}) => (
+	<div style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'flex-end',
+				gap: 16,
+				height,
+				borderLeft: `2px solid ${COLOR_AXIS}`,
+				borderBottom: `2px solid ${COLOR_AXIS}`,
+				paddingLeft: 16,
+			}}
+		>
+			{children}
+		</div>
+		<div
+			style={{
+				display: 'flex',
+				gap: 16,
+				paddingLeft: 16,
+				marginTop: 12,
+			}}
+		>
+			{labels.map((label) => (
+				<div
+					key={label}
+					style={{
+						flex: 1,
+						textAlign: 'center',
+						color: COLOR_MUTED,
+						fontSize: 20,
+					}}
+				>
+					{label}
+				</div>
+			))}
+		</div>
+	</div>
+);
+
+export const MyAnimation = () => {
+	const frame = useCurrentFrame();
+	const {fps, height} = useVideoConfig();
+
+	const data = [
+		{month: 'Jan', price: 2039},
+		{month: 'Mar', price: 2160},
+		{month: 'May', price: 2327},
+		{month: 'Jul', price: 2426},
+		{month: 'Sep', price: 2634},
+		{month: 'Nov', price: 2672},
+	];
+
+	const minPrice = 2000;
+	const maxPrice = 2800;
+	const priceRange = maxPrice - minPrice;
+	const chartHeight = height - 280;
+	const yAxisSteps = [2000, 2400, 2800];
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: COLOR_BG,
+				padding: 60,
+				display: 'flex',
+				flexDirection: 'column',
+				fontFamily,
+			}}
+		>
+			<Title>Gold Price 2024</Title>
+
+			<div style={{display: 'flex', flex: 1}}>
+				<YAxis steps={yAxisSteps} height={chartHeight} />
+				<XAxis height={chartHeight} labels={data.map((d) => d.month)}>
+					{data.map((item, i) => {
+						const progress = spring({
+							frame: frame - i * 5 - 10,
+							fps,
+							config: {damping: 18, stiffness: 80},
+						});
+
+						const barHeight =
+							((item.price - minPrice) / priceRange) * chartHeight * progress;
+
+						return (
+							<Bar key={item.month} height={barHeight} progress={progress} />
+						);
+					})}
+				</XAxis>
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/.agent/skills/remotion/rules/assets/text-animations-typewriter.tsx
+++ b/.agent/skills/remotion/rules/assets/text-animations-typewriter.tsx
@@ -1,0 +1,100 @@
+import {
+	AbsoluteFill,
+	interpolate,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+const COLOR_BG = '#ffffff';
+const COLOR_TEXT = '#000000';
+const FULL_TEXT = 'From prompt to motion graphics. This is Remotion.';
+const PAUSE_AFTER = 'From prompt to motion graphics.';
+const FONT_SIZE = 72;
+const FONT_WEIGHT = 700;
+const CHAR_FRAMES = 2;
+const CURSOR_BLINK_FRAMES = 16;
+const PAUSE_SECONDS = 1;
+
+// Ideal composition size: 1280x720
+
+const getTypedText = ({
+	frame,
+	fullText,
+	pauseAfter,
+	charFrames,
+	pauseFrames,
+}: {
+	frame: number;
+	fullText: string;
+	pauseAfter: string;
+	charFrames: number;
+	pauseFrames: number;
+}): string => {
+	const pauseIndex = fullText.indexOf(pauseAfter);
+	const preLen =
+		pauseIndex >= 0 ? pauseIndex + pauseAfter.length : fullText.length;
+
+	let typedChars = 0;
+	if (frame < preLen * charFrames) {
+		typedChars = Math.floor(frame / charFrames);
+	} else if (frame < preLen * charFrames + pauseFrames) {
+		typedChars = preLen;
+	} else {
+		const postPhase = frame - preLen * charFrames - pauseFrames;
+		typedChars = Math.min(
+			fullText.length,
+			preLen + Math.floor(postPhase / charFrames),
+		);
+	}
+	return fullText.slice(0, typedChars);
+};
+
+const Cursor: React.FC<{
+	frame: number;
+	blinkFrames: number;
+	symbol?: string;
+}> = ({frame, blinkFrames, symbol = '\u258C'}) => {
+	const opacity = interpolate(
+		frame % blinkFrames,
+		[0, blinkFrames / 2, blinkFrames],
+		[1, 0, 1],
+		{extrapolateLeft: 'clamp', extrapolateRight: 'clamp'},
+	);
+
+	return <span style={{opacity}}>{symbol}</span>;
+};
+
+export const MyAnimation = () => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const pauseFrames = Math.round(fps * PAUSE_SECONDS);
+
+	const typedText = getTypedText({
+		frame,
+		fullText: FULL_TEXT,
+		pauseAfter: PAUSE_AFTER,
+		charFrames: CHAR_FRAMES,
+		pauseFrames,
+	});
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: COLOR_BG,
+			}}
+		>
+			<div
+				style={{
+					color: COLOR_TEXT,
+					fontSize: FONT_SIZE,
+					fontWeight: FONT_WEIGHT,
+					fontFamily: 'sans-serif',
+				}}
+			>
+				<span>{typedText}</span>
+				<Cursor frame={frame} blinkFrames={CURSOR_BLINK_FRAMES} />
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/.agent/skills/remotion/rules/assets/text-animations-word-highlight.tsx
+++ b/.agent/skills/remotion/rules/assets/text-animations-word-highlight.tsx
@@ -1,0 +1,103 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import React from 'react';
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+/*
+ * Highlight a word in a sentence with a spring-animated wipe effect.
+ */
+
+// Ideal composition size: 1280x720
+
+const COLOR_BG = '#ffffff';
+const COLOR_TEXT = '#000000';
+const COLOR_HIGHLIGHT = '#A7C7E7';
+const FULL_TEXT = 'This is Remotion.';
+const HIGHLIGHT_WORD = 'Remotion';
+const FONT_SIZE = 72;
+const FONT_WEIGHT = 700;
+const HIGHLIGHT_START_FRAME = 30;
+const HIGHLIGHT_WIPE_DURATION = 18;
+
+const {fontFamily} = loadFont();
+
+const Highlight: React.FC<{
+	word: string;
+	color: string;
+	delay: number;
+	durationInFrames: number;
+}> = ({word, color, delay, durationInFrames}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const highlightProgress = spring({
+		fps,
+		frame,
+		config: {damping: 200},
+		delay,
+		durationInFrames,
+	});
+	const scaleX = Math.max(0, Math.min(1, highlightProgress));
+
+	return (
+		<span style={{position: 'relative', display: 'inline-block'}}>
+			<span
+				style={{
+					position: 'absolute',
+					left: 0,
+					right: 0,
+					top: '50%',
+					height: '1.05em',
+					transform: `translateY(-50%) scaleX(${scaleX})`,
+					transformOrigin: 'left center',
+					backgroundColor: color,
+					borderRadius: '0.18em',
+					zIndex: 0,
+				}}
+			/>
+			<span style={{position: 'relative', zIndex: 1}}>{word}</span>
+		</span>
+	);
+};
+
+export const MyAnimation = () => {
+	const highlightIndex = FULL_TEXT.indexOf(HIGHLIGHT_WORD);
+	const hasHighlight = highlightIndex >= 0;
+	const preText = hasHighlight ? FULL_TEXT.slice(0, highlightIndex) : FULL_TEXT;
+	const postText = hasHighlight
+		? FULL_TEXT.slice(highlightIndex + HIGHLIGHT_WORD.length)
+		: '';
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: COLOR_BG,
+				alignItems: 'center',
+				justifyContent: 'center',
+				fontFamily,
+			}}
+		>
+			<div
+				style={{
+					color: COLOR_TEXT,
+					fontSize: FONT_SIZE,
+					fontWeight: FONT_WEIGHT,
+				}}
+			>
+				{hasHighlight ? (
+					<>
+						<span>{preText}</span>
+						<Highlight
+							word={HIGHLIGHT_WORD}
+							color={COLOR_HIGHLIGHT}
+							delay={HIGHLIGHT_START_FRAME}
+							durationInFrames={HIGHLIGHT_WIPE_DURATION}
+						/>
+						<span>{postText}</span>
+					</>
+				) : (
+					<span>{FULL_TEXT}</span>
+				)}
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/.agent/skills/remotion/rules/audio-visualization.md
+++ b/.agent/skills/remotion/rules/audio-visualization.md
@@ -1,0 +1,198 @@
+---
+name: audio-visualization
+description: Audio visualization patterns - spectrum bars, waveforms, bass-reactive effects
+metadata:
+  tags: audio, visualization, spectrum, waveform, bass, music, audiogram, frequency
+---
+
+# Audio Visualization in Remotion
+
+## Prerequisites
+
+```bash
+npx remotion add @remotion/media-utils
+```
+
+## Loading Audio Data
+
+Use `useWindowedAudioData()` (https://www.remotion.dev/docs/use-windowed-audio-data) to load audio data:
+
+```tsx
+import { useWindowedAudioData } from "@remotion/media-utils";
+import { staticFile, useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+const { audioData, dataOffsetInSeconds } = useWindowedAudioData({
+  src: staticFile("podcast.wav"),
+  frame,
+  fps,
+  windowInSeconds: 30,
+});
+```
+
+## Spectrum Bar Visualization
+
+Use `visualizeAudio()` (https://www.remotion.dev/docs/visualize-audio) to get frequency data for bar charts:
+
+```tsx
+import { useWindowedAudioData, visualizeAudio } from "@remotion/media-utils";
+import { staticFile, useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+const { audioData, dataOffsetInSeconds } = useWindowedAudioData({
+  src: staticFile("music.mp3"),
+  frame,
+  fps,
+  windowInSeconds: 30,
+});
+
+if (!audioData) {
+  return null;
+}
+
+const frequencies = visualizeAudio({
+  fps,
+  frame,
+  audioData,
+  numberOfSamples: 256,
+  optimizeFor: "speed",
+  dataOffsetInSeconds,
+});
+
+return (
+  <div style={{ display: "flex", alignItems: "flex-end", height: 200 }}>
+    {frequencies.map((v, i) => (
+      <div
+        key={i}
+        style={{
+          flex: 1,
+          height: `${v * 100}%`,
+          backgroundColor: "#0b84f3",
+          margin: "0 1px",
+        }}
+      />
+    ))}
+  </div>
+);
+```
+
+- `numberOfSamples` must be power of 2 (32, 64, 128, 256, 512, 1024)
+- Values range 0-1; left of array = bass, right = highs
+- Use `optimizeFor: "speed"` for Lambda or high sample counts
+
+**Important:** When passing `audioData` to child components, also pass the `frame` from the parent. Do not call `useCurrentFrame()` in each child - this causes discontinuous visualization when children are inside `<Sequence>` with offsets.
+
+## Waveform Visualization
+
+Use `visualizeAudioWaveform()` (https://www.remotion.dev/docs/media-utils/visualize-audio-waveform) with `createSmoothSvgPath()` (https://www.remotion.dev/docs/media-utils/create-smooth-svg-path) for oscilloscope-style displays:
+
+```tsx
+import {
+  createSmoothSvgPath,
+  useWindowedAudioData,
+  visualizeAudioWaveform,
+} from "@remotion/media-utils";
+import { staticFile, useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { width, fps } = useVideoConfig();
+const HEIGHT = 200;
+
+const { audioData, dataOffsetInSeconds } = useWindowedAudioData({
+  src: staticFile("voice.wav"),
+  frame,
+  fps,
+  windowInSeconds: 30,
+});
+
+if (!audioData) {
+  return null;
+}
+
+const waveform = visualizeAudioWaveform({
+  fps,
+  frame,
+  audioData,
+  numberOfSamples: 256,
+  windowInSeconds: 0.5,
+  dataOffsetInSeconds,
+});
+
+const path = createSmoothSvgPath({
+  points: waveform.map((y, i) => ({
+    x: (i / (waveform.length - 1)) * width,
+    y: HEIGHT / 2 + (y * HEIGHT) / 2,
+  })),
+});
+
+return (
+  <svg width={width} height={HEIGHT}>
+    <path d={path} fill="none" stroke="#0b84f3" strokeWidth={2} />
+  </svg>
+);
+```
+
+## Bass-Reactive Effects
+
+Extract low frequencies for beat-reactive animations:
+
+```tsx
+const frequencies = visualizeAudio({
+  fps,
+  frame,
+  audioData,
+  numberOfSamples: 128,
+  optimizeFor: "speed",
+  dataOffsetInSeconds,
+});
+
+const lowFrequencies = frequencies.slice(0, 32);
+const bassIntensity =
+  lowFrequencies.reduce((sum, v) => sum + v, 0) / lowFrequencies.length;
+
+const scale = 1 + bassIntensity * 0.5;
+const opacity = Math.min(0.6, bassIntensity * 0.8);
+```
+
+## Volume-Based Waveform
+
+Use `getWaveformPortion()` (https://www.remotion.dev/docs/get-waveform-portion) when you need simplified volume data instead of frequency spectrum:
+
+```tsx
+import { getWaveformPortion } from "@remotion/media-utils";
+import { useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+const currentTimeInSeconds = frame / fps;
+
+const waveform = getWaveformPortion({
+  audioData,
+  startTimeInSeconds: currentTimeInSeconds,
+  durationInSeconds: 5,
+  numberOfSamples: 50,
+});
+
+// Returns array of { index, amplitude } objects (amplitude: 0-1)
+waveform.map((bar) => (
+  <div key={bar.index} style={{ height: bar.amplitude * 100 }} />
+));
+```
+
+## Postprocessing
+
+Low frequencies naturally dominate. Apply logarithmic scaling for visual balance:
+
+```tsx
+const minDb = -100;
+const maxDb = -30;
+
+const scaled = frequencies.map((value) => {
+  const db = 20 * Math.log10(value);
+  return (db - minDb) / (maxDb - minDb);
+});
+```

--- a/.agent/skills/remotion/rules/audio.md
+++ b/.agent/skills/remotion/rules/audio.md
@@ -1,0 +1,169 @@
+---
+name: audio
+description: Using audio and sound in Remotion - importing, trimming, volume, speed, pitch
+metadata:
+  tags: audio, media, trim, volume, speed, loop, pitch, mute, sound, sfx
+---
+
+# Using audio in Remotion
+
+## Prerequisites
+
+First, the @remotion/media package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/media
+```
+
+## Importing Audio
+
+Use `<Audio>` from `@remotion/media` to add audio to your composition.
+
+```tsx
+import { Audio } from "@remotion/media";
+import { staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Audio src={staticFile("audio.mp3")} />;
+};
+```
+
+Remote URLs are also supported:
+
+```tsx
+<Audio src="https://remotion.media/audio.mp3" />
+```
+
+By default, audio plays from the start, at full volume and full length.
+Multiple audio tracks can be layered by adding multiple `<Audio>` components.
+
+## Trimming
+
+Use `trimBefore` and `trimAfter` to remove portions of the audio. Values are in frames.
+
+```tsx
+const { fps } = useVideoConfig();
+
+return (
+  <Audio
+    src={staticFile("audio.mp3")}
+    trimBefore={2 * fps} // Skip the first 2 seconds
+    trimAfter={10 * fps} // End at the 10 second mark
+  />
+);
+```
+
+The audio still starts playing at the beginning of the composition - only the specified portion is played.
+
+## Delaying
+
+Wrap the audio in a `<Sequence>` to delay when it starts:
+
+```tsx
+import { Sequence, staticFile } from "remotion";
+import { Audio } from "@remotion/media";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Sequence from={1 * fps}>
+    <Audio src={staticFile("audio.mp3")} />
+  </Sequence>
+);
+```
+
+The audio will start playing after 1 second.
+
+## Volume
+
+Set a static volume (0 to 1):
+
+```tsx
+<Audio src={staticFile("audio.mp3")} volume={0.5} />
+```
+
+Or use a callback for dynamic volume based on the current frame:
+
+```tsx
+import { interpolate } from "remotion";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Audio
+    src={staticFile("audio.mp3")}
+    volume={(f) =>
+      interpolate(f, [0, 1 * fps], [0, 1], { extrapolateRight: "clamp" })
+    }
+  />
+);
+```
+
+The value of `f` starts at 0 when the audio begins to play, not the composition frame.
+
+## Muting
+
+Use `muted` to silence the audio. It can be set dynamically:
+
+```tsx
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+return (
+  <Audio
+    src={staticFile("audio.mp3")}
+    muted={frame >= 2 * fps && frame <= 4 * fps} // Mute between 2s and 4s
+  />
+);
+```
+
+## Speed
+
+Use `playbackRate` to change the playback speed:
+
+```tsx
+<Audio src={staticFile("audio.mp3")} playbackRate={2} /> {/* 2x speed */}
+<Audio src={staticFile("audio.mp3")} playbackRate={0.5} /> {/* Half speed */}
+```
+
+Reverse playback is not supported.
+
+## Looping
+
+Use `loop` to loop the audio indefinitely:
+
+```tsx
+<Audio src={staticFile("audio.mp3")} loop />
+```
+
+Use `loopVolumeCurveBehavior` to control how the frame count behaves when looping:
+
+- `"repeat"`: Frame count resets to 0 each loop (default)
+- `"extend"`: Frame count continues incrementing
+
+```tsx
+<Audio
+  src={staticFile("audio.mp3")}
+  loop
+  loopVolumeCurveBehavior="extend"
+  volume={(f) => interpolate(f, [0, 300], [1, 0])} // Fade out over multiple loops
+/>
+```
+
+## Pitch
+
+Use `toneFrequency` to adjust the pitch without affecting speed. Values range from 0.01 to 2:
+
+```tsx
+<Audio
+  src={staticFile("audio.mp3")}
+  toneFrequency={1.5} // Higher pitch
+/>
+<Audio
+  src={staticFile("audio.mp3")}
+  toneFrequency={0.8} // Lower pitch
+/>
+```
+
+Pitch shifting only works during server-side rendering, not in the Remotion Studio preview or in the `<Player />`.

--- a/.agent/skills/remotion/rules/calculate-metadata.md
+++ b/.agent/skills/remotion/rules/calculate-metadata.md
@@ -1,0 +1,134 @@
+---
+name: calculate-metadata
+description: Dynamically set composition duration, dimensions, and props
+metadata:
+  tags: calculateMetadata, duration, dimensions, props, dynamic
+---
+
+# Using calculateMetadata
+
+Use `calculateMetadata` on a `<Composition>` to dynamically set duration, dimensions, and transform props before rendering.
+
+```tsx
+<Composition
+  id="MyComp"
+  component={MyComponent}
+  durationInFrames={300}
+  fps={30}
+  width={1920}
+  height={1080}
+  defaultProps={{ videoSrc: "https://remotion.media/video.mp4" }}
+  calculateMetadata={calculateMetadata}
+/>
+```
+
+## Setting duration based on a video
+
+Use the [`getVideoDuration`](./get-video-duration.md) and [`getVideoDimensions`](./get-video-dimensions.md) skills to get the video duration and dimensions:
+
+```tsx
+import { CalculateMetadataFunction } from "remotion";
+import { getVideoDuration } from "./get-video-duration";
+
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  const durationInSeconds = await getVideoDuration(props.videoSrc);
+
+  return {
+    durationInFrames: Math.ceil(durationInSeconds * 30),
+  };
+};
+```
+
+## Matching dimensions of a video
+
+Use the [`getVideoDimensions`](./get-video-dimensions.md) skill to get the video dimensions:
+
+```tsx
+import { CalculateMetadataFunction } from "remotion";
+import { getVideoDuration } from "./get-video-duration";
+import { getVideoDimensions } from "./get-video-dimensions";
+
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  const dimensions = await getVideoDimensions(props.videoSrc);
+
+  return {
+    width: dimensions.width,
+    height: dimensions.height,
+  };
+};
+```
+
+## Setting duration based on multiple videos
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  const metadataPromises = props.videos.map((video) =>
+    getVideoDuration(video.src),
+  );
+  const allMetadata = await Promise.all(metadataPromises);
+
+  const totalDuration = allMetadata.reduce(
+    (sum, durationInSeconds) => sum + durationInSeconds,
+    0,
+  );
+
+  return {
+    durationInFrames: Math.ceil(totalDuration * 30),
+  };
+};
+```
+
+## Setting a default outName
+
+Set the default output filename based on props:
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  return {
+    defaultOutName: `video-${props.id}.mp4`,
+  };
+};
+```
+
+## Transforming props
+
+Fetch data or transform props before rendering:
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+  abortSignal,
+}) => {
+  const response = await fetch(props.dataUrl, { signal: abortSignal });
+  const data = await response.json();
+
+  return {
+    props: {
+      ...props,
+      fetchedData: data,
+    },
+  };
+};
+```
+
+The `abortSignal` cancels stale requests when props change in the Studio.
+
+## Return value
+
+All fields are optional. Returned values override the `<Composition>` props:
+
+- `durationInFrames`: Number of frames
+- `width`: Composition width in pixels
+- `height`: Composition height in pixels
+- `fps`: Frames per second
+- `props`: Transformed props passed to the component
+- `defaultOutName`: Default output filename
+- `defaultCodec`: Default codec for rendering

--- a/.agent/skills/remotion/rules/can-decode.md
+++ b/.agent/skills/remotion/rules/can-decode.md
@@ -1,0 +1,81 @@
+---
+name: can-decode
+description: Check if a video can be decoded by the browser using Mediabunny
+metadata:
+  tags: decode, validation, video, audio, compatibility, browser
+---
+
+# Checking if a video can be decoded
+
+Use Mediabunny to check if a video can be decoded by the browser before attempting to play it.
+
+First, install the right version of Mediabunny:
+
+```bash
+npx remotion add mediabunny
+```
+
+## The `canDecode()` function
+
+This function can be copy-pasted into any project.
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const canDecode = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  try {
+    await input.getFormat();
+  } catch {
+    return false;
+  }
+
+  const videoTrack = await input.getPrimaryVideoTrack();
+  if (videoTrack && !(await videoTrack.canDecode())) {
+    return false;
+  }
+
+  const audioTrack = await input.getPrimaryAudioTrack();
+  if (audioTrack && !(await audioTrack.canDecode())) {
+    return false;
+  }
+
+  return true;
+};
+```
+
+## Usage
+
+```tsx
+const src = "https://remotion.media/video.mp4";
+const isDecodable = await canDecode(src);
+
+if (isDecodable) {
+  console.log("Video can be decoded");
+} else {
+  console.log("Video cannot be decoded by this browser");
+}
+```
+
+## Using with Blob
+
+For file uploads or drag-and-drop, use `BlobSource`:
+
+```tsx
+import { Input, ALL_FORMATS, BlobSource } from "mediabunny";
+
+export const canDecodeBlob = async (blob: Blob) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new BlobSource(blob),
+  });
+
+  // Same validation logic as above
+};
+```

--- a/.agent/skills/remotion/rules/charts.md
+++ b/.agent/skills/remotion/rules/charts.md
@@ -1,0 +1,120 @@
+---
+name: charts
+description: Chart and data visualization patterns for Remotion. Use when creating bar charts, pie charts, line charts, stock graphs, or any data-driven animations.
+metadata:
+  tags: charts, data, visualization, bar-chart, pie-chart, line-chart, stock-chart, svg-paths, graphs
+---
+
+# Charts in Remotion
+
+Create charts using React code - HTML, SVG, and D3.js are all supported.
+
+Disable all animations from third party libraries - they cause flickering.  
+Drive all animations from `useCurrentFrame()`.
+
+## Bar Chart
+
+```tsx
+const STAGGER_DELAY = 5;
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+const bars = data.map((item, i) => {
+  const height = spring({
+    frame,
+    fps,
+    delay: i * STAGGER_DELAY,
+    config: { damping: 200 },
+  });
+  return <div style={{ height: height * item.value }} />;
+});
+```
+
+## Pie Chart
+
+Animate segments using stroke-dashoffset, starting from 12 o'clock:
+
+```tsx
+const progress = interpolate(frame, [0, 100], [0, 1]);
+const circumference = 2 * Math.PI * radius;
+const segmentLength = (value / total) * circumference;
+const offset = interpolate(progress, [0, 1], [segmentLength, 0]);
+
+<circle
+  r={radius}
+  cx={center}
+  cy={center}
+  fill="none"
+  stroke={color}
+  strokeWidth={strokeWidth}
+  strokeDasharray={`${segmentLength} ${circumference}`}
+  strokeDashoffset={offset}
+  transform={`rotate(-90 ${center} ${center})`}
+/>;
+```
+
+## Line Chart / Path Animation
+
+Use `@remotion/paths` for animating SVG paths (line charts, stock graphs, signatures).
+
+Install: `npx remotion add @remotion/paths`  
+Docs: https://remotion.dev/docs/paths.md
+
+### Convert data points to SVG path
+
+```tsx
+type Point = { x: number; y: number };
+
+const generateLinePath = (points: Point[]): string => {
+  if (points.length < 2) return "";
+  return points.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ");
+};
+```
+
+### Draw path with animation
+
+```tsx
+import { evolvePath } from "@remotion/paths";
+
+const path = "M 100 200 L 200 150 L 300 180 L 400 100";
+const progress = interpolate(frame, [0, 2 * fps], [0, 1], {
+  extrapolateLeft: "clamp",
+  extrapolateRight: "clamp",
+  easing: Easing.out(Easing.quad),
+});
+
+const { strokeDasharray, strokeDashoffset } = evolvePath(progress, path);
+
+<path
+  d={path}
+  fill="none"
+  stroke="#FF3232"
+  strokeWidth={4}
+  strokeDasharray={strokeDasharray}
+  strokeDashoffset={strokeDashoffset}
+/>;
+```
+
+### Follow path with marker/arrow
+
+```tsx
+import {
+  getLength,
+  getPointAtLength,
+  getTangentAtLength,
+} from "@remotion/paths";
+
+const pathLength = getLength(path);
+const point = getPointAtLength(path, progress * pathLength);
+const tangent = getTangentAtLength(path, progress * pathLength);
+const angle = Math.atan2(tangent.y, tangent.x);
+
+<g
+  style={{
+    transform: `translate(${point.x}px, ${point.y}px) rotate(${angle}rad)`,
+    transformOrigin: "0 0",
+  }}
+>
+  <polygon points="0,0 -20,-10 -20,10" fill="#FF3232" />
+</g>;
+```

--- a/.agent/skills/remotion/rules/compositions.md
+++ b/.agent/skills/remotion/rules/compositions.md
@@ -1,0 +1,154 @@
+---
+name: compositions
+description: Defining compositions, stills, folders, default props and dynamic metadata
+metadata:
+  tags: composition, still, folder, props, metadata
+---
+
+A `<Composition>` defines the component, width, height, fps and duration of a renderable video.
+
+It normally is placed in the `src/Root.tsx` file.
+
+```tsx
+import { Composition } from "remotion";
+import { MyComposition } from "./MyComposition";
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="MyComposition"
+      component={MyComposition}
+      durationInFrames={100}
+      fps={30}
+      width={1080}
+      height={1080}
+    />
+  );
+};
+```
+
+## Default Props
+
+Pass `defaultProps` to provide initial values for your component.  
+Values must be JSON-serializable (`Date`, `Map`, `Set`, and `staticFile()` are supported).
+
+```tsx
+import { Composition } from "remotion";
+import { MyComposition, MyCompositionProps } from "./MyComposition";
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="MyComposition"
+      component={MyComposition}
+      durationInFrames={100}
+      fps={30}
+      width={1080}
+      height={1080}
+      defaultProps={
+        {
+          title: "Hello World",
+          color: "#ff0000",
+        } satisfies MyCompositionProps
+      }
+    />
+  );
+};
+```
+
+Use `type` declarations for props rather than `interface` to ensure `defaultProps` type safety.
+
+## Folders
+
+Use `<Folder>` to organize compositions in the sidebar.  
+Folder names can only contain letters, numbers, and hyphens.
+
+```tsx
+import { Composition, Folder } from "remotion";
+
+export const RemotionRoot = () => {
+  return (
+    <>
+      <Folder name="Marketing">
+        <Composition id="Promo" /* ... */ />
+        <Composition id="Ad" /* ... */ />
+      </Folder>
+      <Folder name="Social">
+        <Folder name="Instagram">
+          <Composition id="Story" /* ... */ />
+          <Composition id="Reel" /* ... */ />
+        </Folder>
+      </Folder>
+    </>
+  );
+};
+```
+
+## Stills
+
+Use `<Still>` for single-frame images. It does not require `durationInFrames` or `fps`.
+
+```tsx
+import { Still } from "remotion";
+import { Thumbnail } from "./Thumbnail";
+
+export const RemotionRoot = () => {
+  return (
+    <Still id="Thumbnail" component={Thumbnail} width={1280} height={720} />
+  );
+};
+```
+
+## Calculate Metadata
+
+Use `calculateMetadata` to make dimensions, duration, or props dynamic based on data.
+
+```tsx
+import { Composition, CalculateMetadataFunction } from "remotion";
+import { MyComposition, MyCompositionProps } from "./MyComposition";
+
+const calculateMetadata: CalculateMetadataFunction<
+  MyCompositionProps
+> = async ({ props, abortSignal }) => {
+  const data = await fetch(`https://api.example.com/video/${props.videoId}`, {
+    signal: abortSignal,
+  }).then((res) => res.json());
+
+  return {
+    durationInFrames: Math.ceil(data.duration * 30),
+    props: {
+      ...props,
+      videoUrl: data.url,
+    },
+  };
+};
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="MyComposition"
+      component={MyComposition}
+      durationInFrames={100} // Placeholder, will be overridden
+      fps={30}
+      width={1080}
+      height={1080}
+      defaultProps={{ videoId: "abc123" }}
+      calculateMetadata={calculateMetadata}
+    />
+  );
+};
+```
+
+The function can return `props`, `durationInFrames`, `width`, `height`, `fps`, and codec-related defaults. It runs once before rendering begins.
+
+## Nesting compositions within another
+
+To add a composition within another composition, you can use the `<Sequence>` component with a `width` and `height` prop to specify the size of the composition.
+
+```tsx
+<AbsoluteFill>
+  <Sequence width={COMPOSITION_WIDTH} height={COMPOSITION_HEIGHT}>
+    <CompositionComponent />
+  </Sequence>
+</AbsoluteFill>
+```

--- a/.agent/skills/remotion/rules/display-captions.md
+++ b/.agent/skills/remotion/rules/display-captions.md
@@ -1,0 +1,184 @@
+---
+name: display-captions
+description: Displaying captions in Remotion with TikTok-style pages and word highlighting
+metadata:
+  tags: captions, subtitles, display, tiktok, highlight
+---
+
+# Displaying captions in Remotion
+
+This guide explains how to display captions in Remotion, assuming you already have captions in the [`Caption`](https://www.remotion.dev/docs/captions/caption) format.
+
+## Prerequisites
+
+Read [Transcribing audio](transcribe-captions.md) for how to generate captions.
+
+First, the [`@remotion/captions`](https://www.remotion.dev/docs/captions) package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/captions
+```
+
+## Fetching captions
+
+First, fetch your captions JSON file. Use [`useDelayRender()`](https://www.remotion.dev/docs/use-delay-render) to hold the render until the captions are loaded:
+
+```tsx
+import { useState, useEffect, useCallback } from "react";
+import { AbsoluteFill, staticFile, useDelayRender } from "remotion";
+import type { Caption } from "@remotion/captions";
+
+export const MyComponent: React.FC = () => {
+  const [captions, setCaptions] = useState<Caption[] | null>(null);
+  const { delayRender, continueRender, cancelRender } = useDelayRender();
+  const [handle] = useState(() => delayRender());
+
+  const fetchCaptions = useCallback(async () => {
+    try {
+      // Assuming captions.json is in the public/ folder.
+      const response = await fetch(staticFile("captions123.json"));
+      const data = await response.json();
+      setCaptions(data);
+      continueRender(handle);
+    } catch (e) {
+      cancelRender(e);
+    }
+  }, [continueRender, cancelRender, handle]);
+
+  useEffect(() => {
+    fetchCaptions();
+  }, [fetchCaptions]);
+
+  if (!captions) {
+    return null;
+  }
+
+  return <AbsoluteFill>{/* Render captions here */}</AbsoluteFill>;
+};
+```
+
+## Creating pages
+
+Use `createTikTokStyleCaptions()` to group captions into pages. The `combineTokensWithinMilliseconds` option controls how many words appear at once:
+
+```tsx
+import { useMemo } from "react";
+import { createTikTokStyleCaptions } from "@remotion/captions";
+import type { Caption } from "@remotion/captions";
+
+// How often captions should switch (in milliseconds)
+// Higher values = more words per page
+// Lower values = fewer words (more word-by-word)
+const SWITCH_CAPTIONS_EVERY_MS = 1200;
+
+const { pages } = useMemo(() => {
+  return createTikTokStyleCaptions({
+    captions,
+    combineTokensWithinMilliseconds: SWITCH_CAPTIONS_EVERY_MS,
+  });
+}, [captions]);
+```
+
+## Rendering with Sequences
+
+Map over the pages and render each one in a `<Sequence>`. Calculate the start frame and duration from the page timing:
+
+```tsx
+import { Sequence, useVideoConfig, AbsoluteFill } from "remotion";
+import type { TikTokPage } from "@remotion/captions";
+
+const CaptionedContent: React.FC = () => {
+  const { fps } = useVideoConfig();
+
+  return (
+    <AbsoluteFill>
+      {pages.map((page, index) => {
+        const nextPage = pages[index + 1] ?? null;
+        const startFrame = (page.startMs / 1000) * fps;
+        const endFrame = Math.min(
+          nextPage ? (nextPage.startMs / 1000) * fps : Infinity,
+          startFrame + (SWITCH_CAPTIONS_EVERY_MS / 1000) * fps,
+        );
+        const durationInFrames = endFrame - startFrame;
+
+        if (durationInFrames <= 0) {
+          return null;
+        }
+
+        return (
+          <Sequence
+            key={index}
+            from={startFrame}
+            durationInFrames={durationInFrames}
+          >
+            <CaptionPage page={page} />
+          </Sequence>
+        );
+      })}
+    </AbsoluteFill>
+  );
+};
+```
+
+## White-space preservation
+
+The captions are whitespace sensitive. You should include spaces in the `text` field before each word. Use `whiteSpace: "pre"` to preserve the whitespace in the captions.
+
+## Separate component for captions
+
+Put captioning logic in a separate component.  
+Make a new file for it.
+
+## Word highlighting
+
+A caption page contains `tokens` which you can use to highlight the currently spoken word:
+
+```tsx
+import { AbsoluteFill, useCurrentFrame, useVideoConfig } from "remotion";
+import type { TikTokPage } from "@remotion/captions";
+
+const HIGHLIGHT_COLOR = "#39E508";
+
+const CaptionPage: React.FC<{ page: TikTokPage }> = ({ page }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  // Current time relative to the start of the sequence
+  const currentTimeMs = (frame / fps) * 1000;
+  // Convert to absolute time by adding the page start
+  const absoluteTimeMs = page.startMs + currentTimeMs;
+
+  return (
+    <AbsoluteFill style={{ justifyContent: "center", alignItems: "center" }}>
+      <div style={{ fontSize: 80, fontWeight: "bold", whiteSpace: "pre" }}>
+        {page.tokens.map((token) => {
+          const isActive =
+            token.fromMs <= absoluteTimeMs && token.toMs > absoluteTimeMs;
+
+          return (
+            <span
+              key={token.fromMs}
+              style={{ color: isActive ? HIGHLIGHT_COLOR : "white" }}
+            >
+              {token.text}
+            </span>
+          );
+        })}
+      </div>
+    </AbsoluteFill>
+  );
+};
+```
+
+## Display captions alongside video content
+
+By default, put the captions alongside the video content, so the captions are in sync.  
+For each video, make a new captions JSON file.
+
+```tsx
+<AbsoluteFill>
+  <Video src={staticFile("video.mp4")} />
+  <CaptionPage page={page} />
+</AbsoluteFill>
+```

--- a/.agent/skills/remotion/rules/extract-frames.md
+++ b/.agent/skills/remotion/rules/extract-frames.md
@@ -1,0 +1,229 @@
+---
+name: extract-frames
+description: Extract frames from videos at specific timestamps using Mediabunny
+metadata:
+  tags: frames, extract, video, thumbnail, filmstrip, canvas
+---
+
+# Extracting frames from videos
+
+Use Mediabunny to extract frames from videos at specific timestamps. This is useful for generating thumbnails, filmstrips, or processing individual frames.
+
+## The `extractFrames()` function
+
+This function can be copy-pasted into any project.
+
+```tsx
+import {
+  ALL_FORMATS,
+  Input,
+  UrlSource,
+  VideoSample,
+  VideoSampleSink,
+} from "mediabunny";
+
+type Options = {
+  track: { width: number; height: number };
+  container: string;
+  durationInSeconds: number | null;
+};
+
+export type ExtractFramesTimestampsInSecondsFn = (
+  options: Options,
+) => Promise<number[]> | number[];
+
+export type ExtractFramesProps = {
+  src: string;
+  timestampsInSeconds: number[] | ExtractFramesTimestampsInSecondsFn;
+  onVideoSample: (sample: VideoSample) => void;
+  signal?: AbortSignal;
+};
+
+export async function extractFrames({
+  src,
+  timestampsInSeconds,
+  onVideoSample,
+  signal,
+}: ExtractFramesProps): Promise<void> {
+  using input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src),
+  });
+
+  const [durationInSeconds, format, videoTrack] = await Promise.all([
+    input.computeDuration(),
+    input.getFormat(),
+    input.getPrimaryVideoTrack(),
+  ]);
+
+  if (!videoTrack) {
+    throw new Error("No video track found in the input");
+  }
+
+  if (signal?.aborted) {
+    throw new Error("Aborted");
+  }
+
+  const timestamps =
+    typeof timestampsInSeconds === "function"
+      ? await timestampsInSeconds({
+          track: {
+            width: videoTrack.displayWidth,
+            height: videoTrack.displayHeight,
+          },
+          container: format.name,
+          durationInSeconds,
+        })
+      : timestampsInSeconds;
+
+  if (timestamps.length === 0) {
+    return;
+  }
+
+  if (signal?.aborted) {
+    throw new Error("Aborted");
+  }
+
+  const sink = new VideoSampleSink(videoTrack);
+
+  for await (using videoSample of sink.samplesAtTimestamps(timestamps)) {
+    if (signal?.aborted) {
+      break;
+    }
+
+    if (!videoSample) {
+      continue;
+    }
+
+    onVideoSample(videoSample);
+  }
+}
+```
+
+## Basic usage
+
+Extract frames at specific timestamps:
+
+```tsx
+await extractFrames({
+  src: "https://remotion.media/video.mp4",
+  timestampsInSeconds: [0, 1, 2, 3, 4],
+  onVideoSample: (sample) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = sample.displayWidth;
+    canvas.height = sample.displayHeight;
+    const ctx = canvas.getContext("2d");
+    sample.draw(ctx!, 0, 0);
+  },
+});
+```
+
+## Creating a filmstrip
+
+Use a callback function to dynamically calculate timestamps based on video metadata:
+
+```tsx
+const canvasWidth = 500;
+const canvasHeight = 80;
+const fromSeconds = 0;
+const toSeconds = 10;
+
+await extractFrames({
+  src: "https://remotion.media/video.mp4",
+  timestampsInSeconds: async ({ track, durationInSeconds }) => {
+    const aspectRatio = track.width / track.height;
+    const amountOfFramesFit = Math.ceil(
+      canvasWidth / (canvasHeight * aspectRatio),
+    );
+    const segmentDuration = toSeconds - fromSeconds;
+    const timestamps: number[] = [];
+
+    for (let i = 0; i < amountOfFramesFit; i++) {
+      timestamps.push(
+        fromSeconds + (segmentDuration / amountOfFramesFit) * (i + 0.5),
+      );
+    }
+
+    return timestamps;
+  },
+  onVideoSample: (sample) => {
+    console.log(`Frame at ${sample.timestamp}s`);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = sample.displayWidth;
+    canvas.height = sample.displayHeight;
+    const ctx = canvas.getContext("2d");
+    sample.draw(ctx!, 0, 0);
+  },
+});
+```
+
+## Cancellation with AbortSignal
+
+Cancel frame extraction after a timeout:
+
+```tsx
+const controller = new AbortController();
+
+setTimeout(() => controller.abort(), 5000);
+
+try {
+  await extractFrames({
+    src: "https://remotion.media/video.mp4",
+    timestampsInSeconds: [0, 1, 2, 3, 4],
+    onVideoSample: (sample) => {
+      using frame = sample;
+      const canvas = document.createElement("canvas");
+      canvas.width = frame.displayWidth;
+      canvas.height = frame.displayHeight;
+      const ctx = canvas.getContext("2d");
+      frame.draw(ctx!, 0, 0);
+    },
+    signal: controller.signal,
+  });
+
+  console.log("Frame extraction complete!");
+} catch (error) {
+  console.error("Frame extraction was aborted or failed:", error);
+}
+```
+
+## Timeout with Promise.race
+
+```tsx
+const controller = new AbortController();
+
+const timeoutPromise = new Promise<never>((_, reject) => {
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+    reject(new Error("Frame extraction timed out after 10 seconds"));
+  }, 10000);
+
+  controller.signal.addEventListener("abort", () => clearTimeout(timeoutId), {
+    once: true,
+  });
+});
+
+try {
+  await Promise.race([
+    extractFrames({
+      src: "https://remotion.media/video.mp4",
+      timestampsInSeconds: [0, 1, 2, 3, 4],
+      onVideoSample: (sample) => {
+        using frame = sample;
+        const canvas = document.createElement("canvas");
+        canvas.width = frame.displayWidth;
+        canvas.height = frame.displayHeight;
+        const ctx = canvas.getContext("2d");
+        frame.draw(ctx!, 0, 0);
+      },
+      signal: controller.signal,
+    }),
+    timeoutPromise,
+  ]);
+
+  console.log("Frame extraction complete!");
+} catch (error) {
+  console.error("Frame extraction was aborted or failed:", error);
+}
+```

--- a/.agent/skills/remotion/rules/ffmpeg.md
+++ b/.agent/skills/remotion/rules/ffmpeg.md
@@ -1,0 +1,38 @@
+---
+name: ffmpeg
+description: Using FFmpeg and FFprobe in Remotion
+metadata:
+  tags: ffmpeg, ffprobe, video, trimming
+---
+
+## FFmpeg in Remotion
+
+`ffmpeg` and `ffprobe` do not need to be installed. They are available via the `bunx remotion ffmpeg` and `bunx remotion ffprobe`:
+
+```bash
+bunx remotion ffmpeg -i input.mp4 output.mp3
+bunx remotion ffprobe input.mp4
+```
+
+### Trimming videos
+
+You have 2 options for trimming videos:
+
+1. Use the FFmpeg command line. You MUST re-encode the video to avoid frozen frames at the start of the video.
+
+```bash
+# Re-encodes from the exact frame
+bunx remotion ffmpeg -ss 00:00:05 -i public/input.mp4 -to 00:00:10 -c:v libx264 -c:a aac public/output.mp4
+```
+
+2. Use the `trimBefore` and `trimAfter` props of the `<Video>` component. The benefit is that this is non-destructive and you can change the trim at any time.
+
+```tsx
+import { Video } from "@remotion/media";
+
+<Video
+  src={staticFile("video.mp4")}
+  trimBefore={5 * fps}
+  trimAfter={10 * fps}
+/>;
+```

--- a/.agent/skills/remotion/rules/fonts.md
+++ b/.agent/skills/remotion/rules/fonts.md
@@ -1,0 +1,152 @@
+---
+name: fonts
+description: Loading Google Fonts and local fonts in Remotion
+metadata:
+  tags: fonts, google-fonts, typography, text
+---
+
+# Using fonts in Remotion
+
+## Google Fonts with @remotion/google-fonts
+
+The recommended way to use Google Fonts. It's type-safe and automatically blocks rendering until the font is ready.
+
+### Prerequisites
+
+First, the @remotion/google-fonts package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/google-fonts # If project uses npm
+bunx remotion add @remotion/google-fonts # If project uses bun
+yarn remotion add @remotion/google-fonts # If project uses yarn
+pnpm exec remotion add @remotion/google-fonts # If project uses pnpm
+```
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Lobster";
+
+const { fontFamily } = loadFont();
+
+export const MyComposition = () => {
+  return <div style={{ fontFamily }}>Hello World</div>;
+};
+```
+
+Preferrably, specify only needed weights and subsets to reduce file size:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Roboto";
+
+const { fontFamily } = loadFont("normal", {
+  weights: ["400", "700"],
+  subsets: ["latin"],
+});
+```
+
+### Waiting for font to load
+
+Use `waitUntilDone()` if you need to know when the font is ready:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Lobster";
+
+const { fontFamily, waitUntilDone } = loadFont();
+
+await waitUntilDone();
+```
+
+## Local fonts with @remotion/fonts
+
+For local font files, use the `@remotion/fonts` package.
+
+### Prerequisites
+
+First, install @remotion/fonts:
+
+```bash
+npx remotion add @remotion/fonts # If project uses npm
+bunx remotion add @remotion/fonts # If project uses bun
+yarn remotion add @remotion/fonts # If project uses yarn
+pnpm exec remotion add @remotion/fonts # If project uses pnpm
+```
+
+### Loading a local font
+
+Place your font file in the `public/` folder and use `loadFont()`:
+
+```tsx
+import { loadFont } from "@remotion/fonts";
+import { staticFile } from "remotion";
+
+await loadFont({
+  family: "MyFont",
+  url: staticFile("MyFont-Regular.woff2"),
+});
+
+export const MyComposition = () => {
+  return <div style={{ fontFamily: "MyFont" }}>Hello World</div>;
+};
+```
+
+### Loading multiple weights
+
+Load each weight separately with the same family name:
+
+```tsx
+import { loadFont } from "@remotion/fonts";
+import { staticFile } from "remotion";
+
+await Promise.all([
+  loadFont({
+    family: "Inter",
+    url: staticFile("Inter-Regular.woff2"),
+    weight: "400",
+  }),
+  loadFont({
+    family: "Inter",
+    url: staticFile("Inter-Bold.woff2"),
+    weight: "700",
+  }),
+]);
+```
+
+### Available options
+
+```tsx
+loadFont({
+  family: "MyFont", // Required: name to use in CSS
+  url: staticFile("font.woff2"), // Required: font file URL
+  format: "woff2", // Optional: auto-detected from extension
+  weight: "400", // Optional: font weight
+  style: "normal", // Optional: normal or italic
+  display: "block", // Optional: font-display behavior
+});
+```
+
+## Using in components
+
+Call `loadFont()` at the top level of your component or in a separate file that's imported early:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Montserrat";
+
+const { fontFamily } = loadFont("normal", {
+  weights: ["400", "700"],
+  subsets: ["latin"],
+});
+
+export const Title: React.FC<{ text: string }> = ({ text }) => {
+  return (
+    <h1
+      style={{
+        fontFamily,
+        fontSize: 80,
+        fontWeight: "bold",
+      }}
+    >
+      {text}
+    </h1>
+  );
+};
+```

--- a/.agent/skills/remotion/rules/get-audio-duration.md
+++ b/.agent/skills/remotion/rules/get-audio-duration.md
@@ -1,0 +1,58 @@
+---
+name: get-audio-duration
+description: Getting the duration of an audio file in seconds with Mediabunny
+metadata:
+  tags: duration, audio, length, time, seconds, mp3, wav
+---
+
+# Getting audio duration with Mediabunny
+
+Mediabunny can extract the duration of an audio file. It works in browser, Node.js, and Bun environments.
+
+## Getting audio duration
+
+```tsx title="get-audio-duration.ts"
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const getAudioDuration = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  const durationInSeconds = await input.computeDuration();
+  return durationInSeconds;
+};
+```
+
+## Usage
+
+```tsx
+const duration = await getAudioDuration("https://remotion.media/audio.mp3");
+console.log(duration); // e.g. 180.5 (seconds)
+```
+
+## Using with staticFile in Remotion
+
+Make sure to wrap the file path in `staticFile()`:
+
+```tsx
+import { staticFile } from "remotion";
+
+const duration = await getAudioDuration(staticFile("audio.mp3"));
+```
+
+## In Node.js and Bun
+
+Use `FileSource` instead of `UrlSource`:
+
+```tsx
+import { Input, ALL_FORMATS, FileSource } from "mediabunny";
+
+const input = new Input({
+  formats: ALL_FORMATS,
+  source: new FileSource(file), // File object from input or drag-drop
+});
+```

--- a/.agent/skills/remotion/rules/get-video-dimensions.md
+++ b/.agent/skills/remotion/rules/get-video-dimensions.md
@@ -1,0 +1,68 @@
+---
+name: get-video-dimensions
+description: Getting the width and height of a video file with Mediabunny
+metadata:
+  tags: dimensions, width, height, resolution, size, video
+---
+
+# Getting video dimensions with Mediabunny
+
+Mediabunny can extract the width and height of a video file. It works in browser, Node.js, and Bun environments.
+
+## Getting video dimensions
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const getVideoDimensions = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  const videoTrack = await input.getPrimaryVideoTrack();
+  if (!videoTrack) {
+    throw new Error("No video track found");
+  }
+
+  return {
+    width: videoTrack.displayWidth,
+    height: videoTrack.displayHeight,
+  };
+};
+```
+
+## Usage
+
+```tsx
+const dimensions = await getVideoDimensions("https://remotion.media/video.mp4");
+console.log(dimensions.width); // e.g. 1920
+console.log(dimensions.height); // e.g. 1080
+```
+
+## Using with local files
+
+For local files, use `FileSource` instead of `UrlSource`:
+
+```tsx
+import { Input, ALL_FORMATS, FileSource } from "mediabunny";
+
+const input = new Input({
+  formats: ALL_FORMATS,
+  source: new FileSource(file), // File object from input or drag-drop
+});
+
+const videoTrack = await input.getPrimaryVideoTrack();
+const width = videoTrack.displayWidth;
+const height = videoTrack.displayHeight;
+```
+
+## Using with staticFile in Remotion
+
+```tsx
+import { staticFile } from "remotion";
+
+const dimensions = await getVideoDimensions(staticFile("video.mp4"));
+```

--- a/.agent/skills/remotion/rules/get-video-duration.md
+++ b/.agent/skills/remotion/rules/get-video-duration.md
@@ -1,0 +1,60 @@
+---
+name: get-video-duration
+description: Getting the duration of a video file in seconds with Mediabunny
+metadata:
+  tags: duration, video, length, time, seconds
+---
+
+# Getting video duration with Mediabunny
+
+Mediabunny can extract the duration of a video file. It works in browser, Node.js, and Bun environments.
+
+## Getting video duration
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const getVideoDuration = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  const durationInSeconds = await input.computeDuration();
+  return durationInSeconds;
+};
+```
+
+## Usage
+
+```tsx
+const duration = await getVideoDuration("https://remotion.media/video.mp4");
+console.log(duration); // e.g. 10.5 (seconds)
+```
+
+## Video files from the public/ directory
+
+Make sure to wrap the file path in `staticFile()`:
+
+```tsx
+import { staticFile } from "remotion";
+
+const duration = await getVideoDuration(staticFile("video.mp4"));
+```
+
+## In Node.js and Bun
+
+Use `FileSource` instead of `UrlSource`:
+
+```tsx
+import { Input, ALL_FORMATS, FileSource } from "mediabunny";
+
+const input = new Input({
+  formats: ALL_FORMATS,
+  source: new FileSource(file), // File object from input or drag-drop
+});
+
+const durationInSeconds = await input.computeDuration();
+```

--- a/.agent/skills/remotion/rules/gifs.md
+++ b/.agent/skills/remotion/rules/gifs.md
@@ -1,0 +1,141 @@
+---
+name: gif
+description: Displaying GIFs, APNG, AVIF and WebP in Remotion
+metadata:
+  tags: gif, animation, images, animated, apng, avif, webp
+---
+
+# Using Animated images in Remotion
+
+## Basic usage
+
+Use `<AnimatedImage>` to display a GIF, APNG, AVIF or WebP image synchronized with Remotion's timeline:
+
+```tsx
+import { AnimatedImage, staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return (
+    <AnimatedImage src={staticFile("animation.gif")} width={500} height={500} />
+  );
+};
+```
+
+Remote URLs are also supported (must have CORS enabled):
+
+```tsx
+<AnimatedImage
+  src="https://example.com/animation.gif"
+  width={500}
+  height={500}
+/>
+```
+
+## Sizing and fit
+
+Control how the image fills its container with the `fit` prop:
+
+```tsx
+// Stretch to fill (default)
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="fill" />
+
+// Maintain aspect ratio, fit inside container
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="contain" />
+
+// Fill container, crop if needed
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="cover" />
+```
+
+## Playback speed
+
+Use `playbackRate` to control the animation speed:
+
+```tsx
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={2} /> {/* 2x speed */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={0.5} /> {/* Half speed */}
+```
+
+## Looping behavior
+
+Control what happens when the animation finishes:
+
+```tsx
+// Loop indefinitely (default)
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="loop" />
+
+// Play once, show final frame
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="pause-after-finish" />
+
+// Play once, then clear canvas
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="clear-after-finish" />
+```
+
+## Styling
+
+Use the `style` prop for additional CSS (use `width` and `height` props for sizing):
+
+```tsx
+<AnimatedImage
+  src={staticFile("animation.gif")}
+  width={500}
+  height={500}
+  style={{
+    borderRadius: 20,
+    position: "absolute",
+    top: 100,
+    left: 50,
+  }}
+/>
+```
+
+## Getting GIF duration
+
+Use `getGifDurationInSeconds()` from `@remotion/gif` to get the duration of a GIF.
+
+```bash
+npx remotion add @remotion/gif
+```
+
+```tsx
+import { getGifDurationInSeconds } from "@remotion/gif";
+import { staticFile } from "remotion";
+
+const duration = await getGifDurationInSeconds(staticFile("animation.gif"));
+console.log(duration); // e.g. 2.5
+```
+
+This is useful for setting the composition duration to match the GIF:
+
+```tsx
+import { getGifDurationInSeconds } from "@remotion/gif";
+import { staticFile, CalculateMetadataFunction } from "remotion";
+
+const calculateMetadata: CalculateMetadataFunction = async () => {
+  const duration = await getGifDurationInSeconds(staticFile("animation.gif"));
+  return {
+    durationInFrames: Math.ceil(duration * 30),
+  };
+};
+```
+
+## Alternative
+
+If `<AnimatedImage>` does not work (only supported in Chrome and Firefox), you can use `<Gif>` from `@remotion/gif` instead.
+
+```bash
+npx remotion add @remotion/gif # If project uses npm
+bunx remotion add @remotion/gif # If project uses bun
+yarn remotion add @remotion/gif # If project uses yarn
+pnpm exec remotion add @remotion/gif # If project uses pnpm
+```
+
+```tsx
+import { Gif } from "@remotion/gif";
+import { staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Gif src={staticFile("animation.gif")} width={500} height={500} />;
+};
+```
+
+The `<Gif>` component has the same props as `<AnimatedImage>` but only supports GIF files.

--- a/.agent/skills/remotion/rules/images.md
+++ b/.agent/skills/remotion/rules/images.md
@@ -1,0 +1,134 @@
+---
+name: images
+description: Embedding images in Remotion using the <Img> component
+metadata:
+  tags: images, img, staticFile, png, jpg, svg, webp
+---
+
+# Using images in Remotion
+
+## The `<Img>` component
+
+Always use the `<Img>` component from `remotion` to display images:
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Img src={staticFile("photo.png")} />;
+};
+```
+
+## Important restrictions
+
+**You MUST use the `<Img>` component from `remotion`.** Do not use:
+
+- Native HTML `<img>` elements
+- Next.js `<Image>` component
+- CSS `background-image`
+
+The `<Img>` component ensures images are fully loaded before rendering, preventing flickering and blank frames during video export.
+
+## Local images with staticFile()
+
+Place images in the `public/` folder and use `staticFile()` to reference them:
+
+```
+my-video/
+├─ public/
+│  ├─ logo.png
+│  ├─ avatar.jpg
+│  └─ icon.svg
+├─ src/
+├─ package.json
+```
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+<Img src={staticFile("logo.png")} />;
+```
+
+## Remote images
+
+Remote URLs can be used directly without `staticFile()`:
+
+```tsx
+<Img src="https://example.com/image.png" />
+```
+
+Ensure remote images have CORS enabled.
+
+For animated GIFs, use the `<Gif>` component from `@remotion/gif` instead.
+
+## Sizing and positioning
+
+Use the `style` prop to control size and position:
+
+```tsx
+<Img
+  src={staticFile("photo.png")}
+  style={{
+    width: 500,
+    height: 300,
+    position: "absolute",
+    top: 100,
+    left: 50,
+    objectFit: "cover",
+  }}
+/>
+```
+
+## Dynamic image paths
+
+Use template literals for dynamic file references:
+
+```tsx
+import { Img, staticFile, useCurrentFrame } from "remotion";
+
+const frame = useCurrentFrame();
+
+// Image sequence
+<Img src={staticFile(`frames/frame${frame}.png`)} />
+
+// Selecting based on props
+<Img src={staticFile(`avatars/${props.userId}.png`)} />
+
+// Conditional images
+<Img src={staticFile(`icons/${isActive ? "active" : "inactive"}.svg`)} />
+```
+
+This pattern is useful for:
+
+- Image sequences (frame-by-frame animations)
+- User-specific avatars or profile images
+- Theme-based icons
+- State-dependent graphics
+
+## Getting image dimensions
+
+Use `getImageDimensions()` to get the dimensions of an image:
+
+```tsx
+import { getImageDimensions, staticFile } from "remotion";
+
+const { width, height } = await getImageDimensions(staticFile("photo.png"));
+```
+
+This is useful for calculating aspect ratios or sizing compositions:
+
+```tsx
+import {
+  getImageDimensions,
+  staticFile,
+  CalculateMetadataFunction,
+} from "remotion";
+
+const calculateMetadata: CalculateMetadataFunction = async () => {
+  const { width, height } = await getImageDimensions(staticFile("photo.png"));
+  return {
+    width,
+    height,
+  };
+};
+```

--- a/.agent/skills/remotion/rules/import-srt-captions.md
+++ b/.agent/skills/remotion/rules/import-srt-captions.md
@@ -1,0 +1,69 @@
+---
+name: import-srt-captions
+description: Importing .srt subtitle files into Remotion using @remotion/captions
+metadata:
+  tags: captions, subtitles, srt, import, parse
+---
+
+# Importing .srt subtitles into Remotion
+
+If you have an existing `.srt` subtitle file, you can import it into Remotion using `parseSrt()` from `@remotion/captions`.
+
+If you don't have a .srt file, read [Transcribing audio](transcribe-captions.md) for how to generate captions instead.
+
+## Prerequisites
+
+First, the @remotion/captions package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/captions # If project uses npm
+bunx remotion add @remotion/captions # If project uses bun
+yarn remotion add @remotion/captions # If project uses yarn
+pnpm exec remotion add @remotion/captions # If project uses pnpm
+```
+
+## Reading an .srt file
+
+Use `staticFile()` to reference an `.srt` file in your `public` folder, then fetch and parse it:
+
+```tsx
+import { useState, useEffect, useCallback } from "react";
+import { AbsoluteFill, staticFile, useDelayRender } from "remotion";
+import { parseSrt } from "@remotion/captions";
+import type { Caption } from "@remotion/captions";
+
+export const MyComponent: React.FC = () => {
+  const [captions, setCaptions] = useState<Caption[] | null>(null);
+  const { delayRender, continueRender, cancelRender } = useDelayRender();
+  const [handle] = useState(() => delayRender());
+
+  const fetchCaptions = useCallback(async () => {
+    try {
+      const response = await fetch(staticFile("subtitles.srt"));
+      const text = await response.text();
+      const { captions: parsed } = parseSrt({ input: text });
+      setCaptions(parsed);
+      continueRender(handle);
+    } catch (e) {
+      cancelRender(e);
+    }
+  }, [continueRender, cancelRender, handle]);
+
+  useEffect(() => {
+    fetchCaptions();
+  }, [fetchCaptions]);
+
+  if (!captions) {
+    return null;
+  }
+
+  return <AbsoluteFill>{/* Use captions here */}</AbsoluteFill>;
+};
+```
+
+Remote URLs are also supported - you can `fetch()` a remote file via URL instead of using `staticFile()`.
+
+## Using imported captions
+
+Once parsed, the captions are in the `Caption` format and can be used with all `@remotion/captions` utilities.

--- a/.agent/skills/remotion/rules/light-leaks.md
+++ b/.agent/skills/remotion/rules/light-leaks.md
@@ -1,0 +1,73 @@
+---
+name: light-leaks
+description: Light leak overlay effects for Remotion using @remotion/light-leaks.
+metadata:
+  tags: light-leaks, overlays, effects, transitions
+---
+
+## Light Leaks
+
+This only works from Remotion 4.0.415 and up. Use `npx remotion versions` to check your Remotion version and `npx remotion upgrade` to upgrade your Remotion version.
+
+`<LightLeak>` from `@remotion/light-leaks` renders a WebGL-based light leak effect. It reveals during the first half of its duration and retracts during the second half.
+
+Typically used inside a `<TransitionSeries.Overlay>` to play over the cut point between two scenes. See the **transitions** rule for `<TransitionSeries>` and overlay usage.
+
+## Prerequisites
+
+```bash
+npx remotion add @remotion/light-leaks
+```
+
+## Basic usage with TransitionSeries
+
+```tsx
+import { TransitionSeries } from "@remotion/transitions";
+import { LightLeak } from "@remotion/light-leaks";
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneA />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Overlay durationInFrames={30}>
+    <LightLeak />
+  </TransitionSeries.Overlay>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneB />
+  </TransitionSeries.Sequence>
+</TransitionSeries>;
+```
+
+## Props
+
+- `durationInFrames?` — defaults to the parent sequence/composition duration. The effect reveals during the first half and retracts during the second half.
+- `seed?` — determines the shape of the light leak pattern. Different seeds produce different patterns. Default: `0`.
+- `hueShift?` — rotates the hue in degrees (`0`–`360`). Default: `0` (yellow-to-orange). `120` = green, `240` = blue.
+
+## Customizing the look
+
+```tsx
+import { LightLeak } from "@remotion/light-leaks";
+
+// Blue-tinted light leak with a different pattern
+<LightLeak seed={5} hueShift={240} />;
+
+// Green-tinted light leak
+<LightLeak seed={2} hueShift={120} />;
+```
+
+## Standalone usage
+
+`<LightLeak>` can also be used outside of `<TransitionSeries>`, for example as a decorative overlay in any composition:
+
+```tsx
+import { AbsoluteFill } from "remotion";
+import { LightLeak } from "@remotion/light-leaks";
+
+const MyComp: React.FC = () => (
+  <AbsoluteFill>
+    <MyContent />
+    <LightLeak durationInFrames={60} seed={3} />
+  </AbsoluteFill>
+);
+```

--- a/.agent/skills/remotion/rules/lottie.md
+++ b/.agent/skills/remotion/rules/lottie.md
@@ -1,0 +1,70 @@
+---
+name: lottie
+description: Embedding Lottie animations in Remotion.
+metadata:
+  category: Animation
+---
+
+# Using Lottie Animations in Remotion
+
+## Prerequisites
+
+First, the @remotion/lottie package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/lottie # If project uses npm
+bunx remotion add @remotion/lottie # If project uses bun
+yarn remotion add @remotion/lottie # If project uses yarn
+pnpm exec remotion add @remotion/lottie # If project uses pnpm
+```
+
+## Displaying a Lottie file
+
+To import a Lottie animation:
+
+- Fetch the Lottie asset
+- Wrap the loading process in `delayRender()` and `continueRender()`
+- Save the animation data in a state
+- Render the Lottie animation using the `Lottie` component from the `@remotion/lottie` package
+
+```tsx
+import { Lottie, LottieAnimationData } from "@remotion/lottie";
+import { useEffect, useState } from "react";
+import { cancelRender, continueRender, delayRender } from "remotion";
+
+export const MyAnimation = () => {
+  const [handle] = useState(() => delayRender("Loading Lottie animation"));
+
+  const [animationData, setAnimationData] =
+    useState<LottieAnimationData | null>(null);
+
+  useEffect(() => {
+    fetch("https://assets4.lottiefiles.com/packages/lf20_zyquagfl.json")
+      .then((data) => data.json())
+      .then((json) => {
+        setAnimationData(json);
+        continueRender(handle);
+      })
+      .catch((err) => {
+        cancelRender(err);
+      });
+  }, [handle]);
+
+  if (!animationData) {
+    return null;
+  }
+
+  return <Lottie animationData={animationData} />;
+};
+```
+
+## Styling and animating
+
+Lottie supports the `style` prop to allow styles and animations:
+
+```tsx
+return (
+  <Lottie animationData={animationData} style={{ width: 400, height: 400 }} />
+);
+```

--- a/.agent/skills/remotion/rules/maps.md
+++ b/.agent/skills/remotion/rules/maps.md
@@ -1,0 +1,412 @@
+---
+name: maps
+description: Make map animations with Mapbox
+metadata:
+  tags: map, map animation, mapbox
+---
+
+Maps can be added to a Remotion video with Mapbox.  
+The [Mapbox documentation](https://docs.mapbox.com/mapbox-gl-js/api/) has the API reference.
+
+## Prerequisites
+
+Mapbox and `@turf/turf` need to be installed.
+
+Search the project for lockfiles and run the correct command depending on the package manager:
+
+If `package-lock.json` is found, use the following command:
+
+```bash
+npm i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `bun.lock` is found, use the following command:
+
+```bash
+bun i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `yarn.lock` is found, use the following command:
+
+```bash
+yarn add mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `pnpm-lock.yaml` is found, use the following command:
+
+```bash
+pnpm i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+The user needs to create a free Mapbox account and create an access token by visiting https://console.mapbox.com/account/access-tokens/.
+
+The mapbox token needs to be added to the `.env` file:
+
+```txt title=".env"
+REMOTION_MAPBOX_TOKEN==pk.your-mapbox-access-token
+```
+
+## Adding a map
+
+Here is a basic example of a map in Remotion.
+
+```tsx
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AbsoluteFill, useDelayRender, useVideoConfig } from "remotion";
+import mapboxgl, { Map } from "mapbox-gl";
+
+export const lineCoordinates = [
+  [6.56158447265625, 46.059891147620725],
+  [6.5691375732421875, 46.05679376154153],
+  [6.5842437744140625, 46.05059898938315],
+  [6.594886779785156, 46.04702502069337],
+  [6.601066589355469, 46.0460718554722],
+  [6.6089630126953125, 46.0365370783104],
+  [6.6185760498046875, 46.018420689207964],
+];
+
+mapboxgl.accessToken = process.env.REMOTION_MAPBOX_TOKEN as string;
+
+export const MyComposition = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const { delayRender, continueRender } = useDelayRender();
+
+  const { width, height } = useVideoConfig();
+  const [handle] = useState(() => delayRender("Loading map..."));
+  const [map, setMap] = useState<Map | null>(null);
+
+  useEffect(() => {
+    const _map = new Map({
+      container: ref.current!,
+      zoom: 11.53,
+      center: [6.5615, 46.0598],
+      pitch: 65,
+      bearing: 0,
+      style: "⁠mapbox://styles/mapbox/standard",
+      interactive: false,
+      fadeDuration: 0,
+    });
+
+    _map.on("style.load", () => {
+      // Hide all features from the Mapbox Standard style
+      const hideFeatures = [
+        "showRoadsAndTransit",
+        "showRoads",
+        "showTransit",
+        "showPedestrianRoads",
+        "showRoadLabels",
+        "showTransitLabels",
+        "showPlaceLabels",
+        "showPointOfInterestLabels",
+        "showPointsOfInterest",
+        "showAdminBoundaries",
+        "showLandmarkIcons",
+        "showLandmarkIconLabels",
+        "show3dObjects",
+        "show3dBuildings",
+        "show3dTrees",
+        "show3dLandmarks",
+        "show3dFacades",
+      ];
+      for (const feature of hideFeatures) {
+        _map.setConfigProperty("basemap", feature, false);
+      }
+
+      _map.setConfigProperty("basemap", "colorTrunks", "rgba(0, 0, 0, 0)");
+
+      _map.addSource("trace", {
+        type: "geojson",
+        data: {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "LineString",
+            coordinates: lineCoordinates,
+          },
+        },
+      });
+      _map.addLayer({
+        type: "line",
+        source: "trace",
+        id: "line",
+        paint: {
+          "line-color": "black",
+          "line-width": 5,
+        },
+        layout: {
+          "line-cap": "round",
+          "line-join": "round",
+        },
+      });
+    });
+
+    _map.on("load", () => {
+      continueRender(handle);
+      setMap(_map);
+    });
+  }, [handle, lineCoordinates]);
+
+  const style: React.CSSProperties = useMemo(
+    () => ({ width, height, position: "absolute" }),
+    [width, height],
+  );
+
+  return <AbsoluteFill ref={ref} style={style} />;
+};
+```
+
+The following is important in Remotion:
+
+- Animations must be driven by `useCurrentFrame()` and animations that Mapbox brings itself should be disabled. For example, the `fadeDuration` prop should be set to `0`, `interactive` should be set to `false`, etc.
+- Loading the map should be delayed using `useDelayRender()` and the map should be set to `null` until it is loaded.
+- The element containing the ref MUST have an explicit width and height and `position: "absolute"`.
+- Do not add a `_map.remove();` cleanup function.
+
+## Drawing lines
+
+Unless I request it, do not add a glow effect to the lines.
+Unless I request it, do not add additional points to the lines.
+
+## Map style
+
+By default, use the `mapbox://styles/mapbox/standard` style.  
+Hide the labels from the base map style.
+
+Unless I request otherwise, remove all features from the Mapbox Standard style.
+
+```tsx
+// Hide all features from the Mapbox Standard style
+const hideFeatures = [
+  "showRoadsAndTransit",
+  "showRoads",
+  "showTransit",
+  "showPedestrianRoads",
+  "showRoadLabels",
+  "showTransitLabels",
+  "showPlaceLabels",
+  "showPointOfInterestLabels",
+  "showPointsOfInterest",
+  "showAdminBoundaries",
+  "showLandmarkIcons",
+  "showLandmarkIconLabels",
+  "show3dObjects",
+  "show3dBuildings",
+  "show3dTrees",
+  "show3dLandmarks",
+  "show3dFacades",
+];
+for (const feature of hideFeatures) {
+  _map.setConfigProperty("basemap", feature, false);
+}
+
+_map.setConfigProperty("basemap", "colorMotorways", "transparent");
+_map.setConfigProperty("basemap", "colorRoads", "transparent");
+_map.setConfigProperty("basemap", "colorTrunks", "transparent");
+```
+
+## Animating the camera
+
+You can animate the camera along the line by adding a `useEffect` hook that updates the camera position based on the current frame.
+
+Unless I ask for it, do not jump between camera angles.
+
+```tsx
+import * as turf from "@turf/turf";
+import { interpolate } from "remotion";
+import { Easing } from "remotion";
+import { useCurrentFrame, useVideoConfig, useDelayRender } from "remotion";
+
+const animationDuration = 20;
+const cameraAltitude = 4000;
+```
+
+```tsx
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+const { delayRender, continueRender } = useDelayRender();
+
+useEffect(() => {
+  if (!map) {
+    return;
+  }
+  const handle = delayRender("Moving point...");
+
+  const routeDistance = turf.length(turf.lineString(lineCoordinates));
+
+  const progress = interpolate(
+    frame / fps,
+    [0.00001, animationDuration],
+    [0, 1],
+    {
+      easing: Easing.inOut(Easing.sin),
+      extrapolateLeft: "clamp",
+      extrapolateRight: "clamp",
+    },
+  );
+
+  const camera = map.getFreeCameraOptions();
+
+  const alongRoute = turf.along(
+    turf.lineString(lineCoordinates),
+    routeDistance * progress,
+  ).geometry.coordinates;
+
+  camera.lookAtPoint({
+    lng: alongRoute[0],
+    lat: alongRoute[1],
+  });
+
+  map.setFreeCameraOptions(camera);
+  map.once("idle", () => continueRender(handle));
+}, [lineCoordinates, fps, frame, handle, map]);
+```
+
+Notes:
+
+IMPORTANT: Keep the camera by default so north is up.
+IMPORTANT: For multi-step animations, set all properties at all stages (zoom, position, line progress) to prevent jumps. Override initial values.
+
+- The progress is clamped to a minimum value to avoid the line being empty, which can lead to turf errors
+- See [Timing](./timing.md) for more options for timing.
+- Consider the dimensions of the composition and make the lines thick enough and the label font size large enough to be legible for when the composition is scaled down.
+
+## Animating lines
+
+### Straight lines (linear interpolation)
+
+To animate a line that appears straight on the map, use linear interpolation between coordinates. Do NOT use turf's `lineSliceAlong` or `along` functions, as they use geodesic (great circle) calculations which appear curved on a Mercator projection.
+
+```tsx
+const frame = useCurrentFrame();
+const { durationInFrames } = useVideoConfig();
+
+useEffect(() => {
+  if (!map) return;
+
+  const animationHandle = delayRender("Animating line...");
+
+  const progress = interpolate(frame, [0, durationInFrames - 1], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.inOut(Easing.cubic),
+  });
+
+  // Linear interpolation for a straight line on the map
+  const start = lineCoordinates[0];
+  const end = lineCoordinates[1];
+  const currentLng = start[0] + (end[0] - start[0]) * progress;
+  const currentLat = start[1] + (end[1] - start[1]) * progress;
+
+  const lineData: GeoJSON.Feature<GeoJSON.LineString> = {
+    type: "Feature",
+    properties: {},
+    geometry: {
+      type: "LineString",
+      coordinates: [start, [currentLng, currentLat]],
+    },
+  };
+
+  const source = map.getSource("trace") as mapboxgl.GeoJSONSource;
+  if (source) {
+    source.setData(lineData);
+  }
+
+  map.once("idle", () => continueRender(animationHandle));
+}, [frame, map, durationInFrames]);
+```
+
+### Curved lines (geodesic/great circle)
+
+To animate a line that follows the geodesic (great circle) path between two points, use turf's `lineSliceAlong`. This is useful for showing flight paths or the actual shortest distance on Earth.
+
+```tsx
+import * as turf from "@turf/turf";
+
+const routeLine = turf.lineString(lineCoordinates);
+const routeDistance = turf.length(routeLine);
+
+const currentDistance = Math.max(0.001, routeDistance * progress);
+const slicedLine = turf.lineSliceAlong(routeLine, 0, currentDistance);
+
+const source = map.getSource("route") as mapboxgl.GeoJSONSource;
+if (source) {
+  source.setData(slicedLine);
+}
+```
+
+## Markers
+
+Add labels, and markers where appropriate.
+
+```tsx
+_map.addSource("markers", {
+  type: "geojson",
+  data: {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        properties: { name: "Point 1" },
+        geometry: { type: "Point", coordinates: [-118.2437, 34.0522] },
+      },
+    ],
+  },
+});
+
+_map.addLayer({
+  id: "city-markers",
+  type: "circle",
+  source: "markers",
+  paint: {
+    "circle-radius": 40,
+    "circle-color": "#FF4444",
+    "circle-stroke-width": 4,
+    "circle-stroke-color": "#FFFFFF",
+  },
+});
+
+_map.addLayer({
+  id: "labels",
+  type: "symbol",
+  source: "markers",
+  layout: {
+    "text-field": ["get", "name"],
+    "text-font": ["DIN Pro Bold", "Arial Unicode MS Bold"],
+    "text-size": 50,
+    "text-offset": [0, 0.5],
+    "text-anchor": "top",
+  },
+  paint: {
+    "text-color": "#FFFFFF",
+    "text-halo-color": "#000000",
+    "text-halo-width": 2,
+  },
+});
+```
+
+Make sure they are big enough. Check the composition dimensions and scale the labels accordingly.
+For a composition size of 1920x1080, the label font size should be at least 40px.
+
+IMPORTANT: Keep the `text-offset` small enough so it is close to the marker. Consider the marker circle radius. For a circle radius of 40, this is a good offset:
+
+```tsx
+"text-offset": [0, 0.5],
+```
+
+## 3D buildings
+
+To enable 3D buildings, use the following code:
+
+```tsx
+_map.setConfigProperty("basemap", "show3dObjects", true);
+_map.setConfigProperty("basemap", "show3dLandmarks", true);
+_map.setConfigProperty("basemap", "show3dBuildings", true);
+```
+
+## Rendering
+
+When rendering a map animation, make sure to render with the following flags:
+
+```
+npx remotion render --gl=angle --concurrency=1
+```

--- a/.agent/skills/remotion/rules/measuring-dom-nodes.md
+++ b/.agent/skills/remotion/rules/measuring-dom-nodes.md
@@ -1,0 +1,34 @@
+---
+name: measuring-dom-nodes
+description: Measuring DOM element dimensions in Remotion
+metadata:
+  tags: measure, layout, dimensions, getBoundingClientRect, scale
+---
+
+# Measuring DOM nodes in Remotion
+
+Remotion applies a `scale()` transform to the video container, which affects values from `getBoundingClientRect()`. Use `useCurrentScale()` to get correct measurements.
+
+## Measuring element dimensions
+
+```tsx
+import { useCurrentScale } from "remotion";
+import { useRef, useEffect, useState } from "react";
+
+export const MyComponent = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const scale = useCurrentScale();
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    setDimensions({
+      width: rect.width / scale,
+      height: rect.height / scale,
+    });
+  }, [scale]);
+
+  return <div ref={ref}>Content to measure</div>;
+};
+```

--- a/.agent/skills/remotion/rules/measuring-text.md
+++ b/.agent/skills/remotion/rules/measuring-text.md
@@ -1,0 +1,140 @@
+---
+name: measuring-text
+description: Measuring text dimensions, fitting text to containers, and checking overflow
+metadata:
+  tags: measure, text, layout, dimensions, fitText, fillTextBox
+---
+
+# Measuring text in Remotion
+
+## Prerequisites
+
+Install @remotion/layout-utils if it is not already installed:
+
+```bash
+npx remotion add @remotion/layout-utils
+```
+
+## Measuring text dimensions
+
+Use `measureText()` to calculate the width and height of text:
+
+```tsx
+import { measureText } from "@remotion/layout-utils";
+
+const { width, height } = measureText({
+  text: "Hello World",
+  fontFamily: "Arial",
+  fontSize: 32,
+  fontWeight: "bold",
+});
+```
+
+Results are cached - duplicate calls return the cached result.
+
+## Fitting text to a width
+
+Use `fitText()` to find the optimal font size for a container:
+
+```tsx
+import { fitText } from "@remotion/layout-utils";
+
+const { fontSize } = fitText({
+  text: "Hello World",
+  withinWidth: 600,
+  fontFamily: "Inter",
+  fontWeight: "bold",
+});
+
+return (
+  <div
+    style={{
+      fontSize: Math.min(fontSize, 80), // Cap at 80px
+      fontFamily: "Inter",
+      fontWeight: "bold",
+    }}
+  >
+    Hello World
+  </div>
+);
+```
+
+## Checking text overflow
+
+Use `fillTextBox()` to check if text exceeds a box:
+
+```tsx
+import { fillTextBox } from "@remotion/layout-utils";
+
+const box = fillTextBox({ maxBoxWidth: 400, maxLines: 3 });
+
+const words = ["Hello", "World", "This", "is", "a", "test"];
+for (const word of words) {
+  const { exceedsBox } = box.add({
+    text: word + " ",
+    fontFamily: "Arial",
+    fontSize: 24,
+  });
+  if (exceedsBox) {
+    // Text would overflow, handle accordingly
+    break;
+  }
+}
+```
+
+## Best practices
+
+**Load fonts first:** Only call measurement functions after fonts are loaded.
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily, waitUntilDone } = loadFont("normal", {
+  weights: ["400"],
+  subsets: ["latin"],
+});
+
+waitUntilDone().then(() => {
+  // Now safe to measure
+  const { width } = measureText({
+    text: "Hello",
+    fontFamily,
+    fontSize: 32,
+  });
+});
+```
+
+**Use validateFontIsLoaded:** Catch font loading issues early:
+
+```tsx
+measureText({
+  text: "Hello",
+  fontFamily: "MyCustomFont",
+  fontSize: 32,
+  validateFontIsLoaded: true, // Throws if font not loaded
+});
+```
+
+**Match font properties:** Use the same properties for measurement and rendering:
+
+```tsx
+const fontStyle = {
+  fontFamily: "Inter",
+  fontSize: 32,
+  fontWeight: "bold" as const,
+  letterSpacing: "0.5px",
+};
+
+const { width } = measureText({
+  text: "Hello",
+  ...fontStyle,
+});
+
+return <div style={fontStyle}>Hello</div>;
+```
+
+**Avoid padding and border:** Use `outline` instead of `border` to prevent layout differences:
+
+```tsx
+<div style={{ outline: "2px solid red" }}>Text</div>
+```

--- a/.agent/skills/remotion/rules/parameters.md
+++ b/.agent/skills/remotion/rules/parameters.md
@@ -1,0 +1,109 @@
+---
+name: parameters
+description: Make a video parametrizable by adding a Zod schema
+metadata:
+  tags: parameters, zod, schema
+---
+
+To make a video parametrizable, a Zod schema can be added to a composition.
+
+First, `zod` must be installed .
+
+Search the project for lockfiles and run the correct command depending on the package manager:
+
+If `package-lock.json` is found, use the following command:
+
+```bash
+npm i zod
+```
+
+If `bun.lockb` is found, use the following command:
+
+```bash
+bun i zod
+```
+
+If `yarn.lock` is found, use the following command:
+
+```bash
+yarn add zod
+```
+
+If `pnpm-lock.yaml` is found, use the following command:
+
+```bash
+pnpm i zod
+```
+
+Then, a Zod schema can be defined alongside the component:
+
+```tsx title="src/MyComposition.tsx"
+import { z } from "zod";
+
+export const MyCompositionSchema = z.object({
+  title: z.string(),
+});
+
+const MyComponent: React.FC<z.infer<typeof MyCompositionSchema>> = () => {
+  return (
+    <div>
+      <h1>{props.title}</h1>
+    </div>
+  );
+};
+```
+
+In the root file, the schema can be passed to the composition:
+
+```tsx title="src/Root.tsx"
+import { Composition } from "remotion";
+import { MycComponent, MyCompositionSchema } from "./MyComposition";
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="MyComposition"
+      component={MyComponent}
+      durationInFrames={100}
+      fps={30}
+      width={1080}
+      height={1080}
+      defaultProps={{ title: "Hello World" }}
+      schema={MyCompositionSchema}
+    />
+  );
+};
+```
+
+Now, the user can edit the parameter visually in the sidebar.
+
+All schemas that are supported by Zod are supported by Remotion.
+
+Remotion requires that the top-level type is a z.object(), because the collection of props of a React component is always an object.
+
+## Color picker
+
+For adding a color picker, use `zColor()` from `@remotion/zod-types`.
+
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/zod-types # If project uses npm
+bunx remotion add @remotion/zod-types # If project uses bun
+yarn remotion add @remotion/zod-types # If project uses yarn
+pnpm exec remotion add @remotion/zod-types # If project uses pnpm
+```
+
+Then import `zColor` from `@remotion/zod-types`:
+
+```tsx
+import { zColor } from "@remotion/zod-types";
+```
+
+Then use it in the schema:
+
+```tsx
+export const MyCompositionSchema = z.object({
+  color: zColor(),
+});
+```

--- a/.agent/skills/remotion/rules/sequencing.md
+++ b/.agent/skills/remotion/rules/sequencing.md
@@ -1,0 +1,118 @@
+---
+name: sequencing
+description: Sequencing patterns for Remotion - delay, trim, limit duration of items
+metadata:
+  tags: sequence, series, timing, delay, trim
+---
+
+Use `<Sequence>` to delay when an element appears in the timeline.
+
+```tsx
+import { Sequence } from "remotion";
+
+const {fps} = useVideoConfig();
+
+<Sequence from={1 * fps} durationInFrames={2 * fps} premountFor={1 * fps}>
+  <Title />
+</Sequence>
+<Sequence from={2 * fps} durationInFrames={2 * fps} premountFor={1 * fps}>
+  <Subtitle />
+</Sequence>
+```
+
+This will by default wrap the component in an absolute fill element.  
+If the items should not be wrapped, use the `layout` prop:
+
+```tsx
+<Sequence layout="none">
+  <Title />
+</Sequence>
+```
+
+## Premounting
+
+This loads the component in the timeline before it is actually played.  
+Always premount any `<Sequence>`!
+
+```tsx
+<Sequence premountFor={1 * fps}>
+  <Title />
+</Sequence>
+```
+
+## Series
+
+Use `<Series>` when elements should play one after another without overlap.
+
+```tsx
+import { Series } from "remotion";
+
+<Series>
+  <Series.Sequence durationInFrames={45}>
+    <Intro />
+  </Series.Sequence>
+  <Series.Sequence durationInFrames={60}>
+    <MainContent />
+  </Series.Sequence>
+  <Series.Sequence durationInFrames={30}>
+    <Outro />
+  </Series.Sequence>
+</Series>;
+```
+
+Same as with `<Sequence>`, the items will be wrapped in an absolute fill element by default when using `<Series.Sequence>`, unless the `layout` prop is set to `none`.
+
+### Series with overlaps
+
+Use negative offset for overlapping sequences:
+
+```tsx
+<Series>
+  <Series.Sequence durationInFrames={60}>
+    <SceneA />
+  </Series.Sequence>
+  <Series.Sequence offset={-15} durationInFrames={60}>
+    {/* Starts 15 frames before SceneA ends */}
+    <SceneB />
+  </Series.Sequence>
+</Series>
+```
+
+## Frame References Inside Sequences
+
+Inside a Sequence, `useCurrentFrame()` returns the local frame (starting from 0):
+
+```tsx
+<Sequence from={60} durationInFrames={30}>
+  <MyComponent />
+  {/* Inside MyComponent, useCurrentFrame() returns 0-29, not 60-89 */}
+</Sequence>
+```
+
+## Nested Sequences
+
+Sequences can be nested for complex timing:
+
+```tsx
+<Sequence from={0} durationInFrames={120}>
+  <Background />
+  <Sequence from={15} durationInFrames={90} layout="none">
+    <Title />
+  </Sequence>
+  <Sequence from={45} durationInFrames={60} layout="none">
+    <Subtitle />
+  </Sequence>
+</Sequence>
+```
+
+## Nesting compositions within another
+
+To add a composition within another composition, you can use the `<Sequence>` component with a `width` and `height` prop to specify the size of the composition.
+
+```tsx
+<AbsoluteFill>
+  <Sequence width={COMPOSITION_WIDTH} height={COMPOSITION_HEIGHT}>
+    <CompositionComponent />
+  </Sequence>
+</AbsoluteFill>
+```

--- a/.agent/skills/remotion/rules/sfx.md
+++ b/.agent/skills/remotion/rules/sfx.md
@@ -1,0 +1,30 @@
+---
+name: sfx
+description: Including sound effects
+metadata:
+  tags: sfx, sound, effect, audio
+---
+
+To include a sound effect, use the `<Audio>` tag:
+
+```tsx
+import { Audio } from "@remotion/sfx";
+
+<Audio src={"https://remotion.media/whoosh.wav"} />;
+```
+
+The following sound effects are available:
+
+- `https://remotion.media/whoosh.wav`
+- `https://remotion.media/whip.wav`
+- `https://remotion.media/page-turn.wav`
+- `https://remotion.media/switch.wav`
+- `https://remotion.media/mouse-click.wav`
+- `https://remotion.media/shutter-modern.wav`
+- `https://remotion.media/shutter-old.wav`
+- `https://remotion.media/ding.wav`
+- `https://remotion.media/bruh.wav`
+- `https://remotion.media/vine-boom.wav`
+- `https://remotion.media/windows-xp-error.wav`
+
+For more sound effects, search the internet. A good resource is https://github.com/kapishdima/soundcn/tree/main/assets.

--- a/.agent/skills/remotion/rules/subtitles.md
+++ b/.agent/skills/remotion/rules/subtitles.md
@@ -1,0 +1,36 @@
+---
+name: subtitles
+description: subtitles and caption rules
+metadata:
+  tags: subtitles, captions, remotion, json
+---
+
+All captions must be processed in JSON. The captions must use the `Caption` type which is the following:
+
+```ts
+import type { Caption } from "@remotion/captions";
+```
+
+This is the definition:
+
+```ts
+type Caption = {
+  text: string;
+  startMs: number;
+  endMs: number;
+  timestampMs: number | null;
+  confidence: number | null;
+};
+```
+
+## Generating captions
+
+To transcribe video and audio files to generate captions, load the [./transcribe-captions.md](./transcribe-captions.md) file for more instructions.
+
+## Displaying captions
+
+To display captions in your video, load the [./display-captions.md](./display-captions.md) file for more instructions.
+
+## Importing captions
+
+To import captions from a .srt file, load the [./import-srt-captions.md](./import-srt-captions.md) file for more instructions.

--- a/.agent/skills/remotion/rules/tailwind.md
+++ b/.agent/skills/remotion/rules/tailwind.md
@@ -1,0 +1,11 @@
+---
+name: tailwind
+description: Using TailwindCSS in Remotion.
+metadata:
+---
+
+You can and should use TailwindCSS in Remotion, if TailwindCSS is installed in the project.
+
+Don't use `transition-*` or `animate-*` classes - always animate using the `useCurrentFrame()` hook.
+
+Tailwind must be installed and enabled first in a Remotion project - fetch https://www.remotion.dev/docs/tailwind using WebFetch for instructions.

--- a/.agent/skills/remotion/rules/text-animations.md
+++ b/.agent/skills/remotion/rules/text-animations.md
@@ -1,0 +1,20 @@
+---
+name: text-animations
+description: Typography and text animation patterns for Remotion.
+metadata:
+  tags: typography, text, typewriter, highlighter ken
+---
+
+## Text animations
+
+Based on `useCurrentFrame()`, reduce the string character by character to create a typewriter effect.
+
+## Typewriter Effect
+
+See [Typewriter](assets/text-animations-typewriter.tsx) for an advanced example with a blinking cursor and a pause after the first sentence.
+
+Always use string slicing for typewriter effects. Never use per-character opacity.
+
+## Word Highlighting
+
+See [Word Highlight](assets/text-animations-word-highlight.tsx) for an example for how a word highlight is animated, like with a highlighter pen.

--- a/.agent/skills/remotion/rules/timing.md
+++ b/.agent/skills/remotion/rules/timing.md
@@ -1,0 +1,179 @@
+---
+name: timing
+description: Interpolation curves in Remotion - linear, easing, spring animations
+metadata:
+  tags: spring, bounce, easing, interpolation
+---
+
+A simple linear interpolation is done using the `interpolate` function.
+
+```ts title="Going from 0 to 1 over 100 frames"
+import { interpolate } from "remotion";
+
+const opacity = interpolate(frame, [0, 100], [0, 1]);
+```
+
+By default, the values are not clamped, so the value can go outside the range [0, 1].  
+Here is how they can be clamped:
+
+```ts title="Going from 0 to 1 over 100 frames with extrapolation"
+const opacity = interpolate(frame, [0, 100], [0, 1], {
+  extrapolateRight: "clamp",
+  extrapolateLeft: "clamp",
+});
+```
+
+## Spring animations
+
+Spring animations have a more natural motion.  
+They go from 0 to 1 over time.
+
+```ts title="Spring animation from 0 to 1 over 100 frames"
+import { spring, useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+const scale = spring({
+  frame,
+  fps,
+});
+```
+
+### Physical properties
+
+The default configuration is: `mass: 1, damping: 10, stiffness: 100`.  
+This leads to the animation having a bit of bounce before it settles.
+
+The config can be overwritten like this:
+
+```ts
+const scale = spring({
+  frame,
+  fps,
+  config: { damping: 200 },
+});
+```
+
+The recommended configuration for a natural motion without a bounce is: `{ damping: 200 }`.
+
+Here are some common configurations:
+
+```tsx
+const smooth = { damping: 200 }; // Smooth, no bounce (subtle reveals)
+const snappy = { damping: 20, stiffness: 200 }; // Snappy, minimal bounce (UI elements)
+const bouncy = { damping: 8 }; // Bouncy entrance (playful animations)
+const heavy = { damping: 15, stiffness: 80, mass: 2 }; // Heavy, slow, small bounce
+```
+
+### Delay
+
+The animation starts immediately by default.  
+Use the `delay` parameter to delay the animation by a number of frames.
+
+```tsx
+const entrance = spring({
+  frame: frame - ENTRANCE_DELAY,
+  fps,
+  delay: 20,
+});
+```
+
+### Duration
+
+A `spring()` has a natural duration based on the physical properties.  
+To stretch the animation to a specific duration, use the `durationInFrames` parameter.
+
+```tsx
+const spring = spring({
+  frame,
+  fps,
+  durationInFrames: 40,
+});
+```
+
+### Combining spring() with interpolate()
+
+Map spring output (0-1) to custom ranges:
+
+```tsx
+const springProgress = spring({
+  frame,
+  fps,
+});
+
+// Map to rotation
+const rotation = interpolate(springProgress, [0, 1], [0, 360]);
+
+<div style={{ rotate: rotation + "deg" }} />;
+```
+
+### Adding springs
+
+Springs return just numbers, so math can be performed:
+
+```tsx
+const frame = useCurrentFrame();
+const { fps, durationInFrames } = useVideoConfig();
+
+const inAnimation = spring({
+  frame,
+  fps,
+});
+const outAnimation = spring({
+  frame,
+  fps,
+  durationInFrames: 1 * fps,
+  delay: durationInFrames - 1 * fps,
+});
+
+const scale = inAnimation - outAnimation;
+```
+
+## Easing
+
+Easing can be added to the `interpolate` function:
+
+```ts
+import { interpolate, Easing } from "remotion";
+
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.inOut(Easing.quad),
+  extrapolateLeft: "clamp",
+  extrapolateRight: "clamp",
+});
+```
+
+The default easing is `Easing.linear`.  
+There are various other convexities:
+
+- `Easing.in` for starting slow and accelerating
+- `Easing.out` for starting fast and slowing down
+- `Easing.inOut`
+
+and curves (sorted from most linear to most curved):
+
+- `Easing.quad`
+- `Easing.sin`
+- `Easing.exp`
+- `Easing.circle`
+
+Convexities and curves need be combined for an easing function:
+
+```ts
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.inOut(Easing.quad),
+  extrapolateLeft: "clamp",
+  extrapolateRight: "clamp",
+});
+```
+
+Cubic bezier curves are also supported:
+
+```ts
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.bezier(0.8, 0.22, 0.96, 0.65),
+  extrapolateLeft: "clamp",
+  extrapolateRight: "clamp",
+});
+```

--- a/.agent/skills/remotion/rules/transcribe-captions.md
+++ b/.agent/skills/remotion/rules/transcribe-captions.md
@@ -1,0 +1,70 @@
+---
+name: transcribe-captions
+description: Transcribing audio to generate captions in Remotion
+metadata:
+  tags: captions, transcribe, whisper, audio, speech-to-text
+---
+
+# Transcribing audio
+
+To transcribe audio to generate captions in Remotion, you can use the [`transcribe()`](https://www.remotion.dev/docs/install-whisper-cpp/transcribe) function from the [`@remotion/install-whisper-cpp`](https://www.remotion.dev/docs/install-whisper-cpp) package.
+
+## Prerequisites
+
+First, the @remotion/install-whisper-cpp package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/install-whisper-cpp
+```
+
+## Transcribing
+
+Make a Node.js script to download Whisper.cpp and a model, and transcribe the audio.
+
+```ts
+import path from "path";
+import {
+  downloadWhisperModel,
+  installWhisperCpp,
+  transcribe,
+  toCaptions,
+} from "@remotion/install-whisper-cpp";
+import fs from "fs";
+
+const to = path.join(process.cwd(), "whisper.cpp");
+
+await installWhisperCpp({
+  to,
+  version: "1.5.5",
+});
+
+await downloadWhisperModel({
+  model: "medium.en",
+  folder: to,
+});
+
+// Convert the audio to a 16KHz wav file first if needed:
+// import {execSync} from 'child_process';
+// execSync('ffmpeg -i /path/to/audio.mp4 -ar 16000 /path/to/audio.wav -y');
+
+const whisperCppOutput = await transcribe({
+  model: "medium.en",
+  whisperPath: to,
+  whisperCppVersion: "1.5.5",
+  inputPath: "/path/to/audio123.wav",
+  tokenLevelTimestamps: true,
+});
+
+// Optional: Apply our recommended postprocessing
+const { captions } = toCaptions({
+  whisperCppOutput,
+});
+
+// Write it to the public/ folder so it can be fetched from Remotion
+fs.writeFileSync("captions123.json", JSON.stringify(captions, null, 2));
+```
+
+Transcribe each clip individually and create multiple JSON files.
+
+See [Displaying captions](display-captions.md) for how to display the captions in Remotion.

--- a/.agent/skills/remotion/rules/transitions.md
+++ b/.agent/skills/remotion/rules/transitions.md
@@ -1,0 +1,197 @@
+---
+name: transitions
+description: Scene transitions and overlays for Remotion using TransitionSeries.
+metadata:
+  tags: transitions, overlays, fade, slide, wipe, scenes
+---
+
+## TransitionSeries
+
+`<TransitionSeries>` arranges scenes and supports two ways to enhance the cut point between them:
+
+- **Transitions** (`<TransitionSeries.Transition>`) — crossfade, slide, wipe, etc. between two scenes. Shortens the timeline because both scenes play simultaneously during the transition.
+- **Overlays** (`<TransitionSeries.Overlay>`) — render an effect (e.g. a light leak) on top of the cut point without shortening the timeline.
+
+Children are absolutely positioned.
+
+## Prerequisites
+
+```bash
+npx remotion add @remotion/transitions
+```
+
+## Transition example
+
+```tsx
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneA />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Transition
+    presentation={fade()}
+    timing={linearTiming({ durationInFrames: 15 })}
+  />
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneB />
+  </TransitionSeries.Sequence>
+</TransitionSeries>;
+```
+
+## Overlay example
+
+Any React component can be used as an overlay. For a ready-made effect, see the **light-leaks** rule.
+
+```tsx
+import { TransitionSeries } from "@remotion/transitions";
+import { LightLeak } from "@remotion/light-leaks";
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneA />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Overlay durationInFrames={20}>
+    <LightLeak />
+  </TransitionSeries.Overlay>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneB />
+  </TransitionSeries.Sequence>
+</TransitionSeries>;
+```
+
+## Mixing transitions and overlays
+
+Transitions and overlays can coexist in the same `<TransitionSeries>`, but an overlay cannot be adjacent to a transition or another overlay.
+
+```tsx
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
+import { LightLeak } from "@remotion/light-leaks";
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneA />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Overlay durationInFrames={30}>
+    <LightLeak />
+  </TransitionSeries.Overlay>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneB />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Transition
+    presentation={fade()}
+    timing={linearTiming({ durationInFrames: 15 })}
+  />
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneC />
+  </TransitionSeries.Sequence>
+</TransitionSeries>;
+```
+
+## Transition props
+
+`<TransitionSeries.Transition>` requires:
+
+- `presentation` — the visual effect (e.g. `fade()`, `slide()`, `wipe()`).
+- `timing` — controls speed and easing (e.g. `linearTiming()`, `springTiming()`).
+
+## Overlay props
+
+`<TransitionSeries.Overlay>` accepts:
+
+- `durationInFrames` — how long the overlay is visible (positive integer).
+- `offset?` — shifts the overlay relative to the cut point center. Positive = later, negative = earlier. Default: `0`.
+
+## Available transition types
+
+Import transitions from their respective modules:
+
+```tsx
+import { fade } from "@remotion/transitions/fade";
+import { slide } from "@remotion/transitions/slide";
+import { wipe } from "@remotion/transitions/wipe";
+import { flip } from "@remotion/transitions/flip";
+import { clockWipe } from "@remotion/transitions/clock-wipe";
+```
+
+## Slide transition with direction
+
+```tsx
+import { slide } from "@remotion/transitions/slide";
+
+<TransitionSeries.Transition
+  presentation={slide({ direction: "from-left" })}
+  timing={linearTiming({ durationInFrames: 20 })}
+/>;
+```
+
+Directions: `"from-left"`, `"from-right"`, `"from-top"`, `"from-bottom"`
+
+## Timing options
+
+```tsx
+import { linearTiming, springTiming } from "@remotion/transitions";
+
+// Linear timing - constant speed
+linearTiming({ durationInFrames: 20 });
+
+// Spring timing - organic motion
+springTiming({ config: { damping: 200 }, durationInFrames: 25 });
+```
+
+## Duration calculation
+
+Transitions overlap adjacent scenes, so the total composition length is **shorter** than the sum of all sequence durations. Overlays do **not** affect the total duration.
+
+For example, with two 60-frame sequences and a 15-frame transition:
+
+- Without transitions: `60 + 60 = 120` frames
+- With transition: `60 + 60 - 15 = 105` frames
+
+Adding an overlay between two other sequences does not change the total.
+
+### Getting the duration of a transition
+
+Use the `getDurationInFrames()` method on the timing object:
+
+```tsx
+import { linearTiming, springTiming } from "@remotion/transitions";
+
+const linearDuration = linearTiming({
+  durationInFrames: 20,
+}).getDurationInFrames({ fps: 30 });
+// Returns 20
+
+const springDuration = springTiming({
+  config: { damping: 200 },
+}).getDurationInFrames({ fps: 30 });
+// Returns calculated duration based on spring physics
+```
+
+For `springTiming` without an explicit `durationInFrames`, the duration depends on `fps` because it calculates when the spring animation settles.
+
+### Calculating total composition duration
+
+```tsx
+import { linearTiming } from "@remotion/transitions";
+
+const scene1Duration = 60;
+const scene2Duration = 60;
+const scene3Duration = 60;
+
+const timing1 = linearTiming({ durationInFrames: 15 });
+const timing2 = linearTiming({ durationInFrames: 20 });
+
+const transition1Duration = timing1.getDurationInFrames({ fps: 30 });
+const transition2Duration = timing2.getDurationInFrames({ fps: 30 });
+
+const totalDuration =
+  scene1Duration +
+  scene2Duration +
+  scene3Duration -
+  transition1Duration -
+  transition2Duration;
+// 60 + 60 + 60 - 15 - 20 = 145 frames
+```

--- a/.agent/skills/remotion/rules/transparent-videos.md
+++ b/.agent/skills/remotion/rules/transparent-videos.md
@@ -1,0 +1,106 @@
+---
+name: transparent-videos
+description: Rendering transparent videos in Remotion
+metadata:
+  tags: transparent, alpha, codec, vp9, prores, webm
+---
+
+# Rendering Transparent Videos
+
+Remotion can render transparent videos in two ways: as a ProRes video or as a WebM video.
+
+## Transparent ProRes
+
+Ideal for when importing into video editing software.
+
+**CLI:**
+
+```bash
+npx remotion render --image-format=png --pixel-format=yuva444p10le --codec=prores --prores-profile=4444 MyComp out.mov
+```
+
+**Default in Studio** (restart Studio after changing):
+
+```ts
+// remotion.config.ts
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("png");
+Config.setPixelFormat("yuva444p10le");
+Config.setCodec("prores");
+Config.setProResProfile("4444");
+```
+
+**Setting it as the default export settings for a composition** (using `calculateMetadata`):
+
+```tsx
+import { CalculateMetadataFunction } from "remotion";
+
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  return {
+    defaultCodec: "prores",
+    defaultVideoImageFormat: "png",
+    defaultPixelFormat: "yuva444p10le",
+    defaultProResProfile: "4444",
+  };
+};
+
+<Composition
+  id="my-video"
+  component={MyVideo}
+  durationInFrames={150}
+  fps={30}
+  width={1920}
+  height={1080}
+  calculateMetadata={calculateMetadata}
+/>;
+```
+
+## Transparent WebM (VP9)
+
+Ideal for when playing in a browser.
+
+**CLI:**
+
+```bash
+npx remotion render --image-format=png --pixel-format=yuva420p --codec=vp9 MyComp out.webm
+```
+
+**Default in Studio** (restart Studio after changing):
+
+```ts
+// remotion.config.ts
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("png");
+Config.setPixelFormat("yuva420p");
+Config.setCodec("vp9");
+```
+
+**Setting it as the default export settings for a composition** (using `calculateMetadata`):
+
+```tsx
+import { CalculateMetadataFunction } from "remotion";
+
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  return {
+    defaultCodec: "vp8",
+    defaultVideoImageFormat: "png",
+    defaultPixelFormat: "yuva420p",
+  };
+};
+
+<Composition
+  id="my-video"
+  component={MyVideo}
+  durationInFrames={150}
+  fps={30}
+  width={1920}
+  height={1080}
+  calculateMetadata={calculateMetadata}
+/>;
+```

--- a/.agent/skills/remotion/rules/trimming.md
+++ b/.agent/skills/remotion/rules/trimming.md
@@ -1,0 +1,51 @@
+---
+name: trimming
+description: Trimming patterns for Remotion - cut the beginning or end of animations
+metadata:
+  tags: sequence, trim, clip, cut, offset
+---
+
+Use `<Sequence>` with a negative `from` value to trim the start of an animation.
+
+## Trim the Beginning
+
+A negative `from` value shifts time backwards, making the animation start partway through:
+
+```tsx
+import { Sequence, useVideoConfig } from "remotion";
+
+const fps = useVideoConfig();
+
+<Sequence from={-0.5 * fps}>
+  <MyAnimation />
+</Sequence>;
+```
+
+The animation appears 15 frames into its progress - the first 15 frames are trimmed off.
+Inside `<MyAnimation>`, `useCurrentFrame()` starts at 15 instead of 0.
+
+## Trim the End
+
+Use `durationInFrames` to unmount content after a specified duration:
+
+```tsx
+<Sequence durationInFrames={1.5 * fps}>
+  <MyAnimation />
+</Sequence>
+```
+
+The animation plays for 45 frames, then the component unmounts.
+
+## Trim and Delay
+
+Nest sequences to both trim the beginning and delay when it appears:
+
+```tsx
+<Sequence from={30}>
+  <Sequence from={-15}>
+    <MyAnimation />
+  </Sequence>
+</Sequence>
+```
+
+The inner sequence trims 15 frames from the start, and the outer sequence delays the result by 30 frames.

--- a/.agent/skills/remotion/rules/videos.md
+++ b/.agent/skills/remotion/rules/videos.md
@@ -1,0 +1,171 @@
+---
+name: videos
+description: Embedding videos in Remotion - trimming, volume, speed, looping, pitch
+metadata:
+  tags: video, media, trim, volume, speed, loop, pitch
+---
+
+# Using videos in Remotion
+
+## Prerequisites
+
+First, the @remotion/media package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/media # If project uses npm
+bunx remotion add @remotion/media # If project uses bun
+yarn remotion add @remotion/media # If project uses yarn
+pnpm exec remotion add @remotion/media # If project uses pnpm
+```
+
+Use `<Video>` from `@remotion/media` to embed videos into your composition.
+
+```tsx
+import { Video } from "@remotion/media";
+import { staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Video src={staticFile("video.mp4")} />;
+};
+```
+
+Remote URLs are also supported:
+
+```tsx
+<Video src="https://remotion.media/video.mp4" />
+```
+
+## Trimming
+
+Use `trimBefore` and `trimAfter` to remove portions of the video. Values are in seconds.
+
+```tsx
+const { fps } = useVideoConfig();
+
+return (
+  <Video
+    src={staticFile("video.mp4")}
+    trimBefore={2 * fps} // Skip the first 2 seconds
+    trimAfter={10 * fps} // End at the 10 second mark
+  />
+);
+```
+
+## Delaying
+
+Wrap the video in a `<Sequence>` to delay when it appears:
+
+```tsx
+import { Sequence, staticFile } from "remotion";
+import { Video } from "@remotion/media";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Sequence from={1 * fps}>
+    <Video src={staticFile("video.mp4")} />
+  </Sequence>
+);
+```
+
+The video will appear after 1 second.
+
+## Sizing and Position
+
+Use the `style` prop to control size and position:
+
+```tsx
+<Video
+  src={staticFile("video.mp4")}
+  style={{
+    width: 500,
+    height: 300,
+    position: "absolute",
+    top: 100,
+    left: 50,
+    objectFit: "cover",
+  }}
+/>
+```
+
+## Volume
+
+Set a static volume (0 to 1):
+
+```tsx
+<Video src={staticFile("video.mp4")} volume={0.5} />
+```
+
+Or use a callback for dynamic volume based on the current frame:
+
+```tsx
+import { interpolate } from "remotion";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Video
+    src={staticFile("video.mp4")}
+    volume={(f) =>
+      interpolate(f, [0, 1 * fps], [0, 1], { extrapolateRight: "clamp" })
+    }
+  />
+);
+```
+
+Use `muted` to silence the video entirely:
+
+```tsx
+<Video src={staticFile("video.mp4")} muted />
+```
+
+## Speed
+
+Use `playbackRate` to change the playback speed:
+
+```tsx
+<Video src={staticFile("video.mp4")} playbackRate={2} /> {/* 2x speed */}
+<Video src={staticFile("video.mp4")} playbackRate={0.5} /> {/* Half speed */}
+```
+
+Reverse playback is not supported.
+
+## Looping
+
+Use `loop` to loop the video indefinitely:
+
+```tsx
+<Video src={staticFile("video.mp4")} loop />
+```
+
+Use `loopVolumeCurveBehavior` to control how the frame count behaves when looping:
+
+- `"repeat"`: Frame count resets to 0 each loop (for `volume` callback)
+- `"extend"`: Frame count continues incrementing
+
+```tsx
+<Video
+  src={staticFile("video.mp4")}
+  loop
+  loopVolumeCurveBehavior="extend"
+  volume={(f) => interpolate(f, [0, 300], [1, 0])} // Fade out over multiple loops
+/>
+```
+
+## Pitch
+
+Use `toneFrequency` to adjust the pitch without affecting speed. Values range from 0.01 to 2:
+
+```tsx
+<Video
+  src={staticFile("video.mp4")}
+  toneFrequency={1.5} // Higher pitch
+/>
+<Video
+  src={staticFile("video.mp4")}
+  toneFrequency={0.8} // Lower pitch
+/>
+```
+
+Pitch shifting only works during server-side rendering, not in the Remotion Studio preview or in the `<Player />`.

--- a/.agent/skills/remotion/rules/voiceover.md
+++ b/.agent/skills/remotion/rules/voiceover.md
@@ -1,0 +1,99 @@
+---
+name: voiceover
+description: Adding AI-generated voiceover to Remotion compositions using TTS
+metadata:
+  tags: voiceover, audio, elevenlabs, tts, speech, calculateMetadata, dynamic duration
+---
+
+# Adding AI voiceover to a Remotion composition
+
+Use ElevenLabs TTS to generate speech audio per scene, then use [`calculateMetadata`](./calculate-metadata) to dynamically size the composition to match the audio.
+
+## Prerequisites
+
+By default this guide uses **ElevenLabs** as the TTS provider (`ELEVENLABS_API_KEY` environment variable). Users may substitute any TTS service that can produce an audio file.
+
+If the user has not specified a TTS provider, recommend ElevenLabs and ask for their API key.
+
+Ensure the environment variable is available when running the generation script:
+
+```bash
+node --strip-types generate-voiceover.ts
+```
+
+## Generating audio with ElevenLabs
+
+Create a script that reads the config, calls the ElevenLabs API for each scene, and writes MP3 files to the `public/` directory so Remotion can access them via `staticFile()`.
+
+The core API call for a single scene:
+
+```ts title="generate-voiceover.ts"
+const response = await fetch(
+  `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
+  {
+    method: "POST",
+    headers: {
+      "xi-api-key": process.env.ELEVENLABS_API_KEY!,
+      "Content-Type": "application/json",
+      Accept: "audio/mpeg",
+    },
+    body: JSON.stringify({
+      text: "Welcome to the show.",
+      model_id: "eleven_multilingual_v2",
+      voice_settings: {
+        stability: 0.5,
+        similarity_boost: 0.75,
+        style: 0.3,
+      },
+    }),
+  },
+);
+
+const audioBuffer = Buffer.from(await response.arrayBuffer());
+writeFileSync(`public/voiceover/${compositionId}/${scene.id}.mp3`, audioBuffer);
+```
+
+## Dynamic composition duration with calculateMetadata
+
+Use [`calculateMetadata`](./calculate-metadata.md) to measure the [audio durations](./get-audio-duration.md) and set the composition length accordingly.
+
+```tsx
+import { CalculateMetadataFunction, staticFile } from "remotion";
+import { getAudioDuration } from "./get-audio-duration";
+
+const FPS = 30;
+
+const SCENE_AUDIO_FILES = [
+  "voiceover/my-comp/scene-01-intro.mp3",
+  "voiceover/my-comp/scene-02-main.mp3",
+  "voiceover/my-comp/scene-03-outro.mp3",
+];
+
+export const calculateMetadata: CalculateMetadataFunction<Props> = async ({
+  props,
+}) => {
+  const durations = await Promise.all(
+    SCENE_AUDIO_FILES.map((file) => getAudioDuration(staticFile(file))),
+  );
+
+  const sceneDurations = durations.map((durationInSeconds) => {
+    return durationInSeconds * FPS;
+  });
+
+  return {
+    durationInFrames: Math.ceil(sceneDurations.reduce((sum, d) => sum + d, 0)),
+  };
+};
+```
+
+The computed `sceneDurations` are passed into the component via a `voiceover` prop so the component knows how long each scene should be.
+
+If the composition uses [`<TransitionSeries>`](./transitions.md), subtract the overlap from total duration: [./transitions.md#calculating-total-composition-duration](./transitions.md#calculating-total-composition-duration)
+
+## Rendering audio in the component
+
+See [audio.md](./audio.md) for more information on how to render audio in the component.
+
+## Delaying audio start
+
+See [audio.md#delaying](./audio.md#delaying) for more information on how to delay the audio start.

--- a/.agent/skills/sdd-apply/SKILL.md
+++ b/.agent/skills/sdd-apply/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: sdd-apply
+description: >
+  Implement tasks from the change, writing actual code following the specs and design.
+  Trigger: When the orchestrator launches you to implement one or more tasks from a change.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for IMPLEMENTATION. You receive specific tasks from `tasks.md` and implement them by writing actual code. You follow the specs and design strictly.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- The specific task(s) to implement (e.g., "Phase 1, tasks 1.1-1.3")
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete specs and produce wrong code.**
+
+  **STEP A — SEARCH** (get IDs only — content is truncated):
+
+  **Run all artifact searches in parallel** — call all mem_search calls simultaneously in a single response, then all mem_get_observation calls simultaneously in the next response. Do NOT search sequentially.
+
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID
+  4. `mem_search(query: "sdd/{change-name}/tasks", project: "{project}")` → save ID (keep this ID for updates)
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+
+  **Run all retrieval calls in parallel** — call all mem_get_observation calls simultaneously in a single response.
+
+  5. `mem_get_observation(id: {proposal_id})` → full proposal
+  6. `mem_get_observation(id: {spec_id})` → full spec
+  7. `mem_get_observation(id: {design_id})` → full design
+  8. `mem_get_observation(id: {tasks_id})` → full tasks
+
+  **DO NOT use search previews as source material.**
+
+  **Mark tasks complete** (update the tasks artifact as you go):
+  ```
+  mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
+  ```
+
+  **Save progress artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/apply-progress",
+    topic_key: "sdd/{change-name}/apply-progress",
+    type: "architecture",
+    project: "{project}",
+    content: "{your implementation progress report}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for advanced operations.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Update `tasks.md` with `[x]` marks.
+- If mode is `hybrid`: Follow BOTH conventions — persist progress to Engram (`mem_update` for tasks) AND update `tasks.md` with `[x]` marks on filesystem.
+- If mode is `none`: Return progress only. Do not update project artifacts.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Read Context
+
+Before writing ANY code:
+1. Read the specs — understand WHAT the code must do
+2. Read the design — understand HOW to structure the code
+3. Read existing code in affected files — understand current patterns
+4. Check the project's coding conventions from `config.yaml`
+
+### Step 3: Detect Implementation Mode
+
+Before writing code, determine if the project uses TDD:
+
+```
+Detect TDD mode from (in priority order):
+├── openspec/config.yaml → rules.apply.tdd (true/false — highest priority)
+├── User's installed skills (e.g., tdd/SKILL.md exists)
+├── Existing test patterns in the codebase (test files alongside source)
+└── Default: standard mode (write code first, then verify)
+
+IF TDD mode is detected → use Step 3a (TDD Workflow)
+IF standard mode → use Step 3b (Standard Workflow)
+```
+
+### Step 3a: Implement Tasks (TDD Workflow — RED → GREEN → REFACTOR)
+
+When TDD is active, EVERY task follows this cycle:
+
+```
+FOR EACH TASK:
+├── 1. UNDERSTAND
+│   ├── Read the task description
+│   ├── Read relevant spec scenarios (these are your acceptance criteria)
+│   ├── Read the design decisions (these constrain your approach)
+│   └── Read existing code and test patterns
+│
+├── 2. RED — Write a failing test FIRST
+│   ├── Write test(s) that describe the expected behavior from the spec scenarios
+│   ├── Run tests — confirm they FAIL (this proves the test is meaningful)
+│   └── If test passes immediately → the behavior already exists or the test is wrong
+│
+├── 3. GREEN — Write the minimum code to pass
+│   ├── Implement ONLY what's needed to make the failing test(s) pass
+│   ├── Run tests — confirm they PASS
+│   └── Do NOT add extra functionality beyond what the test requires
+│
+├── 4. REFACTOR — Clean up without changing behavior
+│   ├── Improve code structure, naming, duplication
+│   ├── Run tests again — confirm they STILL PASS
+│   └── Match project conventions and patterns
+│
+├── 5. Mark task as complete [x] in tasks.md
+└── 6. Note any issues or deviations
+```
+
+Detect the test runner for execution:
+
+```
+Detect test runner from:
+├── openspec/config.yaml → rules.apply.test_command (highest priority)
+├── package.json → scripts.test
+├── pyproject.toml / pytest.ini → pytest
+├── Makefile → make test
+└── Fallback: report that tests couldn't be run automatically
+```
+
+**Important**: If any user coding skills are installed (e.g., `tdd/SKILL.md`, `pytest/SKILL.md`, `vitest/SKILL.md`), read and follow those skill patterns for writing tests.
+
+### Step 3b: Implement Tasks (Standard Workflow)
+
+When TDD is not active:
+
+```
+FOR EACH TASK:
+├── Read the task description
+├── Read relevant spec scenarios (these are your acceptance criteria)
+├── Read the design decisions (these constrain your approach)
+├── Read existing code patterns (match the project's style)
+├── Write the code
+├── Mark task as complete [x] in tasks.md
+└── Note any issues or deviations
+```
+
+### Step 4: Mark Tasks Complete
+
+Update `tasks.md` — change `- [ ]` to `- [x]` for completed tasks:
+
+```markdown
+## Phase 1: Foundation
+
+- [x] 1.1 Create `internal/auth/middleware.go` with JWT validation
+- [x] 1.2 Add `AuthConfig` struct to `internal/config/config.go`
+- [ ] 1.3 Add auth routes to `internal/server/server.go`  ← still pending
+```
+
+### Step 5: Persist Progress
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+1. Update the tasks artifact with completion marks:
+   ```
+   mem_update(id: {tasks-observation-id}, content: "{updated tasks with [x] marks}")
+   ```
+2. Save progress report:
+   ```
+   mem_save(
+     title: "sdd/{change-name}/apply-progress",
+     topic_key: "sdd/{change-name}/apply-progress",
+     type: "architecture",
+     project: "{project}",
+     content: "{your implementation progress report}"
+   )
+   ```
+
+If mode is `openspec` or `hybrid`: tasks.md was already updated in Step 4.
+
+If mode is `hybrid`: also call `mem_save` and `mem_update` as above.
+
+If you skip this step, sdd-verify will NOT be able to find your progress and the pipeline BREAKS.
+
+### Step 6: Return Summary
+
+Return to the orchestrator:
+
+```markdown
+## Implementation Progress
+
+**Change**: {change-name}
+**Mode**: {TDD | Standard}
+
+### Completed Tasks
+- [x] {task 1.1 description}
+- [x] {task 1.2 description}
+
+### Files Changed
+| File | Action | What Was Done |
+|------|--------|---------------|
+| `path/to/file.ext` | Created | {brief description} |
+| `path/to/other.ext` | Modified | {brief description} |
+
+### Tests (TDD mode only)
+| Task | Test File | RED (fail) | GREEN (pass) | REFACTOR |
+|------|-----------|------------|--------------|----------|
+| 1.1 | `path/to/test.ext` | ✅ Failed as expected | ✅ Passed | ✅ Clean |
+| 1.2 | `path/to/test.ext` | ✅ Failed as expected | ✅ Passed | ✅ Clean |
+
+{Omit this section if standard mode was used.}
+
+### Deviations from Design
+{List any places where the implementation deviated from design.md and why.
+If none, say "None — implementation matches design."}
+
+### Issues Found
+{List any problems discovered during implementation.
+If none, say "None."}
+
+### Remaining Tasks
+- [ ] {next task}
+- [ ] {next task}
+
+### Status
+{N}/{total} tasks complete. {Ready for next batch / Ready for verify / Blocked by X}
+```
+
+## Rules
+
+- ALWAYS read specs before implementing — specs are your acceptance criteria
+- ALWAYS follow the design decisions — don't freelance a different approach
+- ALWAYS match existing code patterns and conventions in the project
+- In `openspec` mode, mark tasks complete in `tasks.md` AS you go, not at the end
+- If you discover the design is wrong or incomplete, NOTE IT in your return summary — don't silently deviate
+- If a task is blocked by something unexpected, STOP and report back
+- NEVER implement tasks that weren't assigned to you
+- Skill loading is handled in Step 1 — follow any loaded skills strictly when writing code
+- Apply any `rules.apply` from `openspec/config.yaml`
+- If TDD mode is detected (Step 3), ALWAYS follow the RED → GREEN → REFACTOR cycle — never skip RED (writing the failing test first)
+- When running tests during TDD, run ONLY the relevant test file/suite, not the entire test suite (for speed)
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/sdd-archive/SKILL.md
+++ b/.agent/skills/sdd-archive/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: sdd-archive
+description: >
+  Sync delta specs to main specs and archive a completed change.
+  Trigger: When the orchestrator launches you to archive a change after implementation and verification.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for ARCHIVING. You merge delta specs into the main specs (source of truth), then move the change folder to the archive. You complete the SDD cycle.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will archive with incomplete data.**
+
+  **STEP A — SEARCH** (get IDs only — content is truncated):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID
+  4. `mem_search(query: "sdd/{change-name}/tasks", project: "{project}")` → save ID
+  5. `mem_search(query: "sdd/{change-name}/verify-report", project: "{project}")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+  6. `mem_get_observation(id: {proposal_id})` → full proposal
+  7. `mem_get_observation(id: {spec_id})` → full spec
+  8. `mem_get_observation(id: {design_id})` → full design
+  9. `mem_get_observation(id: {tasks_id})` → full tasks
+  10. `mem_get_observation(id: {verify_report_id})` → full verification report
+
+  **DO NOT use search previews as source material.**
+
+  **Record all observation IDs** — include them in the archive report for full traceability.
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/archive-report",
+    topic_key: "sdd/{change-name}/archive-report",
+    type: "architecture",
+    project: "{project}",
+    content: "{your archive report with all observation IDs for lineage}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Perform merge and archive folder moves.
+- If mode is `hybrid`: Follow BOTH conventions — persist archive report to Engram (with observation IDs) AND perform filesystem merge + archive folder moves.
+- If mode is `none`: Return closure summary only. Do not perform archive file operations.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Sync Delta Specs to Main Specs
+
+**IF mode is `engram`:** Skip filesystem sync — artifacts live in Engram only. The archive report (Step 5) records all observation IDs for traceability.
+
+**IF mode is `none`:** Skip — no artifacts to sync.
+
+**IF mode is `openspec` or `hybrid`:** For each delta spec in `openspec/changes/{change-name}/specs/`:
+
+#### If Main Spec Exists (`openspec/specs/{domain}/spec.md`)
+
+Read the existing main spec and apply the delta:
+
+```
+FOR EACH SECTION in delta spec:
+├── ADDED Requirements → Append to main spec's Requirements section
+├── MODIFIED Requirements → Replace the matching requirement in main spec
+└── REMOVED Requirements → Delete the matching requirement from main spec
+```
+
+**Merge carefully:**
+- Match requirements by name (e.g., "### Requirement: Session Expiration")
+- Preserve all OTHER requirements that aren't in the delta
+- Maintain proper Markdown formatting and heading hierarchy
+
+#### If Main Spec Does NOT Exist
+
+The delta spec IS a full spec (not a delta). Copy it directly:
+
+```bash
+# Copy new spec to main specs
+openspec/changes/{change-name}/specs/{domain}/spec.md
+  → openspec/specs/{domain}/spec.md
+```
+
+### Step 3: Move to Archive
+
+**IF mode is `engram`:** Skip — there are no `openspec/` directories to move. The archive report in Engram serves as the audit trail.
+
+**IF mode is `none`:** Skip — no filesystem operations.
+
+**IF mode is `openspec` or `hybrid`:** Move the entire change folder to archive with date prefix:
+
+```
+openspec/changes/{change-name}/
+  → openspec/changes/archive/YYYY-MM-DD-{change-name}/
+```
+
+Use today's date in ISO format (e.g., `2026-02-16`).
+
+### Step 4: Verify Archive
+
+**IF mode is `openspec` or `hybrid`:** Confirm:
+- [ ] Main specs updated correctly
+- [ ] Change folder moved to archive
+- [ ] Archive contains all artifacts (proposal, specs, design, tasks)
+- [ ] Active changes directory no longer has this change
+
+**IF mode is `engram`:** Confirm all artifact observation IDs are recorded in the archive report.
+
+**IF mode is `none`:** Skip verification — no persisted artifacts.
+
+### Step 5: Persist Archive Report
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/archive-report",
+  topic_key: "sdd/{change-name}/archive-report",
+  type: "architecture",
+  project: "{project}",
+  content: "{your archive report with all observation IDs for lineage}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+### Step 6: Return Summary
+
+Return to the orchestrator:
+
+```markdown
+## Change Archived
+
+**Change**: {change-name}
+**Archived to**: `openspec/changes/archive/{YYYY-MM-DD}-{change-name}/` (openspec/hybrid) | Engram archive report (engram) | inline (none)
+
+### Specs Synced
+| Domain | Action | Details |
+|--------|--------|---------|
+| {domain} | Created/Updated | {N added, M modified, K removed requirements} |
+
+### Archive Contents
+- proposal.md ✅
+- specs/ ✅
+- design.md ✅
+- tasks.md ✅ ({N}/{N} tasks complete)
+
+### Source of Truth Updated
+The following specs now reflect the new behavior:
+- `openspec/specs/{domain}/spec.md`
+
+### SDD Cycle Complete
+The change has been fully planned, implemented, verified, and archived.
+Ready for the next change.
+```
+
+## Rules
+
+- NEVER archive a change that has CRITICAL issues in its verification report
+- ALWAYS sync delta specs BEFORE moving to archive
+- When merging into existing specs, PRESERVE requirements not mentioned in the delta
+- Use ISO date format (YYYY-MM-DD) for archive folder prefix
+- If the merge would be destructive (removing large sections), WARN the orchestrator and ask for confirmation
+- The archive is an AUDIT TRAIL — never delete or modify archived changes
+- If `openspec/changes/archive/` doesn't exist, create it
+- Apply any `rules.archive` from `openspec/config.yaml`
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/sdd-design/SKILL.md
+++ b/.agent/skills/sdd-design/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: sdd-design
+description: >
+  Create technical design document with architecture decisions and approach.
+  Trigger: When the orchestrator launches you to write or update the technical design for a change.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for TECHNICAL DESIGN. You take the proposal and specs, then produce a `design.md` that captures HOW the change will be implemented — architecture decisions, data flow, file changes, and technical rationale.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete data and produce wrong design.**
+
+  **STEP A — SEARCH** (get IDs only — content is truncated):
+
+  **Run all artifact searches in parallel** — call all mem_search calls simultaneously in a single response, then all mem_get_observation calls simultaneously in the next response. Do NOT search sequentially.
+
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID (optional — may not exist if running in parallel with sdd-spec)
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each found):
+
+  **Run all retrieval calls in parallel** — call all mem_get_observation calls simultaneously in a single response.
+
+  3. `mem_get_observation(id: {proposal_id})` → full proposal content (REQUIRED)
+  4. If spec found: `mem_get_observation(id: {spec_id})` → full spec content
+
+  **DO NOT use search previews as source material.**
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/design",
+    topic_key: "sdd/{change-name}/design",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full design markdown}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions — persist to Engram AND write `design.md` to filesystem. Retrieve dependencies from Engram (primary) with filesystem fallback.
+- If mode is `none`: Return result only. Never create or modify project files.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Read the Codebase
+
+Before designing, read the actual code that will be affected:
+- Entry points and module structure
+- Existing patterns and conventions
+- Dependencies and interfaces
+- Test infrastructure (if any)
+
+### Step 3: Write design.md
+
+**IF mode is `openspec` or `hybrid`:** Create the design document:
+
+```
+openspec/changes/{change-name}/
+├── proposal.md
+├── specs/
+└── design.md              ← You create this
+```
+
+**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories or files. Compose the design content in memory — you will persist it in Step 4.
+
+#### Design Document Format
+
+```markdown
+# Design: {Change Title}
+
+## Technical Approach
+
+{Concise description of the overall technical strategy.
+How does this map to the proposal's approach? Reference specs.}
+
+## Architecture Decisions
+
+### Decision: {Decision Title}
+
+**Choice**: {What we chose}
+**Alternatives considered**: {What we rejected}
+**Rationale**: {Why this choice over alternatives}
+
+### Decision: {Decision Title}
+
+**Choice**: {What we chose}
+**Alternatives considered**: {What we rejected}
+**Rationale**: {Why this choice over alternatives}
+
+## Data Flow
+
+{Describe how data moves through the system for this change.
+Use ASCII diagrams when helpful.}
+
+    Component A ──→ Component B ──→ Component C
+         │                              │
+         └──────── Store ───────────────┘
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `path/to/new-file.ext` | Create | {What this file does} |
+| `path/to/existing.ext` | Modify | {What changes and why} |
+| `path/to/old-file.ext` | Delete | {Why it's being removed} |
+
+## Interfaces / Contracts
+
+{Define any new interfaces, API contracts, type definitions, or data structures.
+Use code blocks with the project's language.}
+
+## Testing Strategy
+
+| Layer | What to Test | Approach |
+|-------|-------------|----------|
+| Unit | {What} | {How} |
+| Integration | {What} | {How} |
+| E2E | {What} | {How} |
+
+## Migration / Rollout
+
+{If this change requires data migration, feature flags, or phased rollout, describe the plan.
+If not applicable, state "No migration required."}
+
+## Open Questions
+
+- [ ] {Any unresolved technical question}
+- [ ] {Any decision that needs team input}
+```
+
+### Step 4: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/design",
+  topic_key: "sdd/{change-name}/design",
+  type: "architecture",
+  project: "{project}",
+  content: "{your full design markdown from Step 3}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+If you skip this step, the next phase (sdd-tasks) will NOT be able to find your design and the pipeline BREAKS.
+
+### Step 5: Return Summary
+
+Return to the orchestrator:
+
+```markdown
+## Design Created
+
+**Change**: {change-name}
+**Location**: `openspec/changes/{change-name}/design.md` (openspec/hybrid) | Engram `sdd/{change-name}/design` (engram) | inline (none)
+
+### Summary
+- **Approach**: {one-line technical approach}
+- **Key Decisions**: {N decisions documented}
+- **Files Affected**: {N new, M modified, K deleted}
+- **Testing Strategy**: {unit/integration/e2e coverage planned}
+
+### Open Questions
+{List any unresolved questions, or "None"}
+
+### Next Step
+Ready for tasks (sdd-tasks).
+```
+
+## Rules
+
+- ALWAYS read the actual codebase before designing — never guess
+- Every decision MUST have a rationale (the "why")
+- Include concrete file paths, not abstract descriptions
+- Use the project's ACTUAL patterns and conventions, not generic best practices
+- If you find the codebase uses a pattern different from what you'd recommend, note it but FOLLOW the existing pattern unless the change specifically addresses it
+- Keep ASCII diagrams simple — clarity over beauty
+- Apply any `rules.design` from `openspec/config.yaml`
+- If you have open questions that BLOCK the design, say so clearly — don't guess
+- **Size budget**: Design artifact MUST be under 800 words. Architecture decisions as tables (option | tradeoff | decision). Code snippets only for non-obvious patterns.
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/sdd-explore/SKILL.md
+++ b/.agent/skills/sdd-explore/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: sdd-explore
+description: >
+  Explore and investigate ideas before committing to a change.
+  Trigger: When the orchestrator launches you to think through a feature, investigate the codebase, or clarify requirements.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for EXPLORATION. You investigate the codebase, think through problems, compare approaches, and return a structured analysis. By default you only research and report back; only create `exploration.md` when this exploration is tied to a named change.
+
+## What You Receive
+
+The orchestrator will give you:
+- A topic or feature to explore
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **Read context** (optional — load project context if available):
+  1. `mem_search(query: "sdd-init/{project}", project: "{project}")` → get observation ID
+  2. `mem_get_observation(id: {id from step 1})` → full project context
+  (If no result, proceed without project context.)
+
+  **Save your artifact**:
+  - If tied to a named change:
+    ```
+    mem_save(
+      title: "sdd/{change-name}/explore",
+      topic_key: "sdd/{change-name}/explore",
+      type: "architecture",
+      project: "{project}",
+      content: "{your full exploration markdown}"
+    )
+    ```
+  - If standalone (no change name):
+    ```
+    mem_save(
+      title: "sdd/explore/{topic-slug}",
+      topic_key: "sdd/explore/{topic-slug}",
+      type: "architecture",
+      project: "{project}",
+      content: "{your full exploration markdown}"
+    )
+    ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions — persist to Engram AND write to filesystem.
+- If mode is `none`: Return result only.
+
+### Retrieving Context
+
+Before starting, load any existing project context and specs per the active convention:
+- **engram**:
+  1. `mem_search(query: "sdd-init/{project}", project: "{project}")` → get observation ID
+  2. `mem_get_observation(id: {id from step 1})` → full project context
+  3. Optionally `mem_search(query: "sdd/", project: "{project}")` → find existing artifacts
+  (If no results, proceed without prior context.)
+- **openspec**: Read `openspec/config.yaml` and `openspec/specs/`.
+- **none**: Use whatever context the orchestrator passed in the prompt.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Understand the Request
+
+Parse what the user wants to explore:
+- Is this a new feature? A bug fix? A refactor?
+- What domain does it touch?
+
+### Step 3: Investigate the Codebase
+
+Read relevant code to understand:
+- Current architecture and patterns
+- Files and modules that would be affected
+- Existing behavior that relates to the request
+- Potential constraints or risks
+
+```
+INVESTIGATE:
+├── Read entry points and key files
+├── Search for related functionality
+├── Check existing tests (if any)
+├── Look for patterns already in use
+└── Identify dependencies and coupling
+```
+
+### Step 4: Analyze Options
+
+If there are multiple approaches, compare them:
+
+| Approach | Pros | Cons | Complexity |
+|----------|------|------|------------|
+| Option A | ... | ... | Low/Med/High |
+| Option B | ... | ... | Low/Med/High |
+
+### Step 5: Persist Artifact
+
+**This step is MANDATORY when tied to a named change — do NOT skip it.**
+
+If mode is `engram` and this exploration is tied to a change:
+```
+mem_save(
+  title: "sdd/{change-name}/explore",
+  topic_key: "sdd/{change-name}/explore",
+  type: "architecture",
+  project: "{project}",
+  content: "{your full exploration markdown from Step 4}"
+)
+```
+
+If standalone (no change name), persistence is optional but recommended:
+```
+mem_save(
+  title: "sdd/explore/{topic-slug}",
+  topic_key: "sdd/explore/{topic-slug}",
+  type: "architecture",
+  project: "{project}",
+  content: "{your full exploration markdown}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 4.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+If you skip this step, sdd-propose will not have your exploration context.
+
+### Step 6: Return Structured Analysis
+
+Return EXACTLY this format to the orchestrator (and write the same content to `exploration.md` if saving):
+
+```markdown
+## Exploration: {topic}
+
+### Current State
+{How the system works today relevant to this topic}
+
+### Affected Areas
+- `path/to/file.ext` — {why it's affected}
+- `path/to/other.ext` — {why it's affected}
+
+### Approaches
+1. **{Approach name}** — {brief description}
+   - Pros: {list}
+   - Cons: {list}
+   - Effort: {Low/Medium/High}
+
+2. **{Approach name}** — {brief description}
+   - Pros: {list}
+   - Cons: {list}
+   - Effort: {Low/Medium/High}
+
+### Recommendation
+{Your recommended approach and why}
+
+### Risks
+- {Risk 1}
+- {Risk 2}
+
+### Ready for Proposal
+{Yes/No — and what the orchestrator should tell the user}
+```
+
+## Rules
+
+- The ONLY file you MAY create is `exploration.md` inside the change folder (if a change name is provided)
+- DO NOT modify any existing code or files
+- ALWAYS read real code, never guess about the codebase
+- Keep your analysis CONCISE - the orchestrator needs a summary, not a novel
+- If you can't find enough information, say so clearly
+- If the request is too vague to explore, say what clarification is needed
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/sdd-init/SKILL.md
+++ b/.agent/skills/sdd-init/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: sdd-init
+description: >
+  Initialize Spec-Driven Development context in any project. Detects stack, conventions, and bootstraps the active persistence backend.
+  Trigger: When user wants to initialize SDD in a project, or says "sdd init", "iniciar sdd", "openspec init".
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for initializing the Spec-Driven Development (SDD) context in a project. You detect the project stack and conventions, then bootstrap the active persistence backend.
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+  Do NOT create `openspec/` directory.
+
+  **Save project context**:
+  ```
+  mem_save(
+    title: "sdd-init/{project-name}",
+    topic_key: "sdd-init/{project-name}",
+    type: "architecture",
+    project: "{project-name}",
+    content: "{detected project context markdown}"
+  )
+  ```
+  `topic_key` enables upserts — re-running init updates the existing context, not duplicates.
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Run full bootstrap.
+- If mode is `hybrid`: Read and follow BOTH convention files. Run openspec bootstrap AND persist context to Engram.
+- If mode is `none`: Return detected context without writing project files.
+
+## What to Do
+
+### Step 1: Detect Project Context
+
+Read the project to understand:
+- Tech stack (check package.json, go.mod, pyproject.toml, etc.)
+- Existing conventions (linters, test frameworks, CI)
+- Architecture patterns in use
+
+### Step 2: Initialize Persistence Backend
+
+If mode resolves to `openspec`, create this directory structure:
+
+```
+openspec/
+├── config.yaml              ← Project-specific SDD config
+├── specs/                   ← Source of truth (empty initially)
+└── changes/                 ← Active changes
+    └── archive/             ← Completed changes
+```
+
+### Step 3: Generate Config (openspec mode)
+
+Based on what you detected, create the config when in `openspec` mode:
+
+```yaml
+# openspec/config.yaml
+schema: spec-driven
+
+context: |
+  Tech stack: {detected stack}
+  Architecture: {detected patterns}
+  Testing: {detected test framework}
+  Style: {detected linting/formatting}
+
+rules:
+  proposal:
+    - Include rollback plan for risky changes
+    - Identify affected modules/packages
+  specs:
+    - Use Given/When/Then format for scenarios
+    - Use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY)
+  design:
+    - Include sequence diagrams for complex flows
+    - Document architecture decisions with rationale
+  tasks:
+    - Group tasks by phase (infrastructure, implementation, testing)
+    - Use hierarchical numbering (1.1, 1.2, etc.)
+    - Keep tasks small enough to complete in one session
+  apply:
+    - Follow existing code patterns and conventions
+    - Load relevant coding skills for the project stack
+  verify:
+    - Run tests if test infrastructure exists
+    - Compare implementation against every spec scenario
+  archive:
+    - Warn before merging destructive deltas (large removals)
+```
+
+### Step 4: Build Skill Registry
+
+Follow the same logic as the `skill-registry` skill (`skills/skill-registry/SKILL.md`):
+
+1. Scan user skills: glob `*/SKILL.md` across ALL known skill directories. **User-level**: `~/.claude/skills/`, `~/.config/opencode/skills/`, `~/.gemini/skills/`, `~/.cursor/skills/`, `~/.copilot/skills/`, parent of this skill file. **Project-level**: `.claude/skills/`, `.gemini/skills/`, `.agent/skills/`, `skills/`. Skip `sdd-*`, `_shared`, `skill-registry`. Deduplicate by name (project-level wins). Read frontmatter triggers.
+2. Scan project conventions: check for `agents.md`, `AGENTS.md`, `CLAUDE.md` (project-level), `.cursorrules`, `GEMINI.md`, `copilot-instructions.md` in the project root. If an index file is found (e.g., `agents.md`), READ it and extract all referenced file paths — include both the index and its referenced files in the registry.
+3. **ALWAYS write `.atl/skill-registry.md`** in the project root (create `.atl/` if needed). This file is mode-independent — it's infrastructure, not an SDD artifact.
+4. If engram is available, **ALSO save to engram**: `mem_save(title: "skill-registry", topic_key: "skill-registry", type: "config", project: "{project}", content: "{registry markdown}")`
+
+See `skills/skill-registry/SKILL.md` for the full registry format and scanning details.
+
+### Step 5: Persist Project Context
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd-init/{project-name}",
+  topic_key: "sdd-init/{project-name}",
+  type: "architecture",
+  project: "{project-name}",
+  content: "{your detected project context from Steps 1-4}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the config was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+### Step 6: Return Summary
+
+Return a structured summary adapted to the resolved mode:
+
+#### If mode is `engram`:
+
+Persist project context following `skills/_shared/engram-convention.md` with title and topic_key `sdd-init/{project-name}`.
+
+Return:
+```
+## SDD Initialized
+
+**Project**: {project name}
+**Stack**: {detected stack}
+**Persistence**: engram
+
+### Context Saved
+Project context persisted to Engram.
+- **Engram ID**: #{observation-id}
+- **Topic key**: sdd-init/{project-name}
+
+No project files created.
+
+### Next Steps
+Ready for /sdd-explore <topic> or /sdd-new <change-name>.
+```
+
+#### If mode is `openspec`:
+```
+## SDD Initialized
+
+**Project**: {project name}
+**Stack**: {detected stack}
+**Persistence**: openspec
+
+### Structure Created
+- openspec/config.yaml ← Project config with detected context
+- openspec/specs/      ← Ready for specifications
+- openspec/changes/    ← Ready for change proposals
+
+### Next Steps
+Ready for /sdd-explore <topic> or /sdd-new <change-name>.
+```
+
+#### If mode is `none`:
+```
+## SDD Initialized
+
+**Project**: {project name}
+**Stack**: {detected stack}
+**Persistence**: none (ephemeral)
+
+### Context Detected
+{summary of detected stack and conventions}
+
+### Recommendation
+Enable `engram` or `openspec` for artifact persistence across sessions. Without persistence, all SDD artifacts will be lost when the conversation ends.
+
+### Next Steps
+Ready for /sdd-explore <topic> or /sdd-new <change-name>.
+```
+
+## Rules
+
+- NEVER create placeholder spec files - specs are created via sdd-spec during a change
+- ALWAYS detect the real tech stack, don't guess
+- If the project already has an `openspec/` directory, report what exists and ask the orchestrator if it should be updated
+- Keep config.yaml context CONCISE - no more than 10 lines
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks`

--- a/.agent/skills/sdd-propose/SKILL.md
+++ b/.agent/skills/sdd-propose/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: sdd-propose
+description: >
+  Create a change proposal with intent, scope, and approach.
+  Trigger: When the orchestrator launches you to create or update a proposal for a change.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for creating PROPOSALS. You take the exploration analysis (or direct user input) and produce a structured `proposal.md` document inside the change folder.
+
+## What You Receive
+
+From the orchestrator:
+- Change name (e.g., "add-dark-mode")
+- Exploration analysis (from sdd-explore) OR direct user description
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **Read dependencies** (two-step — search returns truncated previews):
+  1. `mem_search(query: "sdd/{change-name}/explore", project: "{project}")` → get observation ID (optional — may not exist)
+  2. If found: `mem_get_observation(id: {id})` → full exploration content
+  3. `mem_search(query: "sdd-init/{project}", project: "{project}")` → project context (optional)
+  4. If found: `mem_get_observation(id: {id})` → full project context
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/proposal",
+    topic_key: "sdd/{change-name}/proposal",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full proposal markdown}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions — persist to Engram AND write to filesystem. Retrieve dependencies from Engram (primary) with filesystem fallback.
+- If mode is `none`: Return result only. Never create or modify project files.
+- Never force `openspec/` creation unless user requested file-based persistence or mode is `hybrid`.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Create Change Directory
+
+**IF mode is `openspec` or `hybrid`:** create the change folder structure:
+
+```
+openspec/changes/{change-name}/
+└── proposal.md
+```
+
+**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories. Skip this step.
+
+### Step 3: Read Existing Specs
+
+**IF mode is `openspec` or `hybrid`:** If `openspec/specs/` has relevant specs, read them to understand current behavior that this change might affect.
+
+**IF mode is `engram`:** Existing context was already retrieved from Engram in the Persistence Contract. Skip filesystem reads.
+
+**IF mode is `none`:** Skip — no existing specs to read.
+
+### Step 4: Write proposal.md
+
+```markdown
+# Proposal: {Change Title}
+
+## Intent
+
+{What problem are we solving? Why does this change need to happen?
+Be specific about the user need or technical debt being addressed.}
+
+## Scope
+
+### In Scope
+- {Concrete deliverable 1}
+- {Concrete deliverable 2}
+- {Concrete deliverable 3}
+
+### Out of Scope
+- {What we're explicitly NOT doing}
+- {Future work that's related but deferred}
+
+## Approach
+
+{High-level technical approach. How will we solve this?
+Reference the recommended approach from exploration if available.}
+
+## Affected Areas
+
+| Area | Impact | Description |
+|------|--------|-------------|
+| `path/to/area` | New/Modified/Removed | {What changes} |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| {Risk description} | Low/Med/High | {How we mitigate} |
+
+## Rollback Plan
+
+{How to revert if something goes wrong. Be specific.}
+
+## Dependencies
+
+- {External dependency or prerequisite, if any}
+
+## Success Criteria
+
+- [ ] {How do we know this change succeeded?}
+- [ ] {Measurable outcome}
+```
+
+### Step 5: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/proposal",
+  topic_key: "sdd/{change-name}/proposal",
+  type: "architecture",
+  project: "{project}",
+  content: "{your full proposal markdown from Step 4}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 4.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+If you skip this step, the next phase (sdd-spec) will NOT be able to find your proposal and the pipeline BREAKS.
+
+### Step 6: Return Summary
+
+Return to the orchestrator:
+
+```markdown
+## Proposal Created
+
+**Change**: {change-name}
+**Location**: `openspec/changes/{change-name}/proposal.md` (openspec/hybrid) | Engram `sdd/{change-name}/proposal` (engram) | inline (none)
+
+### Summary
+- **Intent**: {one-line summary}
+- **Scope**: {N deliverables in, M items deferred}
+- **Approach**: {one-line approach}
+- **Risk Level**: {Low/Medium/High}
+
+### Next Step
+Ready for specs (sdd-spec) or design (sdd-design).
+```
+
+## Rules
+
+- In `openspec` mode, ALWAYS create the `proposal.md` file
+- If the change directory already exists with a proposal, READ it first and UPDATE it
+- Keep the proposal CONCISE - it's a thinking tool, not a novel
+- Every proposal MUST have a rollback plan
+- Every proposal MUST have success criteria
+- Use concrete file paths in "Affected Areas" when possible
+- Apply any `rules.proposal` from `openspec/config.yaml`
+- **Size budget**: Proposal artifact MUST be under 400 words. Use bullet points and tables over prose. Headers organize, not explain.
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/sdd-spec/SKILL.md
+++ b/.agent/skills/sdd-spec/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: sdd-spec
+description: >
+  Write specifications with requirements and scenarios (delta specs for changes).
+  Trigger: When the orchestrator launches you to write or update specs for a change.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for writing SPECIFICATIONS. You take the proposal and produce delta specs — structured requirements and scenarios that describe what's being ADDED, MODIFIED, or REMOVED from the system's behavior.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete data and produce wrong specs.**
+
+  **STEP A — SEARCH** (get IDs only — content is truncated):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory):
+  2. `mem_get_observation(id: {proposal_id})` → full proposal content (REQUIRED)
+
+  **DO NOT use search previews as source material.**
+
+  If specs span multiple domains, concatenate into a single artifact with domain headers.
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/spec",
+    topic_key: "sdd/{change-name}/spec",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full spec markdown — all domains concatenated}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions — persist to Engram (single concatenated artifact) AND write domain files to filesystem.
+- If mode is `none`: Return result only. Never create or modify project files.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Identify Affected Domains
+
+From the proposal's "Affected Areas", determine which spec domains are touched. Group changes by domain (e.g., `auth/`, `payments/`, `ui/`).
+
+### Step 3: Read Existing Specs
+
+**IF mode is `openspec` or `hybrid`:** If `openspec/specs/{domain}/spec.md` exists, read it to understand CURRENT behavior. Your delta specs describe CHANGES to this behavior.
+
+**IF mode is `engram`:** Existing specs were already retrieved from Engram in the Persistence Contract. Skip filesystem reads.
+
+**IF mode is `none`:** Skip — no existing specs to read.
+
+### Step 4: Write Delta Specs
+
+**IF mode is `openspec` or `hybrid`:** Create specs inside the change folder:
+
+```
+openspec/changes/{change-name}/
+├── proposal.md              ← (already exists)
+└── specs/
+    └── {domain}/
+        └── spec.md          ← Delta spec
+```
+
+**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories or files. Compose the spec content in memory — you will persist it in Step 5.
+
+#### Delta Spec Format
+
+```markdown
+# Delta for {Domain}
+
+## ADDED Requirements
+
+### Requirement: {Requirement Name}
+
+{Description using RFC 2119 keywords: MUST, SHALL, SHOULD, MAY}
+
+The system {MUST/SHALL/SHOULD} {do something specific}.
+
+#### Scenario: {Happy path scenario}
+
+- GIVEN {precondition}
+- WHEN {action}
+- THEN {expected outcome}
+- AND {additional outcome, if any}
+
+#### Scenario: {Edge case scenario}
+
+- GIVEN {precondition}
+- WHEN {action}
+- THEN {expected outcome}
+
+## MODIFIED Requirements
+
+### Requirement: {Existing Requirement Name}
+
+{New description — replaces the existing one}
+(Previously: {what it was before})
+
+#### Scenario: {Updated scenario}
+
+- GIVEN {updated precondition}
+- WHEN {updated action}
+- THEN {updated outcome}
+
+## REMOVED Requirements
+
+### Requirement: {Requirement Being Removed}
+
+(Reason: {why this requirement is being deprecated/removed})
+```
+
+#### For NEW Specs (No Existing Spec)
+
+If this is a completely new domain, create a FULL spec (not a delta):
+
+```markdown
+# {Domain} Specification
+
+## Purpose
+
+{High-level description of this spec's domain.}
+
+## Requirements
+
+### Requirement: {Name}
+
+The system {MUST/SHALL/SHOULD} {behavior}.
+
+#### Scenario: {Name}
+
+- GIVEN {precondition}
+- WHEN {action}
+- THEN {outcome}
+```
+
+### Step 5: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/spec",
+  topic_key: "sdd/{change-name}/spec",
+  type: "architecture",
+  project: "{project}",
+  content: "{your full spec markdown from Step 4 — all domains concatenated}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 4.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+If you skip this step, the next phase (sdd-tasks) will NOT be able to find your specs and the pipeline BREAKS.
+
+### Step 6: Return Summary
+
+Return to the orchestrator:
+
+```markdown
+## Specs Created
+
+**Change**: {change-name}
+
+### Specs Written
+| Domain | Type | Requirements | Scenarios |
+|--------|------|-------------|-----------|
+| {domain} | Delta/New | {N added, M modified, K removed} | {total scenarios} |
+
+### Coverage
+- Happy paths: {covered/missing}
+- Edge cases: {covered/missing}
+- Error states: {covered/missing}
+
+### Next Step
+Ready for design (sdd-design). If design already exists, ready for tasks (sdd-tasks).
+```
+
+## Rules
+
+- ALWAYS use Given/When/Then format for scenarios
+- ALWAYS use RFC 2119 keywords (MUST, SHALL, SHOULD, MAY) for requirement strength
+- If existing specs exist, write DELTA specs (ADDED/MODIFIED/REMOVED sections)
+- If NO existing specs exist for the domain, write a FULL spec
+- Every requirement MUST have at least ONE scenario
+- Include both happy path AND edge case scenarios
+- Keep scenarios TESTABLE — someone should be able to write an automated test from each one
+- DO NOT include implementation details in specs — specs describe WHAT, not HOW
+- Apply any `rules.specs` from `openspec/config.yaml`
+- **Size budget**: Spec artifact MUST be under 650 words. Prefer requirement tables over narrative descriptions. Each scenario: 3-5 lines max.
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)
+
+## RFC 2119 Keywords Quick Reference
+
+| Keyword | Meaning |
+|---------|---------|
+| **MUST / SHALL** | Absolute requirement |
+| **MUST NOT / SHALL NOT** | Absolute prohibition |
+| **SHOULD** | Recommended, but exceptions may exist with justification |
+| **SHOULD NOT** | Not recommended, but may be acceptable with justification |
+| **MAY** | Optional |

--- a/.agent/skills/sdd-tasks/SKILL.md
+++ b/.agent/skills/sdd-tasks/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: sdd-tasks
+description: >
+  Break down a change into an implementation task checklist.
+  Trigger: When the orchestrator launches you to create or update the task breakdown for a change.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for creating the TASK BREAKDOWN. You take the proposal, specs, and design, then produce a `tasks.md` with concrete, actionable implementation steps organized by phase.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will work with incomplete data and produce wrong tasks.**
+
+  **STEP A — SEARCH** (get IDs only — content is truncated):
+
+  **Run all artifact searches in parallel** — call all mem_search calls simultaneously in a single response, then all mem_get_observation calls simultaneously in the next response. Do NOT search sequentially.
+
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+
+  **Run all retrieval calls in parallel** — call all mem_get_observation calls simultaneously in a single response.
+
+  4. `mem_get_observation(id: {proposal_id})` → full proposal (REQUIRED)
+  5. `mem_get_observation(id: {spec_id})` → full spec (REQUIRED)
+  6. `mem_get_observation(id: {design_id})` → full design (REQUIRED)
+
+  **DO NOT use search previews as source material.**
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/tasks",
+    topic_key: "sdd/{change-name}/tasks",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full tasks markdown}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`.
+- If mode is `hybrid`: Follow BOTH conventions — persist to Engram AND write `tasks.md` to filesystem. Retrieve dependencies from Engram (primary) with filesystem fallback.
+- If mode is `none`: Return result only. Never create or modify project files.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Analyze the Design
+
+From the design document, identify:
+- All files that need to be created/modified/deleted
+- The dependency order (what must come first)
+- Testing requirements per component
+
+### Step 3: Write tasks.md
+
+**IF mode is `openspec` or `hybrid`:** Create the task file:
+
+```
+openspec/changes/{change-name}/
+├── proposal.md
+├── specs/
+├── design.md
+└── tasks.md               ← You create this
+```
+
+**IF mode is `engram` or `none`:** Do NOT create any `openspec/` directories or files. Compose the tasks content in memory — you will persist it in Step 4.
+
+#### Task File Format
+
+```markdown
+# Tasks: {Change Title}
+
+## Phase 1: {Phase Name} (e.g., Infrastructure / Foundation)
+
+- [ ] 1.1 {Concrete action — what file, what change}
+- [ ] 1.2 {Concrete action}
+- [ ] 1.3 {Concrete action}
+
+## Phase 2: {Phase Name} (e.g., Core Implementation)
+
+- [ ] 2.1 {Concrete action}
+- [ ] 2.2 {Concrete action}
+- [ ] 2.3 {Concrete action}
+- [ ] 2.4 {Concrete action}
+
+## Phase 3: {Phase Name} (e.g., Testing / Verification)
+
+- [ ] 3.1 {Write tests for ...}
+- [ ] 3.2 {Write tests for ...}
+- [ ] 3.3 {Verify integration between ...}
+
+## Phase 4: {Phase Name} (e.g., Cleanup / Documentation)
+
+- [ ] 4.1 {Update docs/comments}
+- [ ] 4.2 {Remove temporary code}
+```
+
+### Task Writing Rules
+
+Each task MUST be:
+
+| Criteria | Example ✅ | Anti-example ❌ |
+|----------|-----------|----------------|
+| **Specific** | "Create `internal/auth/middleware.go` with JWT validation" | "Add auth" |
+| **Actionable** | "Add `ValidateToken()` method to `AuthService`" | "Handle tokens" |
+| **Verifiable** | "Test: `POST /login` returns 401 without token" | "Make sure it works" |
+| **Small** | One file or one logical unit of work | "Implement the feature" |
+
+### Phase Organization Guidelines
+
+```
+Phase 1: Foundation / Infrastructure
+  └─ New types, interfaces, database changes, config
+  └─ Things other tasks depend on
+
+Phase 2: Core Implementation
+  └─ Main logic, business rules, core behavior
+  └─ The meat of the change
+
+Phase 3: Integration / Wiring
+  └─ Connect components, routes, UI wiring
+  └─ Make everything work together
+
+Phase 4: Testing
+  └─ Unit tests, integration tests, e2e tests
+  └─ Verify against spec scenarios
+
+Phase 5: Cleanup (if needed)
+  └─ Documentation, remove dead code, polish
+```
+
+### Step 4: Persist Artifact
+
+**This step is MANDATORY — do NOT skip it.**
+
+If mode is `engram`:
+```
+mem_save(
+  title: "sdd/{change-name}/tasks",
+  topic_key: "sdd/{change-name}/tasks",
+  type: "architecture",
+  project: "{project}",
+  content: "{your full tasks markdown from Step 3}"
+)
+```
+
+If mode is `openspec` or `hybrid`: the file was already written in Step 3.
+
+If mode is `hybrid`: also call `mem_save` as above (write to BOTH backends).
+
+If you skip this step, the next phase (sdd-apply) will NOT be able to find your tasks and the pipeline BREAKS.
+
+### Step 5: Return Summary
+
+Return to the orchestrator:
+
+```markdown
+## Tasks Created
+
+**Change**: {change-name}
+**Location**: `openspec/changes/{change-name}/tasks.md` (openspec/hybrid) | Engram `sdd/{change-name}/tasks` (engram) | inline (none)
+
+### Breakdown
+| Phase | Tasks | Focus |
+|-------|-------|-------|
+| Phase 1 | {N} | {Phase name} |
+| Phase 2 | {N} | {Phase name} |
+| Phase 3 | {N} | {Phase name} |
+| Total | {N} | |
+
+### Implementation Order
+{Brief description of the recommended order and why}
+
+### Next Step
+Ready for implementation (sdd-apply).
+```
+
+## Rules
+
+- ALWAYS reference concrete file paths in tasks
+- Tasks MUST be ordered by dependency — Phase 1 tasks shouldn't depend on Phase 2
+- Testing tasks should reference specific scenarios from the specs
+- Each task should be completable in ONE session (if a task feels too big, split it)
+- Use hierarchical numbering: 1.1, 1.2, 2.1, 2.2, etc.
+- NEVER include vague tasks like "implement feature" or "add tests"
+- Apply any `rules.tasks` from `openspec/config.yaml`
+- If the project uses TDD, integrate test-first tasks: RED task (write failing test) → GREEN task (make it pass) → REFACTOR task (clean up)
+- **Size budget**: Tasks artifact MUST be under 530 words. Each task: 1-2 lines max. Use checklist format, not paragraphs.
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/sdd-verify/SKILL.md
+++ b/.agent/skills/sdd-verify/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: sdd-verify
+description: >
+  Validate that implementation matches specs, design, and tasks.
+  Trigger: When the orchestrator launches you to verify a completed (or partially completed) change.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "2.0"
+---
+
+## Purpose
+
+You are a sub-agent responsible for VERIFICATION. You are the quality gate. Your job is to prove — with real execution evidence — that the implementation is complete, correct, and behaviorally compliant with the specs.
+
+Static analysis alone is NOT enough. You must execute the code.
+
+## What You Receive
+
+From the orchestrator:
+- Change name
+- Artifact store mode (`engram | openspec | hybrid | none`)
+
+## Execution and Persistence Contract
+
+- If mode is `engram`:
+
+  **CRITICAL: `mem_search` returns 300-char PREVIEWS, not full content. You MUST call `mem_get_observation(id)` for EVERY artifact. If you skip this, you will verify against incomplete specs and miss issues.**
+
+  **STEP A — SEARCH** (get IDs only — content is truncated):
+  1. `mem_search(query: "sdd/{change-name}/proposal", project: "{project}")` → save ID
+  2. `mem_search(query: "sdd/{change-name}/spec", project: "{project}")` → save ID
+  3. `mem_search(query: "sdd/{change-name}/design", project: "{project}")` → save ID
+  4. `mem_search(query: "sdd/{change-name}/tasks", project: "{project}")` → save ID
+
+  **STEP B — RETRIEVE FULL CONTENT** (mandatory for each):
+  5. `mem_get_observation(id: {proposal_id})` → full proposal
+  6. `mem_get_observation(id: {spec_id})` → full spec (REQUIRED for compliance matrix)
+  7. `mem_get_observation(id: {design_id})` → full design
+  8. `mem_get_observation(id: {tasks_id})` → full tasks
+
+  **DO NOT use search previews as source material.**
+
+  **Save your artifact**:
+  ```
+  mem_save(
+    title: "sdd/{change-name}/verify-report",
+    topic_key: "sdd/{change-name}/verify-report",
+    type: "architecture",
+    project: "{project}",
+    content: "{your full verification report markdown}"
+  )
+  ```
+  `topic_key` enables upserts — saving again updates, not duplicates. (Read `skills/_shared/sdd-phase-common.md`.)
+
+  (See `skills/_shared/engram-convention.md` for full naming conventions.)
+- If mode is `openspec`: Read and follow `skills/_shared/openspec-convention.md`. Save to `openspec/changes/{change-name}/verify-report.md`.
+- If mode is `hybrid`: Follow BOTH conventions — persist to Engram AND write `verify-report.md` to filesystem.
+- If mode is `none`: Return the verification report inline only. Never write files.
+
+## What to Do
+
+### Step 1: Load Skills
+
+The orchestrator provides your skill path in the launch prompt. Load it now. If no path was provided, proceed without additional skills.
+
+> Read `skills/_shared/sdd-phase-common.md` for the engram upsert note and return envelope format.
+
+### Step 2: Check Completeness
+
+Verify ALL tasks are done:
+
+```
+Read tasks.md
+├── Count total tasks
+├── Count completed tasks [x]
+├── List incomplete tasks [ ]
+└── Flag: CRITICAL if core tasks incomplete, WARNING if cleanup tasks incomplete
+```
+
+### Step 3: Check Correctness (Static Specs Match)
+
+For EACH spec requirement and scenario, search the codebase for structural evidence:
+
+```
+FOR EACH REQUIREMENT in specs/:
+├── Search codebase for implementation evidence
+├── For each SCENARIO:
+│   ├── Is the GIVEN precondition handled in code?
+│   ├── Is the WHEN action implemented?
+│   ├── Is the THEN outcome produced?
+│   └── Are edge cases covered?
+└── Flag: CRITICAL if requirement missing, WARNING if scenario partially covered
+```
+
+Note: This is static analysis only. Behavioral validation with real execution happens in Step 6.
+
+### Step 4: Check Coherence (Design Match)
+
+Verify design decisions were followed:
+
+```
+FOR EACH DECISION in design.md:
+├── Was the chosen approach actually used?
+├── Were rejected alternatives accidentally implemented?
+├── Do file changes match the "File Changes" table?
+└── Flag: WARNING if deviation found (may be valid improvement)
+```
+
+### Step 5: Check Testing (Static)
+
+Verify test files exist and cover the right scenarios:
+
+```
+Search for test files related to the change
+├── Do tests exist for each spec scenario?
+├── Do tests cover happy paths?
+├── Do tests cover edge cases?
+├── Do tests cover error states?
+└── Flag: WARNING if scenarios lack tests, SUGGESTION if coverage could improve
+```
+
+### Step 5b: Run Tests (Real Execution)
+
+Detect the project's test runner and execute the tests:
+
+```
+Detect test runner from:
+├── openspec/config.yaml → rules.verify.test_command (highest priority)
+├── package.json → scripts.test
+├── pyproject.toml / pytest.ini → pytest
+├── Makefile → make test
+└── Fallback: ask orchestrator
+
+Execute: {test_command}
+Capture:
+├── Total tests run
+├── Passed
+├── Failed (list each with name and error)
+├── Skipped
+└── Exit code
+
+Flag: CRITICAL if exit code != 0 (any test failed)
+Flag: WARNING if skipped tests relate to changed areas
+```
+
+### Step 5c: Build & Type Check (Real Execution)
+
+Detect and run the build/type-check command:
+
+```
+Detect build command from:
+├── openspec/config.yaml → rules.verify.build_command (highest priority)
+├── package.json → scripts.build → also run tsc --noEmit if tsconfig.json exists
+├── pyproject.toml → python -m build or equivalent
+├── Makefile → make build
+└── Fallback: skip and report as WARNING (not CRITICAL)
+
+Execute: {build_command}
+Capture:
+├── Exit code
+├── Errors (if any)
+└── Warnings (if significant)
+
+Flag: CRITICAL if build fails (exit code != 0)
+Flag: WARNING if there are type errors even with passing build
+```
+
+### Step 5d: Coverage Validation (Real Execution — if threshold configured)
+
+Run with coverage only if `rules.verify.coverage_threshold` is set in `openspec/config.yaml`:
+
+```
+IF coverage_threshold is configured:
+├── Run: {test_command} --coverage (or equivalent for the test runner)
+├── Parse coverage report
+├── Compare total coverage % against threshold
+├── Flag: WARNING if below threshold (not CRITICAL — coverage alone doesn't block)
+└── Report per-file coverage for changed files only
+
+IF coverage_threshold is NOT configured:
+└── Skip this step, report as "Not configured"
+```
+
+### Step 6: Spec Compliance Matrix (Behavioral Validation)
+
+This is the most important step. Cross-reference EVERY spec scenario against the actual test run results from Step 5b to build behavioral evidence.
+
+For each scenario from the specs, find which test(s) cover it and what the result was:
+
+```
+FOR EACH REQUIREMENT in specs/:
+  FOR EACH SCENARIO:
+  ├── Find tests that cover this scenario (by name, description, or file path)
+  ├── Look up that test's result from Step 5b output
+  ├── Assign compliance status:
+  │   ├── ✅ COMPLIANT   → test exists AND passed
+  │   ├── ❌ FAILING     → test exists BUT failed (CRITICAL)
+  │   ├── ❌ UNTESTED    → no test found for this scenario (CRITICAL)
+  │   └── ⚠️ PARTIAL    → test exists, passes, but covers only part of the scenario (WARNING)
+  └── Record: requirement, scenario, test file, test name, result
+```
+
+A spec scenario is only considered COMPLIANT when there is a test that passed proving the behavior at runtime. Code existing in the codebase is NOT sufficient evidence.
+
+### Step 7: Persist Verification Report
+
+Persist the report according to the resolved `artifact_store.mode`, following the conventions in `skills/_shared/`:
+
+- **engram**: Use `engram-convention.md` — artifact type `verify-report`
+- **openspec**: Write to `openspec/changes/{change-name}/verify-report.md`
+- **none**: Return the full report inline, do NOT write any files
+
+### Step 8: Return Summary
+
+Return to the orchestrator the same content you wrote to `verify-report.md`:
+
+```markdown
+## Verification Report
+
+**Change**: {change-name}
+**Version**: {spec version or N/A}
+
+---
+
+### Completeness
+| Metric | Value |
+|--------|-------|
+| Tasks total | {N} |
+| Tasks complete | {N} |
+| Tasks incomplete | {N} |
+
+{List incomplete tasks if any}
+
+---
+
+### Build & Tests Execution
+
+**Build**: ✅ Passed / ❌ Failed
+```
+{build command output or error if failed}
+```
+
+**Tests**: ✅ {N} passed / ❌ {N} failed / ⚠️ {N} skipped
+```
+{failed test names and errors if any}
+```
+
+**Coverage**: {N}% / threshold: {N}% → ✅ Above threshold / ⚠️ Below threshold / ➖ Not configured
+
+---
+
+### Spec Compliance Matrix
+
+| Requirement | Scenario | Test | Result |
+|-------------|----------|------|--------|
+| {REQ-01: name} | {Scenario name} | `{test file} > {test name}` | ✅ COMPLIANT |
+| {REQ-01: name} | {Scenario name} | `{test file} > {test name}` | ❌ FAILING |
+| {REQ-02: name} | {Scenario name} | (none found) | ❌ UNTESTED |
+| {REQ-02: name} | {Scenario name} | `{test file} > {test name}` | ⚠️ PARTIAL |
+
+**Compliance summary**: {N}/{total} scenarios compliant
+
+---
+
+### Correctness (Static — Structural Evidence)
+| Requirement | Status | Notes |
+|------------|--------|-------|
+| {Req name} | ✅ Implemented | {brief note} |
+| {Req name} | ⚠️ Partial | {what's missing} |
+| {Req name} | ❌ Missing | {not implemented} |
+
+---
+
+### Coherence (Design)
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| {Decision name} | ✅ Yes | |
+| {Decision name} | ⚠️ Deviated | {how and why} |
+
+---
+
+### Issues Found
+
+**CRITICAL** (must fix before archive):
+{List or "None"}
+
+**WARNING** (should fix):
+{List or "None"}
+
+**SUGGESTION** (nice to have):
+{List or "None"}
+
+---
+
+### Verdict
+{PASS / PASS WITH WARNINGS / FAIL}
+
+{One-line summary of overall status}
+```
+
+## Rules
+
+- ALWAYS read the actual source code — don't trust summaries
+- ALWAYS execute tests — static analysis alone is not verification
+- A spec scenario is only COMPLIANT when a test that covers it has PASSED
+- Compare against SPECS first (behavioral correctness), DESIGN second (structural correctness)
+- Be objective — report what IS, not what should be
+- CRITICAL issues = must fix before archive
+- WARNINGS = should fix but won't block
+- SUGGESTIONS = improvements, not blockers
+- DO NOT fix any issues — only report them. The orchestrator decides what to do.
+- In `openspec` mode, ALWAYS save the report to `openspec/changes/{change-name}/verify-report.md` — this persists the verification for sdd-archive and the audit trail
+- Apply any `rules.verify` from `openspec/config.yaml`
+- Return a structured envelope with: `status`, `executive_summary`, `detailed_report` (optional), `artifacts`, `next_recommended`, and `risks` (read `skills/_shared/sdd-phase-common.md` for the full envelope spec)

--- a/.agent/skills/skill-registry/SKILL.md
+++ b/.agent/skills/skill-registry/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: skill-registry
+description: >
+  Create or update the skill registry for the current project. Scans user skills and project conventions, writes .atl/skill-registry.md, and saves to engram if available.
+  Trigger: When user says "update skills", "skill registry", "actualizar skills", "update registry", or after installing/removing skills.
+license: MIT
+metadata:
+  author: gentleman-programming
+  version: "1.0"
+---
+
+## Purpose
+
+You generate or update the **skill registry** — a catalog of all available skills (user-level and project-level) that the **orchestrator reads once per session** and uses to pass pre-resolved skill paths to sub-agents. Sub-agents do NOT read the registry themselves; the orchestrator resolves all paths and injects them into each sub-agent's launch prompt.
+
+## When to Run
+
+- After installing or removing skills
+- After setting up a new project
+- When the user explicitly asks to update the registry
+- As part of `sdd-init` (it calls this same logic)
+
+## What to Do
+
+### Step 1: Scan User Skills
+
+1. Glob for `*/SKILL.md` files across ALL known skill directories. Check every path below — scan ALL that exist, not just the first match:
+
+   **User-level (global skills):**
+   - `~/.claude/skills/` — Claude Code
+   - `~/.config/opencode/skills/` — OpenCode
+   - `~/.gemini/skills/` — Gemini CLI
+   - `~/.cursor/skills/` — Cursor
+   - `~/.copilot/skills/` — VS Code Copilot
+   - The parent directory of this skill file (catch-all for any tool)
+
+   **Project-level (workspace skills):**
+   - `{project-root}/.claude/skills/` — Claude Code
+   - `{project-root}/.gemini/skills/` — Gemini CLI
+   - `{project-root}/.agent/skills/` — Antigravity (workspace)
+   - `{project-root}/skills/` — Generic
+
+2. **SKIP `sdd-*` and `_shared`** — those are SDD workflow skills, not coding/task skills
+3. Also **SKIP `skill-registry`** — that's this skill
+4. **Deduplicate** — if the same skill name appears in multiple locations, keep the project-level version (more specific). If both are user-level, keep the first found.
+5. For each skill found, read only the frontmatter (first 10 lines) to extract:
+   - `name` field
+   - `description` field → extract the trigger text (after "Trigger:" in the description)
+6. Build a table of: Trigger | Skill Name | Full Path
+
+### Step 2: Scan Project Conventions
+
+1. Check the project root for convention files. Look for:
+   - `agents.md` or `AGENTS.md`
+   - `CLAUDE.md` (only project-level, not `~/.claude/CLAUDE.md`)
+   - `.cursorrules`
+   - `GEMINI.md`
+   - `copilot-instructions.md`
+2. **If an index file is found** (e.g., `agents.md`, `AGENTS.md`): READ its contents and extract all referenced file paths. These index files typically list project conventions with paths — extract every referenced path and include it in the registry table alongside the index file itself.
+3. For non-index files (`.cursorrules`, `CLAUDE.md`, etc.): record the file directly.
+4. The final table should include the index file AND all paths it references — zero extra hops for sub-agents.
+
+### Step 3: Write the Registry
+
+Build the registry markdown:
+
+```markdown
+# Skill Registry
+
+**Orchestrator use only.** Read this registry once per session to resolve skill paths, then pass pre-resolved paths directly to each sub-agent's launch prompt. Sub-agents receive the path and load the skill directly — they do NOT read this registry.
+
+## User Skills
+
+| Trigger | Skill | Path |
+|---------|-------|------|
+| {trigger from frontmatter} | {skill name} | {full path to SKILL.md} |
+| ... | ... | ... |
+
+## Project Conventions
+
+| File | Path | Notes |
+|------|------|-------|
+| {index file} | {path} | Index — references files below |
+| {referenced file} | {extracted path} | Referenced by {index file} |
+| {standalone file} | {path} | |
+
+Read the convention files listed above for project-specific patterns and rules. All referenced paths have been extracted — no need to read index files to discover more.
+```
+
+### Step 4: Persist the Registry
+
+**This step is MANDATORY — do NOT skip it.**
+
+#### A. Always write the file (guaranteed availability):
+
+Create the `.atl/` directory in the project root if it doesn't exist, then write:
+
+```
+.atl/skill-registry.md
+```
+
+#### B. If engram is available, also save to engram (cross-session bonus):
+
+```
+mem_save(
+  title: "skill-registry",
+  topic_key: "skill-registry",
+  type: "config",
+  project: "{project}",
+  content: "{registry markdown from Step 3}"
+)
+```
+
+`topic_key` ensures upserts — running again updates the same observation.
+
+### Step 5: Return Summary
+
+```markdown
+## Skill Registry Updated
+
+**Project**: {project name}
+**Location**: .atl/skill-registry.md
+**Engram**: {saved / not available}
+
+### User Skills Found
+| Skill | Trigger |
+|-------|---------|
+| {name} | {trigger} |
+| ... | ... |
+
+### Project Conventions Found
+| File | Path |
+|------|------|
+| {file} | {path} |
+
+### Next Steps
+The orchestrator reads this registry once per session and passes pre-resolved skill paths to sub-agents via their launch prompts.
+To update after installing/removing skills, run this again.
+```
+
+## Rules
+
+- ALWAYS write `.atl/skill-registry.md` regardless of any SDD persistence mode
+- ALWAYS save to engram if the `mem_save` tool is available
+- SKIP `sdd-*`, `_shared`, and `skill-registry` directories when scanning
+- Only read frontmatter (first 10 lines) — do NOT read full skill files
+- Include ALL convention index files found (not just the first)
+- If no skills or conventions are found, write an empty registry (so sub-agents don't waste time searching)
+- Add `.atl/` to the project's `.gitignore` if it exists and `.atl` is not already listed

--- a/web/src/pages/ClientPortal/ClientPortalPage.tsx
+++ b/web/src/pages/ClientPortal/ClientPortalPage.tsx
@@ -13,49 +13,10 @@ import {
 } from "lucide-react";
 import { ClientPortalUnavailable } from "./components/ClientPortalUnavailable";
 import { useTranslation } from "react-i18next";
+import { components } from "@/types/api";
 
-// ─────────────────────────────────────────────────────────────────────────
-// Types — mirror backend `PublicEventView` from
-// handlers/event_public_link_handler.go. We intentionally do NOT import
-// the generated OpenAPI types because the public-portal endpoint is not
-// yet documented in openapi.yaml; we'll migrate once it lands there.
-// ─────────────────────────────────────────────────────────────────────────
-
-interface PortalEvent {
-  id: string;
-  service_type: string;
-  event_date: string; // yyyy-MM-dd
-  start_time?: string | null;
-  end_time?: string | null;
-  location?: string | null;
-  city?: string | null;
-  num_people: number;
-  status: string;
-}
-
-interface PortalOrganizer {
-  business_name?: string;
-  logo_url?: string;
-  brand_color?: string;
-}
-
-interface PortalClient {
-  name: string;
-}
-
-interface PortalPayment {
-  total: number;
-  paid: number;
-  remaining: number;
-  currency: string;
-}
-
-interface PortalData {
-  event: PortalEvent;
-  organizer: PortalOrganizer;
-  client: PortalClient;
-  payment: PortalPayment;
-}
+// Generated type from OpenAPI spec
+type PortalData = components["schemas"]["PublicEventView"];
 
 const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8080/api";
 

--- a/web/src/pages/PublicEventForm/PublicEventFormPage.tsx
+++ b/web/src/pages/PublicEventForm/PublicEventFormPage.tsx
@@ -19,22 +19,14 @@ import { PublicFormExpired } from "./components/PublicFormExpired";
 import { PublicFormSuccess } from "./components/PublicFormSuccess";
 import { PublicProductCard } from "./components/PublicProductCard";
 import { useTranslation } from "react-i18next";
+import { components } from "@/types/api";
 
-interface PublicProduct {
-  id: string;
-  name: string;
-  category: string;
-  image_url?: string;
-}
-
-interface Organizer {
-  business_name?: string;
-  logo_url?: string;
-  brand_color?: string;
-}
+// Generated types from OpenAPI spec
+type PublicProduct = components["schemas"]["PublicProduct"];
+type PublicOrganizer = components["schemas"]["PublicOrganizer"];
 
 interface FormData {
-  organizer: Organizer;
+  organizer: PublicOrganizer;
   products: PublicProduct[];
   link_id: string;
   expires_at: string;

--- a/web/src/pages/PublicEventForm/components/PublicProductCard.tsx
+++ b/web/src/pages/PublicEventForm/components/PublicProductCard.tsx
@@ -1,13 +1,9 @@
 import React from "react";
 import { Check, Minus, Plus } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { components } from "@/types/api";
 
-interface PublicProduct {
-  id: string;
-  name: string;
-  category: string;
-  image_url?: string;
-}
+type PublicProduct = components["schemas"]["PublicProduct"];
 
 interface Props {
   product: PublicProduct;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1908,8 +1908,11 @@ export interface components {
             url: string;
             thumbnail_url: string;
             filename: string;
+            /** @description Storage key/path for the original object (retrocompatible optional field). */
             object_key?: string | null;
+            /** @description Storage key/path for the thumbnail object (retrocompatible optional field). */
             thumbnail_object_key?: string | null;
+            /** @description MIME type for the original upload (retrocompatible optional field). */
             content_type?: string | null;
         };
         UploadPresignRequest: {
@@ -1918,6 +1921,7 @@ export interface components {
         };
         UploadPresignResponse: {
             upload_url: string;
+            /** @example PUT */
             method: string;
             headers: {
                 [key: string]: string;
@@ -6066,19 +6070,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Link has already been used */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example link_already_used */
-                        error?: string;
-                        message?: string;
-                    };
                 };
             };
             /** @description Link has expired or is no longer valid */


### PR DESCRIPTION
## Summary

Closes #187 — OpenAPI sync with public flows and generated clients.

### Changes

1. **Web: Migrated public-flow types to generated OpenAPI** ✅
   - `ClientPortalPage.tsx`: PortalData → PublicEventView (components)
   - `PublicEventFormPage.tsx`: Manual types → generated (PublicProduct, PublicOrganizer)
   - `PublicProductCard.tsx`: Manual PublicProduct → generated type
   - Benefit: Web now uses contract-first types, enabling audit and parity verification

2. **Platform Audit (iOS + Android)** ✅
   - iOS: Public flows are out-of-scope (organizer-only app)
   - Android: Same as iOS (organizer-only design)
   - Conclusion: Public endpoints (/api/public/*) are Web-only per product strategy
   - Enables lean mobile apps focused on organizer workflows

3. **OpenAPI Spec Status** ✅
   - Already synchronized (commit b7ff7be8) with routes:
     - `/api/event-forms`, `/api/public/event-forms/{token}`
     - `/api/public/events/{token}`
     - `/api/events/{id}/public-link`
     - `/api/staff/teams`

### Platform Parity

| App | Public Flows | Organizer Flows |
|-----|---|---|
| Web | ✅ Implemented | ✅ Implemented |
| iOS | ❌ Out-of-scope | ✅ Partial (share links) |
| Android | ❌ Out-of-scope | ✅ Partial (share links) |
| Backend | ✅ All routes exposed | ✅ All routes exposed |

### Acceptance Criteria

- [x] OpenAPI covers authenticated and public portal/event-form/staff-team routes
- [x] Web no longer needs hand-written public portal/event-form transport types
- [x] iOS and Android audited — public flows correctly out-of-scope
- [x] PRD and docs updated to clarify public-endpoint scope

## Testing

- `npm run check` passes (Web TypeScript check + OpenAPI generation)
- Type definitions generated and aligned with backend contract
- No breaking changes to existing functionality
