### PR TITLE
fix(web): remove invoice UI from all entry points

### DIFF
--- a/web/src/pages/Events/EventSummary.tsx
+++ b/web/src/pages/Events/EventSummary.tsx
@@ -491,18 +491,6 @@ export const EventSummary: React.FC = () => {
                 <button
                   type="button"
                   onClick={() => {
-                    generateInvoicePDF(event, profile as UserProfile | null, products, extras, i18n.language);
-                    setActionsDropdownOpen(false);
-                  }}
-                  className="w-full flex items-center px-4 py-2.5 text-sm text-text hover:bg-surface-alt dark:hover:bg-surface transition-colors"
-                  role="menuitem"
-                >
-                  <FileText className="h-5 w-5 mr-3 text-text-secondary" />
-                  {t('events:summary.actions.invoice')}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
                     const purchaseSupplies = supplies
                       .filter((s: EventSupply) => s.source === 'purchase')
                       .map((s: EventSupply) => ({
@@ -849,14 +837,6 @@ export const EventSummary: React.FC = () => {
                     <Building className="h-3.5 w-3.5" /> {t('events:general.location')}
                   </dt>
                   <dd className="mt-1 font-bold text-text">{event.location || t('common:not_defined')}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs font-semibold text-text-tertiary uppercase tracking-wide flex items-center gap-1.5">
-                    <Receipt className="h-3.5 w-3.5" /> {t('events:financials.invoice')}
-                  </dt>
-                  <dd className="mt-1 font-bold text-text">
-                    {event.requires_invoice ? t('events:financials.requires_invoice_rate', { rate: event.tax_rate || 16 }) : t('events:financials.no_invoice')}
-                  </dd>
                 </div>
                 {event.deposit_percent > 0 && (
                   <div>

--- a/web/src/pages/Events/components/EventFinancials.tsx
+++ b/web/src/pages/Events/components/EventFinancials.tsx
@@ -51,24 +51,6 @@ export const EventFinancials: React.FC<EventFinancialsProps> = ({
         <div>
           <div className="space-y-4">
             <div className="bg-card p-4 rounded-xl shadow-xs border border-border">
-              <label htmlFor="requires_invoice" className="block text-sm font-medium text-text-secondary mb-2">
-                {t('events:financials.invoice')}
-              </label>
-              <div className="flex items-center gap-3">
-                <input
-                  id="requires_invoice"
-                  type="checkbox"
-                  {...register('requires_invoice')}
-                  className="h-4 w-4 text-primary border-border rounded-sm focus:ring-primary bg-card"
-                  aria-describedby="requires_invoice-description"
-                />
-                <span id="requires_invoice-description" className="text-sm text-text-secondary">
-                  {t('events:financials.invoice')} ({t('events:financials.tax')} {taxRateValue}%)
-                </span>
-              </div>
-            </div>
-
-            <div className="bg-card p-4 rounded-xl shadow-xs border border-border">
               <div className="flex items-center justify-between mb-2">
                 <label htmlFor="discount" className="text-sm font-medium text-text-secondary">
                   {t('events:financials.discount')}
@@ -186,13 +168,6 @@ export const EventFinancials: React.FC<EventFinancialsProps> = ({
                     return amount.toLocaleString(moneyLocale, { minimumFractionDigits: 2 });
                   })()}
                 </span>
-              </div>
-            )}
-
-            {requiresInvoiceValue && (
-              <div className="flex justify-between text-text-secondary">
-                <span>{t('events:financials.tax')} ({taxRateValue}%):</span>
-                <span>${taxAmountValue.toLocaleString(moneyLocale, { minimumFractionDigits: 2 })}</span>
               </div>
             )}
 

--- a/web/src/pages/QuickQuote/QuickQuotePage.tsx
+++ b/web/src/pages/QuickQuote/QuickQuotePage.tsx
@@ -498,27 +498,11 @@ export const QuickQuotePage: React.FC = () => {
               />
             </div>
 
-            {/* Discount & Invoice controls */}
+            {/* Discount controls */}
             <div className="bg-card p-4 sm:p-6 rounded-xl shadow-xs border border-border space-y-4">
               <h3 className="text-lg font-medium text-text">
                 {t("quotes:discount_invoice")}
               </h3>
-
-              <div className="flex items-center gap-3">
-                <input
-                  id="requires-invoice"
-                  type="checkbox"
-                  checked={requiresInvoice}
-                  onChange={(e) => setRequiresInvoice(e.target.checked)}
-                  className="h-4 w-4 text-primary border-border rounded-sm focus:ring-primary bg-card"
-                />
-                <label
-                  htmlFor="requires-invoice"
-                  className="text-sm text-text-secondary"
-                >
-                  {t("quotes:invoice_required", { rate: taxRate })}
-                </label>
-              </div>
 
               <div>
                 <div className="flex items-center justify-between mb-2">
@@ -581,13 +565,6 @@ export const QuickQuotePage: React.FC = () => {
                       {discountType === "percent" ? `(${discountValue}%)` : ""}:
                     </span>
                     <span>-${financials.discountAmount.toLocaleString(moneyLocale, { minimumFractionDigits: 2 })}</span>
-                  </div>
-                )}
-
-                {requiresInvoice && (
-                  <div className="flex justify-between text-text-secondary">
-                    <span>{t("quotes:invoice_required", { rate: taxRate })}:</span>
-                    <span>${financials.taxAmount.toLocaleString(moneyLocale, { minimumFractionDigits: 2 })}</span>
                   </div>
                 )}
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Elimina todas las opciones de "Generar Factura" de la app web. Solennix no emite facturas fiscales y tener esa opción visible puede generar problemas legales/de expectativa con los usuarios.

## Cambios

- **EventSummary**: removido botón "Generar Factura" e import de `generateInvoicePDF`
- **EventFinancials**: removida acción de factura del panel de resumen financiero  
- **QuickQuotePage**: removida opción de factura del menú de acciones de cotización

## Issue relacionado

Closes #214

## Tipo de cambio

- [x] Bug fix / remoción de feature incorrecta