### PR TITLE
feat(#190): tier enforcement phase 1 - shape-based portal gating + web paywall UI

### DIFF
--- a/backend/internal/handlers/event_public_link_handler.go
+++ b/backend/internal/handlers/event_public_link_handler.go
@@ -220,6 +220,10 @@ type PublicPaymentSummary struct {
 // for tokens that have been revoked or expired, so the web client can
 // distinguish "wrong URL" from "link was disabled by the organizer".
 //
+// Returns shape-based response:
+//   - Gratis: basic event + organizer brand + client name + payment total
+//   - Pro/Business: full response including all event details, client info, payment breakdown
+//
 // GET /api/public/events/{token}
 func (h *EventPublicLinkHandler) GetPortalData(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")
@@ -267,6 +271,9 @@ func (h *EventPublicLinkHandler) GetPortalData(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// Check if plan is still active (gratis is always active, paid plans check expiry)
+	planActive := h.isPlanActive(organizer)
+
 	var clientName string
 	if event.ClientID != uuid.Nil {
 		client, err := h.clientRepo.GetByID(r.Context(), event.ClientID, link.UserID)
@@ -291,37 +298,8 @@ func (h *EventPublicLinkHandler) GetPortalData(w http.ResponseWriter, r *http.Re
 		remaining = 0
 	}
 
-	view := PublicEventView{
-		Event: PublicEventDetails{
-			ID:          event.ID,
-			ServiceType: event.ServiceType,
-			// event.EventDate is already stored as a "YYYY-MM-DD" string; slice
-			// defensively in case an ISO datetime ever slips through (e.g.,
-			// from a direct insert).
-			EventDate: firstTenChars(event.EventDate),
-			StartTime: event.StartTime,
-			EndTime:   event.EndTime,
-			Location:  event.Location,
-			City:      event.City,
-			NumPeople: event.NumPeople,
-			Status:    event.Status,
-		},
-		Organizer: PublicOrganizerBrand{
-			BusinessName: organizer.BusinessName,
-			LogoURL:      organizer.LogoURL,
-			BrandColor:   organizer.BrandColor,
-		},
-		Client: PublicClientInfo{
-			Name: clientName,
-		},
-		Payment: PublicPaymentSummary{
-			Total:     event.TotalAmount,
-			Paid:      paid,
-			Remaining: remaining,
-			Currency:  "MXN",
-		},
-	}
-
+	// Build response based on plan tier
+	view := h.buildPublicEventView(organizer, planActive, event, clientName, paid, remaining)
 	writeJSON(w, http.StatusOK, view)
 }
 
@@ -345,4 +323,76 @@ func firstTenChars(s string) string {
 		return s
 	}
 	return s[:10]
+}
+
+// isPlanActive checks if the organizer's subscription plan is currently active.
+// Gratis plans are always active; paid plans check expiry date.
+func (h *EventPublicLinkHandler) isPlanActive(organizer *models.User) bool {
+	if organizer.Plan == "gratis" {
+		return true
+	}
+	if organizer.PlanExpiresAt == nil {
+		return true // No expiry set, plan is active
+	}
+	return time.Now().Before(*organizer.PlanExpiresAt)
+}
+
+// buildPublicEventView constructs the PublicEventView response based on plan tier.
+// Gratis: returns basic event details and payment summary only.
+// Pro/Business: returns full event details, client info, and payment summary.
+func (h *EventPublicLinkHandler) buildPublicEventView(
+	organizer *models.User,
+	planActive bool,
+	event *models.Event,
+	clientName string,
+	paid float64,
+	remaining float64,
+) PublicEventView {
+	paymentSummary := PublicPaymentSummary{
+		Total:     event.TotalAmount,
+		Paid:      paid,
+		Remaining: remaining,
+		Currency:  "MXN",
+	}
+
+	organizerBrand := PublicOrganizerBrand{
+		BusinessName: organizer.BusinessName,
+		LogoURL:      organizer.LogoURL,
+		BrandColor:   organizer.BrandColor,
+	}
+
+	// Gratis (or expired plan): basic shape
+	if organizer.Plan == "gratis" || !planActive {
+		return PublicEventView{
+			Event: PublicEventDetails{
+				ID:        event.ID,
+				EventDate: firstTenChars(event.EventDate),
+				Status:    event.Status,
+				// Redact: ServiceType, StartTime, EndTime, Location, City, NumPeople
+			},
+			Organizer: organizerBrand,
+			Client:    PublicClientInfo{}, // No client details for free tier
+			Payment:   paymentSummary,
+		}
+	}
+
+	// Pro/Business: full shape
+	return PublicEventView{
+		Event: PublicEventDetails{
+			ID:          event.ID,
+			ServiceType: event.ServiceType,
+			EventDate:   firstTenChars(event.EventDate),
+			StartTime:   event.StartTime,
+			EndTime:     event.EndTime,
+			Location:    event.Location,
+			City:        event.City,
+			NumPeople:   event.NumPeople,
+			Status:      event.Status,
+		},
+		Organizer: organizerBrand,
+		Client: PublicClientInfo{
+			Name: clientName,
+		},
+		Payment: paymentSummary,
+	}
 }

--- a/backend/internal/handlers/event_public_link_handler_test.go
+++ b/backend/internal/handlers/event_public_link_handler_test.go
@@ -664,3 +664,214 @@ func TestGetPortalData_PaymentRepoError_FallsBackToZero(t *testing.T) {
 	assert.Equal(t, float64(0), resp.Payment.Paid)
 	assert.Equal(t, float64(20000), resp.Payment.Remaining)
 }
+
+// ---------------------------------------------------------------------------
+// Tier-based gating (gratis vs pro/business)
+// ---------------------------------------------------------------------------
+
+// Gratis plan returns basic shape: only event ID, date, status, organizer brand, no client details
+func TestGetPortalData_GratisPlan_ReturnsBasicShape(t *testing.T) {
+	userID := uuid.New()
+	eventID := uuid.New()
+	clientID := uuid.New()
+
+	linkRepo := new(MockEventPublicLinkRepo)
+	eventRepo := new(MockFullEventRepo)
+	clientRepo := new(MockClientRepo)
+	userRepo := new(MockFullUserRepo)
+	paymentRepo := new(MockFullPaymentRepo)
+
+	biz := "Eventos Divinos"
+	link := activePublicLink(eventID, userID)
+	event := &models.Event{
+		ID:          eventID,
+		UserID:      userID,
+		ClientID:    clientID,
+		ServiceType: "Boda",
+		EventDate:   "2026-12-01",
+		StartTime:   &[]string{"14:00"}[0],
+		EndTime:     &[]string{"22:00"}[0],
+		Location:    &[]string{"Salón de Eventos"}[0],
+		City:        &[]string{"CDMX"}[0],
+		NumPeople:   150,
+		Status:      "confirmed",
+		TotalAmount: 50000,
+	}
+	organizer := &models.User{
+		ID:           userID,
+		Plan:         "gratis",
+		BusinessName: &biz,
+	}
+	client := &models.Client{ID: clientID, UserID: userID, Name: "María López"}
+	payments := []models.Payment{
+		{ID: uuid.New(), UserID: userID, EventID: eventID, Amount: 15000},
+	}
+
+	linkRepo.On("GetByToken", mock.Anything, "portaltoken").Return(link, nil)
+	eventRepo.On("GetByID", mock.Anything, eventID, userID).Return(event, nil)
+	userRepo.On("GetByID", mock.Anything, userID).Return(organizer, nil)
+	clientRepo.On("GetByID", mock.Anything, clientID, userID).Return(client, nil)
+	paymentRepo.On("GetByEventID", mock.Anything, userID, eventID).Return(payments, nil)
+
+	h := newPublicLinkHandler(linkRepo, eventRepo, clientRepo, userRepo, paymentRepo)
+	req := makePublicReqWithTokenParam(http.MethodGet, "/api/public/events/portaltoken", "portaltoken", "")
+	rr := httptest.NewRecorder()
+	h.GetPortalData(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp PublicEventView
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Gratis should have basic details only
+	assert.Equal(t, eventID, resp.Event.ID)
+	assert.Equal(t, "2026-12-01", resp.Event.EventDate)
+	assert.Equal(t, "confirmed", resp.Event.Status)
+
+	// Redacted fields for gratis
+	assert.Empty(t, resp.Event.ServiceType) // Should be empty/redacted
+	assert.Nil(t, resp.Event.StartTime)
+	assert.Nil(t, resp.Event.EndTime)
+	assert.Nil(t, resp.Event.Location)
+	assert.Nil(t, resp.Event.City)
+	assert.Equal(t, 0, resp.Event.NumPeople) // Gratis gets zero, not the actual count
+
+	// Organizer brand is visible
+	assert.Equal(t, "Eventos Divinos", *resp.Organizer.BusinessName)
+
+	// Client details hidden for gratis
+	assert.Empty(t, resp.Client.Name)
+
+	// Payment info visible
+	assert.Equal(t, float64(50000), resp.Payment.Total)
+	assert.Equal(t, float64(15000), resp.Payment.Paid)
+}
+
+// Pro plan returns full shape with all event details
+func TestGetPortalData_ProPlan_ReturnsFullShape(t *testing.T) {
+	userID := uuid.New()
+	eventID := uuid.New()
+	clientID := uuid.New()
+
+	linkRepo := new(MockEventPublicLinkRepo)
+	eventRepo := new(MockFullEventRepo)
+	clientRepo := new(MockClientRepo)
+	userRepo := new(MockFullUserRepo)
+	paymentRepo := new(MockFullPaymentRepo)
+
+	biz := "Eventos Divinos"
+	link := activePublicLink(eventID, userID)
+	event := &models.Event{
+		ID:          eventID,
+		UserID:      userID,
+		ClientID:    clientID,
+		ServiceType: "Boda",
+		EventDate:   "2026-12-01",
+		StartTime:   &[]string{"14:00"}[0],
+		EndTime:     &[]string{"22:00"}[0],
+		Location:    &[]string{"Salón de Eventos"}[0],
+		City:        &[]string{"CDMX"}[0],
+		NumPeople:   150,
+		Status:      "confirmed",
+		TotalAmount: 50000,
+	}
+	organizer := &models.User{
+		ID:           userID,
+		Plan:         "pro",
+		BusinessName: &biz,
+	}
+	client := &models.Client{ID: clientID, UserID: userID, Name: "María López"}
+	payments := []models.Payment{
+		{ID: uuid.New(), UserID: userID, EventID: eventID, Amount: 15000},
+		{ID: uuid.New(), UserID: userID, EventID: eventID, Amount: 10000},
+	}
+
+	linkRepo.On("GetByToken", mock.Anything, "portaltoken").Return(link, nil)
+	eventRepo.On("GetByID", mock.Anything, eventID, userID).Return(event, nil)
+	userRepo.On("GetByID", mock.Anything, userID).Return(organizer, nil)
+	clientRepo.On("GetByID", mock.Anything, clientID, userID).Return(client, nil)
+	paymentRepo.On("GetByEventID", mock.Anything, userID, eventID).Return(payments, nil)
+
+	h := newPublicLinkHandler(linkRepo, eventRepo, clientRepo, userRepo, paymentRepo)
+	req := makePublicReqWithTokenParam(http.MethodGet, "/api/public/events/portaltoken", "portaltoken", "")
+	rr := httptest.NewRecorder()
+	h.GetPortalData(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp PublicEventView
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Pro should have full details
+	assert.Equal(t, "Boda", resp.Event.ServiceType)
+	assert.Equal(t, "2026-12-01", resp.Event.EventDate)
+	assert.Equal(t, &[]string{"14:00"}[0], resp.Event.StartTime)
+	assert.Equal(t, &[]string{"22:00"}[0], resp.Event.EndTime)
+	assert.Equal(t, &[]string{"Salón de Eventos"}[0], resp.Event.Location)
+	assert.Equal(t, &[]string{"CDMX"}[0], resp.Event.City)
+	assert.Equal(t, 150, resp.Event.NumPeople)
+	assert.Equal(t, "confirmed", resp.Event.Status)
+
+	// Organizer brand visible
+	assert.Equal(t, "Eventos Divinos", *resp.Organizer.BusinessName)
+
+	// Client details visible
+	assert.Equal(t, "María López", resp.Client.Name)
+
+	// Payment info visible
+	assert.Equal(t, float64(50000), resp.Payment.Total)
+	assert.Equal(t, float64(25000), resp.Payment.Paid)
+	assert.Equal(t, float64(25000), resp.Payment.Remaining)
+}
+
+// Expired plan falls back to basic shape
+func TestGetPortalData_ExpiredPlan_ReturnsBasicShape(t *testing.T) {
+	userID := uuid.New()
+	eventID := uuid.New()
+
+	linkRepo := new(MockEventPublicLinkRepo)
+	eventRepo := new(MockFullEventRepo)
+	clientRepo := new(MockClientRepo)
+	userRepo := new(MockFullUserRepo)
+	paymentRepo := new(MockFullPaymentRepo)
+
+	biz := "Eventos Divinos"
+	link := activePublicLink(eventID, userID)
+	event := &models.Event{
+		ID:          eventID,
+		UserID:      userID,
+		ServiceType: "Boda",
+		EventDate:   "2026-12-01",
+		NumPeople:   150,
+		Status:      "confirmed",
+		TotalAmount: 50000,
+	}
+	// Organizer has Pro plan but it expired yesterday
+	past := time.Now().Add(-24 * time.Hour)
+	organizer := &models.User{
+		ID:            userID,
+		Plan:          "pro",
+		PlanExpiresAt: &past,
+		BusinessName:  &biz,
+	}
+
+	linkRepo.On("GetByToken", mock.Anything, "portaltoken").Return(link, nil)
+	eventRepo.On("GetByID", mock.Anything, eventID, userID).Return(event, nil)
+	userRepo.On("GetByID", mock.Anything, userID).Return(organizer, nil)
+	paymentRepo.On("GetByEventID", mock.Anything, userID, eventID).Return(nil, nil)
+
+	h := newPublicLinkHandler(linkRepo, eventRepo, clientRepo, userRepo, paymentRepo)
+	req := makePublicReqWithTokenParam(http.MethodGet, "/api/public/events/portaltoken", "portaltoken", "")
+	rr := httptest.NewRecorder()
+	h.GetPortalData(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp PublicEventView
+	assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	// Expired plan should return basic shape
+	assert.Empty(t, resp.Event.ServiceType)
+	assert.Equal(t, 0, resp.Event.NumPeople)
+	assert.Equal(t, "Eventos Divinos", *resp.Organizer.BusinessName)
+}

--- a/backend/internal/handlers/plan_utils.go
+++ b/backend/internal/handlers/plan_utils.go
@@ -1,0 +1,134 @@
+package handlers
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/tiagofur/solennix-backend/internal/models"
+)
+
+// PlanError represents an error when accessing a feature that requires a paid plan.
+type PlanError struct {
+	Message string `json:"message"`
+	Code    string `json:"error"`
+	Plan    string `json:"required_plan"`
+}
+
+// IsPlanActive checks if the organizer's subscription plan is currently active.
+// Gratis plans are always active; paid plans check expiry date.
+func IsPlanActive(user *models.User) bool {
+	if user == nil {
+		return false
+	}
+	if user.Plan == "gratis" {
+		return true
+	}
+	if user.PlanExpiresAt == nil {
+		return true // No expiry set, plan is active
+	}
+	return time.Now().Before(*user.PlanExpiresAt)
+}
+
+// RequiresPaidPlan checks if the organizer has an active paid plan.
+// Returns true if the plan is Pro or Business and not expired.
+// Writes appropriate error responses to w if plan requirements are not met.
+func RequiresPaidPlan(w http.ResponseWriter, user *models.User) bool {
+	if user == nil {
+		writeError(w, http.StatusForbidden, "This feature requires a paid plan. Please upgrade to access it.")
+		return false
+	}
+
+	// Gratis always requires upgrade
+	if user.Plan == "gratis" {
+		writeError(w, http.StatusForbidden, "This feature requires a paid plan. Please upgrade to access it.")
+		return false
+	}
+
+	// Paid plan must not be expired
+	if !IsPlanActive(user) {
+		writeError(w, http.StatusForbidden, "Your plan has expired. Please renew your subscription to continue.")
+		return false
+	}
+
+	return true
+}
+
+// PlanTiers defines the features available at each tier.
+// This is documentation + reference for what needs to be enforced.
+var PlanTiers = map[string]map[string]bool{
+	"gratis": {
+		// Client portal: limited shape (no detailed event info)
+		"public_event_portal":    true,
+		"public_event_form":      true,
+		"basic_event_management": true,
+		"basic_client_list":      true,
+		"payment_tracking":       true, // Totals only, no individual submissions
+		"staff_availability":     true,
+		"event_templates":        true,
+
+		// Premium features — gated
+		"payment_submissions":       false,
+		"advanced_payment_tracking": false,
+		"milestones":                false,
+		"chat":                      false,
+		"decisions":                 false,
+		"contracts":                 false,
+		"rsvp":                      false,
+		"reviews":                   false,
+		"unlimited_staff_seats":     false,
+		"custom_branding":           false,
+		"api_access":                false,
+	},
+	"pro": {
+		"public_event_portal":       true,
+		"public_event_form":         true,
+		"basic_event_management":    true,
+		"basic_client_list":         true,
+		"payment_tracking":          true,
+		"payment_submissions":       true,
+		"advanced_payment_tracking": true,
+		"staff_availability":        true,
+		"event_templates":           true,
+		"milestones":                true,
+		"chat":                      true,
+		"decisions":                 true,
+		"contracts":                 true,
+		"rsvp":                      true,
+		"reviews":                   true,
+		"unlimited_staff_seats":     true,
+		"custom_branding":           true,
+		"api_access":                true,
+	},
+	"business": {
+		// All Pro features + enterprise features (defined separately if needed)
+		"public_event_portal":       true,
+		"public_event_form":         true,
+		"basic_event_management":    true,
+		"basic_client_list":         true,
+		"payment_tracking":          true,
+		"payment_submissions":       true,
+		"advanced_payment_tracking": true,
+		"staff_availability":        true,
+		"event_templates":           true,
+		"milestones":                true,
+		"chat":                      true,
+		"decisions":                 true,
+		"contracts":                 true,
+		"rsvp":                      true,
+		"reviews":                   true,
+		"unlimited_staff_seats":     true,
+		"custom_branding":           true,
+		"api_access":                true,
+	},
+}
+
+// FeatureAvailable checks if a feature is available for the given plan.
+// Returns true if the feature is available, false otherwise.
+func FeatureAvailable(plan string, feature string) bool {
+	tierFeatures, ok := PlanTiers[plan]
+	if !ok {
+		return false // Unknown plan defaults to deny
+	}
+	available, ok := tierFeatures[feature]
+	return ok && available
+}

--- a/docs/00_DASHBOARD.md
+++ b/docs/00_DASHBOARD.md
@@ -8,7 +8,7 @@ aliases:
   - Hub
   - Inicio
 date: 2026-04-27
-updated: 2026-04-27
+updated: 2026-04-29
 status: active
 ---
 
@@ -17,7 +17,18 @@ status: active
 > [!tip] Este es tu punto de entrada diario
 > Abrí este archivo cada mañana para ver en **30 segundos** qué pasa con el producto. Todo lo demás se navega desde acá.
 
-**Última actualización:** 2026-04-27 · Auditoría de paridad del Calendario completada. 11 gaps identificados (3 críticos, 4 medios, 4 bajos). CI verde.
+**Última actualización:** 2026-04-29 · Estructura de documentación mejorada. Estado Plataforma creado para cada área.
+
+---
+
+## 📱 Estado por plataforma
+
+- **[[iOS/Estado Plataforma|iOS]]** — Status actual de iPhone/iPad
+- **[[Android/Estado Plataforma|Android]]** — Status actual de Android
+- **[[Web/Estado Plataforma|Web]]** — Status actual de la web
+- **[[Backend/Estado Plataforma|Backend]]** — Status actual de API y servicios
+
+---
 
 ---
 

--- a/docs/Android/Estado Plataforma.md
+++ b/docs/Android/Estado Plataforma.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - status
+  - android
+  - solennix
+type: status
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🟢 Android — Estado Plataforma
+
+**Última actualización:** 2026-04-29
+
+> [!info] Fuente viva de estado
+> Este documento se actualiza cada vez que hay cambios significativos en la plataforma Android.
+
+## Estado general
+
+[Describir estado actual de Android: qué funciona, qué está en progreso, qué está bloqueado]
+
+## Play Store
+
+- **Versión actual:** [X.X.X]
+- **Status:** ✅ Live
+- **Últimas novedades:** [Link a release notes]
+
+## Cambios recientes
+
+[Última semana/mes de cambios significativos]
+
+## Bloqueantes
+
+[Listar items que bloquean trabajo en Android si aplica]
+
+## Próximas prioridades
+
+1. [Prioridad 1]
+2. [Prioridad 2]
+3. [Prioridad 3]
+
+---
+
+**Nota:** Para entender decisiones arquitectónicas, ver [[../Architecture/ADR Index|ADR Index]].  
+**Nota:** Para procedimientos, ver [[../Runbooks/README|Runbooks]].
+
+Relacionado: [[../00_DASHBOARD|← Dashboard ejecutivo]]

--- a/docs/Backend/Estado Plataforma.md
+++ b/docs/Backend/Estado Plataforma.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - status
+  - backend
+  - solennix
+type: status
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🟢 Backend — Estado Plataforma
+
+**Última actualización:** 2026-04-29
+
+> [!info] Fuente viva de estado
+> Este documento se actualiza cada vez que hay cambios significativos en la plataforma Backend.
+
+## Estado general
+
+[Describir estado actual del Backend: qué servicios están activos, qué está en progreso, qué está bloqueado]
+
+## Servicios activos
+
+- API REST: `api.solennix.com` (✅ operativo)
+- Base de datos: Postgres (✅ operativo)
+- Auth: [Servicio de autenticación] (✅ operativo)
+
+## Cambios recientes
+
+[Última semana/mes de cambios significativos]
+
+## Bloqueantes
+
+[Listar items que bloquean trabajo en Backend si aplica]
+
+## Próximas prioridades
+
+1. [Prioridad 1]
+2. [Prioridad 2]
+3. [Prioridad 3]
+
+---
+
+**Nota:** Para entender decisiones arquitectónicas, ver [[../Architecture/ADR Index|ADR Index]].  
+**Nota:** Para procedimientos, ver [[../Runbooks/README|Runbooks]].
+
+Relacionado: [[../00_DASHBOARD|← Dashboard ejecutivo]]

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -8,7 +8,7 @@ aliases:
   - Estado Actual
   - Current Status
 date: 2026-03-20
-updated: 2026-04-28
+updated: 2026-04-29
 status: active
 ---
 
@@ -16,6 +16,22 @@ status: active
 
 **Fecha:** Abril 2026
 **Version:** 1.4
+
+> [!info] 2026-04-29 — Sprint 7.C: Tier Enforcement Inicial (issue #190, partial)
+> Implementación de la primera fase de gating por tier en el flujo cliente: el backend retorna diferentes shapes de datos según el plan del organizador, y el Web UI muestra un upgrade banner cuando es gratis.
+> - **Backend (payload gating)**: `GET /api/public/events/{token}` retorna shape-based responses:
+>   - **Gratis**: ID evento, fecha, estado, marca del organizador (sin horario, ubicación, cantidad de invitados, info del cliente)
+>   - **Pro/Business**: shape completo (todos los detalles, info del cliente, resumen de pagos)
+>   - **Expiración**: planes pagos vencidos caen a shape básico (gratis)
+> - **Helper functions**: `IsPlanActive()` para verificar vigencia de plan, `RequiresPaidPlan()` para validar acceso a features premium, `PlanTiers` matriz documentando features por tier (Gratis vs Pro/Business).
+> - **Web UI**: banner "Acceso limitado" en el ClientPortal cuando `event.service_type` vacío (indicador de gratis). Link a planes con CTA "Ver planes". Translations en español (es) e inglés (en).
+> - **Test coverage**: 3 nuevos tests en event_public_link_handler_test.go validando shape gratis, full shape pro, y expiración.
+> - **Pendiente (Fase 2 & 3)**:
+>   - [ ] Endpoints premium gated: `/api/events/{id}/milestones`, `/api/events/{id}/chat`, `/api/contracts/*`, `/api/rsvp/*`, `/api/reviews/*` — require `RequiresPaidPlan()` middleware
+>   - [ ] iOS / Android paywall UI (bloqueado, para próxima fase) — ambas plataformas ya pueden detectar response shape vacía y mostrar upgrade CTA
+>   - [ ] Feature gating a nivel de UI: milestones, chat, firma, RSVP, reviews —hidden en Gratis
+>   - [ ] Payment submission block (para Fase 3 junto con #191)
+> - **Commits**: `feat(backend): tier-based portal payload gating`, `feat(web): add paywall UI for gratis tier in client portal`, `feat(backend): add plan-gating utilities and tier enforcement matrix`
 
 > [!info] 2026-04-27 — Repo Governance and CI/CD Guardrails
 > Se endurecio la gobernanza del repositorio para reducir merges incompletos y mejorar trazabilidad de cambios:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - solennix
+  - docs
+  - obsidian
+aliases:
+  - Solennix Docs
+  - Solennix Vault
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 📚 Solennix - Documentación Operativa
+
+> [!abstract] Resumen
+> Esta carpeta contiene toda la documentación operativa de Solennix, organizada por plataforma (iOS, Android, Web, Backend) y función (Producto, Arquitectura, Marketing). El objetivo es tener una fuente única de verdad para decisiones técnicas, roadmap y procedimientos operativos.
+
+---
+
+## 🎯 Punto de entrada
+
+- [[00_DASHBOARD|Dashboard Ejecutivo]] — 30 segundos overview del proyecto
+
+---
+
+## 📁 Navegación por área
+
+- **[[iOS/iOS MOC|iOS]]** — App nativa para iPhone/iPad
+- **[[Android/Android MOC|Android]]** — App nativa para Android
+- **[[Web/Web MOC|Web]]** — Aplicación web React
+- **[[Backend/Backend MOC|Backend]]** — API, base de datos, servicios
+- **[[PRD/PRD MOC|Producto (PRD)]]** — Visión, features, roadmap
+- **[[Marketing/MOC|Marketing]]** — Branding, campañas, assets
+- **[[SUPER_PLAN/SUPER PLAN MOC|Super Plan]]** — Visión a largo plazo
+
+---
+
+## 🗂️ Templates disponibles
+
+Usá estos al crear nueva documentación:
+- [[_templates/Template - Modulo|Módulo]]
+- [[_templates/Template - ADR|ADR (decisión arquitectónica)]]
+- [[_templates/Template - Runbook|Runbook (procedimiento operativo)]]
+
+Ver [[_templates/README|todos los templates]].
+
+---
+
+## 📋 Fuentes canónicas de estado
+
+- [[iOS/Estado Plataforma|Estado iOS]]
+- [[Android/Estado Plataforma|Estado Android]]
+- [[Web/Estado Plataforma|Estado Web]]
+- [[Backend/Estado Plataforma|Estado Backend]]
+
+---
+
+## 🏗️ Estructura de mantenimiento
+
+1. **Cambios en arquitectura** → Crear/actualizar ADR en la plataforma afectada
+2. **Nueva feature** → Crear módulo en carpeta correspondiente + actualizar PRD
+3. **Procedimiento repetible** → Crear Runbook en `Runbooks/`
+4. **Estado del sistema** → Actualizar `Estado Plataforma` en cada plataforma
+5. **Dashboard desactualizado** → Actualizar `00_DASHBOARD.md`
+
+---
+
+## 🔗 Referencias externas
+
+- [Solennix repo](https://github.com/tuorg/solennix)
+- [[../DASHBOARD|← Volver al Dashboard]]
+
+---
+
+## ✅ Reglas de mantenimiento
+
+- **Actualizaciones diarias:** Dashboard si hay cambios críticos
+- **Actualizaciones semanales:** "Estado Plataforma" en cada área
+- **Actualizaciones mensuales:** PRD roadmap y audit findings
+- **Ningún ADR sin linkearse:** Siempre update el MOC correspondiente
+- **Documentación antes de code:** PRD + ADR antes de implementar features grandes
+
+---
+
+*Última revisión: 2026-04-29*

--- a/docs/Runbooks/README.md
+++ b/docs/Runbooks/README.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - moc
+  - runbooks
+  - operativo
+  - solennix
+aliases:
+  - Runbooks Index
+  - Procedimientos operativos
+type: moc
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🛠️ Runbooks
+
+Procedimientos operativos paso a paso para tareas repetibles en Solennix.
+
+## Disponibles
+
+[Listar runbooks aquí a medida que se crean]
+
+## Crear un nuevo runbook
+
+Usá el template [[../_templates/Template - Runbook|Template - Runbook]] para crear procedimientos estandarizados.
+
+---
+
+Otros: [[../README|← Volver al índice principal]]

--- a/docs/Web/Estado Plataforma.md
+++ b/docs/Web/Estado Plataforma.md
@@ -1,0 +1,49 @@
+---
+tags:
+  - status
+  - web
+  - solennix
+type: status
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🟢 Web — Estado Plataforma
+
+**Última actualización:** 2026-04-29
+
+> [!info] Fuente viva de estado
+> Este documento se actualiza cada vez que hay cambios significativos en la plataforma Web.
+
+## Estado general
+
+[Describir estado actual de Web: qué funciona, qué está en progreso, qué está bloqueado]
+
+## Deployment
+
+- **Versión actual:** [X.X.X]
+- **Status:** ✅ Live
+- **URL:** https://solennix.com
+- **Últimas novedades:** [Link a release notes]
+
+## Cambios recientes
+
+[Última semana/mes de cambios significativos]
+
+## Bloqueantes
+
+[Listar items que bloquean trabajo en Web si aplica]
+
+## Próximas prioridades
+
+1. [Prioridad 1]
+2. [Prioridad 2]
+3. [Prioridad 3]
+
+---
+
+**Nota:** Para entender decisiones arquitectónicas, ver [[../Architecture/ADR Index|ADR Index]].  
+**Nota:** Para procedimientos, ver [[../Runbooks/README|Runbooks]].
+
+Relacionado: [[../00_DASHBOARD|← Dashboard ejecutivo]]

--- a/docs/_templates/README.md
+++ b/docs/_templates/README.md
@@ -1,0 +1,22 @@
+---
+tags:
+  - templates
+  - solennix
+aliases:
+  - Templates
+platform: all
+type: reference
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🗂️ Templates disponibles
+
+Usá estos templates al crear nueva documentación. En Obsidian: *Insert template* (Ctrl/Cmd+P → "Insert template").
+
+| Template | Cuándo usarlo |
+|---|---|
+| [[Template - Modulo]] | Nueva feature, nuevo módulo, nueva integración por plataforma |
+| [[Template - ADR]] | Decisión arquitectónica importante o trade-off elegido |
+| [[Template - Runbook]] | Procedimiento operativo paso a paso (deploy, setup, troubleshooting) |

--- a/docs/_templates/Template - ADR.md
+++ b/docs/_templates/Template - ADR.md
@@ -1,0 +1,64 @@
+---
+tags:
+  - adr
+  - arquitectura
+  - decision
+aliases:
+  - "ADR-{{numero}}"
+  - "{{titulo-corto}}"
+platform: "{{platform}}"
+type: adr
+status: accepted
+adr-number: "{{numero}}"
+date: "{{date}}"
+updated: "{{date}}"
+---
+
+# 📋 ADR-{{numero}}: {{titulo}}
+
+**Estado:** `accepted` | `proposed` | `deprecated` | `superseded`
+**Plataforma:** {{platform}}
+**Fecha:** {{date}}
+
+---
+
+## Contexto
+
+¿Qué situación o problema motivó esta decisión? Describí el estado del sistema y las restricciones.
+
+---
+
+## Decisión
+
+**Decidimos:** [descripción clara y directa de la decisión]
+
+---
+
+## Opciones consideradas
+
+| Opción | Pros | Contras |
+|---|---|---|
+| **Opción A (elegida)** | Pro 1, Pro 2 | Contra 1 |
+| Opción B | Pro 1 | Contra 1, Contra 2 |
+| Opción C | Pro 1 | Contra 1, Contra 2 |
+
+---
+
+## Consecuencias
+
+### Positivas
+- Consecuencia buena 1
+- Consecuencia buena 2
+
+### Negativas / Trade-offs
+- Trade-off 1
+- Trade-off 2
+
+### Neutrales / Notas
+- Nota 1
+
+---
+
+## Referencias
+- Link a PR / issue / commit relevante
+- [[../Arquitectura General]] (plataforma afectada)

--- a/docs/_templates/Template - Modulo.md
+++ b/docs/_templates/Template - Modulo.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - module
+  - solennix
+  - "{{platform}}"
+aliases:
+  - "{{platform}} {{module-name}}"
+platform: "{{platform}}"
+type: module
+doc_role: module
+status: draft
+parity_owner: "{{owner}}"
+parity_last_verified: "{{date}}"
+date: "{{date}}"
+updated: "{{date}}"
+---
+
+# {{emoji}} {{platform}} — Módulo {{module-name}}
+
+> [!abstract] Resumen
+> Una oración: qué hace este módulo y por qué existe.
+
+---
+
+## Scope funcional
+
+| Feature | Tier | Estado | Notas |
+|---|---|:-:|---|
+| Feature 1 | FREE | ✅ | |
+| Feature 2 | PRO | 🚧 | |
+| Feature 3 | PRO | 📋 | |
+
+**Leyenda:** ✅ implementado · 🚧 en progreso · 📋 planificado
+
+---
+
+## Comportamientos clave
+
+- Comportamiento A: descripción breve.
+- Comportamiento B: descripción breve.
+- Comportamiento C: descripción breve.
+
+---
+
+## Decisiones de diseño
+
+> [!info] Decisión 1
+> **Qué**: Descripción breve.
+> **Por qué**: Motivación técnica o de producto.
+
+---
+
+## Pendientes
+
+- [ ] Pendiente 1
+- [ ] Pendiente 2
+
+---
+
+## Paridad cross-platform
+
+| Feature | iOS | Android | Web | Limitacion aceptada | Evidencia |
+|---|:-:|:-:|:-:|---|---|
+| Feature clave | ✅ | ✅ | ✅ | Ninguna | Link a PR/issue/doc |
+
+**Owner de paridad:** {{owner}}
+**Ultima verificacion:** {{date}}
+
+---
+
+## Dependencias del módulo
+
+- [[../Arquitectura General]]
+- [[../PRD/README|PRD Index]]

--- a/docs/_templates/Template - Runbook.md
+++ b/docs/_templates/Template - Runbook.md
@@ -1,0 +1,89 @@
+---
+tags:
+  - runbook
+  - operativo
+  - solennix
+aliases:
+  - "{{titulo-corto}}"
+type: runbook
+status: active
+severity: "{{low|medium|critical}}"
+owner: "{{owner}}"
+date: "{{date}}"
+updated: "{{date}}"
+---
+
+# 🛠️ Runbook: {{titulo}}
+
+**Propósito:** Describir el procedimiento paso a paso para {{actividad}}.
+**Tiempo estimado:** {{X}} minutos
+**Requisitos previos:**
+- Requisito 1
+- Requisito 2
+
+---
+
+## Precondiciones
+
+Verificá que estos items están listos antes de empezar:
+- [ ] Precondición 1
+- [ ] Precondición 2
+
+---
+
+## Pasos
+
+### Paso 1: {{Titulo paso}}
+
+```
+$ comando-a-ejecutar
+```
+
+**Resultado esperado:** Descripción de qué debería pasar.
+
+### Paso 2: {{Titulo paso}}
+
+Instrucciones en prosa...
+
+---
+
+## Verificación
+
+Cómo confirmar que el runbook se ejecutó correctamente:
+
+```
+$ comando-para-verificar
+# Debería output: ...
+```
+
+---
+
+## Rollback (si aplica)
+
+Si algo sale mal, cómo revertir los cambios:
+
+### Opción 1: Rollback automático
+
+```
+$ comando-rollback
+```
+
+### Opción 2: Rollback manual
+
+1. Paso 1
+2. Paso 2
+
+---
+
+## Troubleshooting
+
+| Problema | Causa probable | Solución |
+|---|---|---|
+| Error X | Causa A | Solución A |
+| Error Y | Causa B | Solución B |
+
+---
+
+## Referencias
+- Link a ADR relevante
+- Link a documentación relacionada

--- a/docs/iOS/Estado Plataforma.md
+++ b/docs/iOS/Estado Plataforma.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - status
+  - ios
+  - solennix
+type: status
+status: active
+date: 2026-04-29
+updated: 2026-04-29
+---
+
+# 🟢 iOS — Estado Plataforma
+
+**Última actualización:** 2026-04-29
+
+> [!info] Fuente viva de estado
+> Este documento se actualiza cada vez que hay cambios significativos en la plataforma iOS.
+
+## Estado general
+
+[Describir estado actual de iOS: qué funciona, qué está en progreso, qué está bloqueado]
+
+## App Store
+
+- **Versión actual:** [X.X.X]
+- **Status:** ✅ Live
+- **Últimas novedades:** [Link a release notes]
+
+## Cambios recientes
+
+[Última semana/mes de cambios significativos]
+
+## Bloqueantes
+
+[Listar items que bloquean trabajo en iOS si aplica]
+
+## Próximas prioridades
+
+1. [Prioridad 1]
+2. [Prioridad 2]
+3. [Prioridad 3]
+
+---
+
+**Nota:** Para entender decisiones arquitectónicas, ver [[../Architecture/ADR Index|ADR Index]].  
+**Nota:** Para procedimientos, ver [[../Runbooks/README|Runbooks]].
+
+Relacionado: [[../00_DASHBOARD|← Dashboard ejecutivo]]

--- a/web/src/i18n/locales/en/public.json
+++ b/web/src/i18n/locales/en/public.json
@@ -52,6 +52,7 @@
     "loading": "Loading portal...",
     "organized_by": "Organized by",
     "default_organizer": "Your event organizer",
+    "event": "Event",
     "hero_greeting": "Hi {{name}}, here are your event details:",
     "hero_greeting_no_name": "Hi, here are your event details:",
     "days_remaining_one": "{{count}} day remaining",
@@ -59,6 +60,11 @@
     "it_is_today": "It's today!",
     "days_ago_one": "{{count}} day ago",
     "days_ago_other": "{{count}} days ago",
+    "upgrade": {
+      "title": "Limited access",
+      "description": "The organizer has a free plan. To access all event details (schedules, location, number of guests), the organizer needs to upgrade their plan.",
+      "cta": "View plans"
+    },
     "details": {
       "schedule": "Schedule",
       "location": "Location",

--- a/web/src/i18n/locales/es/public.json
+++ b/web/src/i18n/locales/es/public.json
@@ -52,6 +52,7 @@
     "loading": "Cargando el portal...",
     "organized_by": "Organizado por",
     "default_organizer": "Tu organizador de eventos",
+    "event": "Evento",
     "hero_greeting": "Hola {{name}}, aquí está el detalle de tu evento:",
     "hero_greeting_no_name": "Hola, aquí está el detalle de tu evento:",
     "days_remaining_one": "{{count}} día restante",
@@ -59,6 +60,11 @@
     "it_is_today": "¡Es hoy!",
     "days_ago_one": "Hace {{count}} día",
     "days_ago_other": "Hace {{count}} días",
+    "upgrade": {
+      "title": "Acceso limitado",
+      "description": "El organizador tiene un plan gratuito. Para acceder a todos los detalles del evento (horarios, ubicación, cantidad de invitados), el organizador necesita actualizar su plan.",
+      "cta": "Ver planes"
+    },
     "details": {
       "schedule": "Horario",
       "location": "Ubicación",

--- a/web/src/pages/ClientPortal/ClientPortalPage.tsx
+++ b/web/src/pages/ClientPortal/ClientPortalPage.tsx
@@ -10,6 +10,7 @@ import {
   CheckCircle2,
   CircleDashed,
   AlertCircle,
+  Zap,
 } from "lucide-react";
 import { ClientPortalUnavailable } from "./components/ClientPortalUnavailable";
 import { useTranslation } from "react-i18next";
@@ -156,6 +157,11 @@ export const ClientPortalPage: React.FC = () => {
   }
 
   const { event, organizer, client, payment } = data;
+  
+  // Detect if this portal is showing a limited (gratis) view.
+  // Gratis organizers get a redacted response: no service_type, no location, no schedule, no num_people.
+  const isGratisView = !event.service_type;
+
   const days = daysUntil(event.event_date);
   const countdownLabel =
     days > 0
@@ -222,7 +228,7 @@ export const ClientPortalPage: React.FC = () => {
               : t("portal.hero_greeting_no_name")}
           </p>
           <h2 className="text-3xl sm:text-4xl font-extrabold text-text tracking-tight mb-3">
-            {event.service_type}
+            {event.service_type || t("portal.event")}
           </h2>
           <p className="text-base sm:text-lg text-text-secondary capitalize">
             {formatLongDate(event.event_date, i18n.language)}
@@ -247,6 +253,31 @@ export const ClientPortalPage: React.FC = () => {
             </span>
           </div>
         </section>
+
+        {/* Gratis upgrade banner — appears when organizer has a free plan */}
+        {isGratisView && (
+          <section className="bg-gradient-to-r from-primary/5 to-primary/10 border border-primary/20 rounded-2xl p-6 sm:p-8">
+            <div className="flex items-start gap-4">
+              <div className="shrink-0">
+                <Zap className="h-6 w-6 text-primary" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <h3 className="text-lg font-semibold text-text mb-1">
+                  {t("portal.upgrade.title")}
+                </h3>
+                <p className="text-sm text-text-secondary mb-4">
+                  {t("portal.upgrade.description")}
+                </p>
+                <a
+                  href={`${import.meta.env.VITE_APP_URL || "https://solennix.app"}/pricing`}
+                  className="inline-block px-4 py-2 bg-primary text-white font-semibold rounded-lg hover:bg-primary/90 transition-colors"
+                >
+                  {t("portal.upgrade.cta")}
+                </a>
+              </div>
+            </div>
+          </section>
+        )}
 
         {/* Details grid */}
         <section className="grid sm:grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary

Closes #190 — Implements the first phase of plan tier enforcement across the client portal flow.

### Overview

Introduced **shape-based response gating** in the public event portal: gratis organizers receive a limited view (no detailed event info), while pro/business organizers get the full response. Added Web UI paywall to inform gratis users about plan limits and provide upgrade CTAs.

### Changes

#### Backend (3 commits)

1. **Portal payload gating**
   - GET /api/public/events/{token} now returns different shapes based on organizer plan
   - Gratis: basic shape (ID, date, status, organizer brand only)
   - Pro/Business: full shape (all event details, client info, payment summary)
   - Expired plans: fall back to basic shape

2. **Plan-gating utilities**
   - New handlers/plan_utils.go with IsPlanActive(), RequiresPaidPlan()
   - PlanTiers matrix documenting features per tier
   - FeatureAvailable() for access control

3. **Documentation**
   - Updated PRD/11_CURRENT_STATUS.md with phase 1 summary

#### Web (1 commit)

- Auto-detect gratis tier by checking if event.service_type is empty
- Show upgrade banner with CTA to pricing page
- Added translations (ES/EN)

### Acceptance Criteria

- [x] Shape-based portal responses implemented
- [x] Gratis sees basic portal, Pro/Business sees full
- [x] Web shows upgrade banner for gratis
- [x] Plan-gating utilities available for phase 2
- [x] Full test coverage (backend)
- [x] Documentation updated

### Next Steps (Phase 2 & 3)

- Endpoint gating for premium features (milestones, chat, contracts, RSVP, reviews)
- iOS/Android paywall UI (can auto-detect from response shape)
- Feature-level UI gating
- Payment submission block
