### PR TITLE
feat(cross-platform): localize dashboard experience

### DIFF
--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/DashboardScreen.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/DashboardScreen.kt
@@ -1,5 +1,6 @@
 package com.creapolis.solennix.feature.dashboard.ui
 
+import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -26,6 +27,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -44,11 +46,19 @@ import com.creapolis.solennix.core.model.EventStatus
 import com.creapolis.solennix.core.model.InventoryItem
 import com.creapolis.solennix.core.model.extensions.asMXNCompact
 import com.creapolis.solennix.core.model.extensions.parseFlexibleDate
+import com.creapolis.solennix.feature.dashboard.R
 import com.creapolis.solennix.feature.dashboard.viewmodel.DashboardViewModel
 import com.creapolis.solennix.feature.dashboard.viewmodel.MIN_PENDING_AMOUNT
 import com.creapolis.solennix.feature.dashboard.viewmodel.PendingEvent
 import com.creapolis.solennix.feature.dashboard.viewmodel.PendingEventReason
 import com.creapolis.solennix.feature.dashboard.viewmodel.StatusCount
+import java.text.NumberFormat
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.format.TextStyle
+import java.util.Currency
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -82,11 +92,11 @@ fun DashboardScreen(
     Scaffold(
         topBar = {
             SolennixSectionTopAppBar(
-                title = "Inicio",
+                title = stringResource(R.string.dashboard_title),
                 onSearchClick = onSearchClick,
                 actions = {
                     IconButton(onClick = { viewModel.refresh() }) {
-                        Icon(Icons.Default.Refresh, contentDescription = "Actualizar")
+                        Icon(Icons.Default.Refresh, contentDescription = stringResource(R.string.dashboard_refresh))
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors()
@@ -136,7 +146,7 @@ fun DashboardScreen(
                 if (uiState.isBasicPlan) {
                     item {
                         UpgradeBanner(
-                            message = "Potenciá tu negocio con el plan Pro: eventos ilimitados, inventario y más.",
+                            message = stringResource(R.string.dashboard_upgrade_banner),
                             style = UpgradeBannerStyle.PROMO,
                             onUpgradeClick = onUpgradeClick
                         )
@@ -154,7 +164,7 @@ fun DashboardScreen(
                         ) {
                             Column(modifier = Modifier.padding(16.dp)) {
                                 Text(
-                                    text = "Requieren atención (${uiState.pendingEvents.size})",
+                                    text = stringResource(R.string.dashboard_attention_title_with_count, uiState.pendingEvents.size),
                                     style = MaterialTheme.typography.titleSmall,
                                     color = SolennixTheme.colors.warning,
                                     fontWeight = FontWeight.SemiBold
@@ -185,14 +195,14 @@ fun DashboardScreen(
                 item {
                     if (isWideScreen) {
                         val kpiItems = listOf(
-                            Triple("Ventas Netas", uiState.revenueThisMonth.asMXNCompact(), Triple(Icons.Default.AttachMoney, SolennixTheme.colors.kpiGreen, "Eventos confirmados y completados")),
-                            Triple("Cobrado", uiState.cashCollected.asMXNCompact(), Triple(Icons.Default.Payments, SolennixTheme.colors.kpiOrange, "Este mes")),
-                            Triple("IVA Cobrado", uiState.vatCollected.asMXNCompact(), Triple(Icons.Default.Receipt, SolennixTheme.colors.kpiBlue, "Este mes")),
-                            Triple("IVA Pendiente", uiState.vatOutstanding.asMXNCompact(), Triple(Icons.Default.ReceiptLong, SolennixTheme.colors.kpiBlue, "Por cobrar")),
-                            Triple("Eventos del Mes", uiState.eventsThisMonth.toString(), Triple(Icons.Default.CalendarMonth, SolennixTheme.colors.kpiOrange, null)),
-                            Triple("Stock Bajo", uiState.lowStockCount.toString(), Triple(Icons.Default.Inventory2, if (uiState.lowStockCount > 0) SolennixTheme.colors.kpiOrange else SolennixTheme.colors.kpiGreen, null)),
-                            Triple("Clientes", uiState.totalClients.toString(), Triple(Icons.Default.People, SolennixTheme.colors.kpiBlue, "Total")),
-                            Triple("Cotizaciones", uiState.pendingQuotes.toString(), Triple(Icons.Default.RequestQuote, SolennixTheme.colors.kpiOrange, null))
+                            Triple(stringResource(R.string.dashboard_kpi_net_sales), uiState.revenueThisMonth.asMXNCompact(), Triple(Icons.Default.AttachMoney, SolennixTheme.colors.kpiGreen, stringResource(R.string.dashboard_kpi_confirmed_completed))),
+                            Triple(stringResource(R.string.dashboard_kpi_collected), uiState.cashCollected.asMXNCompact(), Triple(Icons.Default.Payments, SolennixTheme.colors.kpiOrange, stringResource(R.string.dashboard_kpi_this_month))),
+                            Triple(stringResource(R.string.dashboard_kpi_vat_collected), uiState.vatCollected.asMXNCompact(), Triple(Icons.Default.Receipt, SolennixTheme.colors.kpiBlue, stringResource(R.string.dashboard_kpi_this_month))),
+                            Triple(stringResource(R.string.dashboard_kpi_vat_outstanding), uiState.vatOutstanding.asMXNCompact(), Triple(Icons.Default.ReceiptLong, SolennixTheme.colors.kpiBlue, stringResource(R.string.dashboard_kpi_due))),
+                            Triple(stringResource(R.string.dashboard_kpi_events_this_month), uiState.eventsThisMonth.toString(), Triple(Icons.Default.CalendarMonth, SolennixTheme.colors.kpiOrange, null)),
+                            Triple(stringResource(R.string.dashboard_kpi_low_stock), uiState.lowStockCount.toString(), Triple(Icons.Default.Inventory2, if (uiState.lowStockCount > 0) SolennixTheme.colors.kpiOrange else SolennixTheme.colors.kpiGreen, null)),
+                            Triple(stringResource(R.string.dashboard_kpi_clients), uiState.totalClients.toString(), Triple(Icons.Default.People, SolennixTheme.colors.kpiBlue, stringResource(R.string.dashboard_kpi_total))),
+                            Triple(stringResource(R.string.dashboard_kpi_quotes), uiState.pendingQuotes.toString(), Triple(Icons.Default.RequestQuote, SolennixTheme.colors.kpiOrange, null))
                         )
                         Column(modifier = Modifier.padding(vertical = 8.dp)) {
                             kpiItems.chunked(4).forEach { rowItems ->
@@ -234,14 +244,14 @@ fun DashboardScreen(
                             horizontalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Spacer(modifier = Modifier.width(4.dp))
-                            KPICard(title = "Ventas Netas", value = uiState.revenueThisMonth.asMXNCompact(), icon = Icons.Default.AttachMoney, iconColor = SolennixTheme.colors.kpiGreen, subtitle = "Eventos confirmados y completados", modifier = cardModifier)
-                            KPICard(title = "Cobrado", value = uiState.cashCollected.asMXNCompact(), icon = Icons.Default.Payments, iconColor = SolennixTheme.colors.kpiOrange, subtitle = "Este mes", modifier = cardModifier)
-                            KPICard(title = "IVA Cobrado", value = uiState.vatCollected.asMXNCompact(), icon = Icons.Default.Receipt, iconColor = SolennixTheme.colors.kpiBlue, subtitle = "Este mes", modifier = cardModifier)
-                            KPICard(title = "IVA Pendiente", value = uiState.vatOutstanding.asMXNCompact(), icon = Icons.Default.ReceiptLong, iconColor = SolennixTheme.colors.kpiBlue, subtitle = "Por cobrar", modifier = cardModifier)
-                            KPICard(title = "Eventos del Mes", value = uiState.eventsThisMonth.toString(), icon = Icons.Default.CalendarMonth, iconColor = SolennixTheme.colors.kpiOrange, modifier = cardModifier)
-                            KPICard(title = "Stock Bajo", value = uiState.lowStockCount.toString(), icon = Icons.Default.Inventory2, iconColor = if (uiState.lowStockCount > 0) SolennixTheme.colors.kpiOrange else SolennixTheme.colors.kpiGreen, modifier = cardModifier)
-                            KPICard(title = "Clientes", value = uiState.totalClients.toString(), icon = Icons.Default.People, iconColor = SolennixTheme.colors.kpiBlue, subtitle = "Total", modifier = cardModifier)
-                            KPICard(title = "Cotizaciones", value = uiState.pendingQuotes.toString(), icon = Icons.Default.RequestQuote, iconColor = SolennixTheme.colors.kpiOrange, modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_net_sales), value = uiState.revenueThisMonth.asMXNCompact(), icon = Icons.Default.AttachMoney, iconColor = SolennixTheme.colors.kpiGreen, subtitle = stringResource(R.string.dashboard_kpi_confirmed_completed), modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_collected), value = uiState.cashCollected.asMXNCompact(), icon = Icons.Default.Payments, iconColor = SolennixTheme.colors.kpiOrange, subtitle = stringResource(R.string.dashboard_kpi_this_month), modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_vat_collected), value = uiState.vatCollected.asMXNCompact(), icon = Icons.Default.Receipt, iconColor = SolennixTheme.colors.kpiBlue, subtitle = stringResource(R.string.dashboard_kpi_this_month), modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_vat_outstanding), value = uiState.vatOutstanding.asMXNCompact(), icon = Icons.Default.ReceiptLong, iconColor = SolennixTheme.colors.kpiBlue, subtitle = stringResource(R.string.dashboard_kpi_due), modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_events_this_month), value = uiState.eventsThisMonth.toString(), icon = Icons.Default.CalendarMonth, iconColor = SolennixTheme.colors.kpiOrange, modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_low_stock), value = uiState.lowStockCount.toString(), icon = Icons.Default.Inventory2, iconColor = if (uiState.lowStockCount > 0) SolennixTheme.colors.kpiOrange else SolennixTheme.colors.kpiGreen, modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_clients), value = uiState.totalClients.toString(), icon = Icons.Default.People, iconColor = SolennixTheme.colors.kpiBlue, subtitle = stringResource(R.string.dashboard_kpi_total), modifier = cardModifier)
+                            KPICard(title = stringResource(R.string.dashboard_kpi_quotes), value = uiState.pendingQuotes.toString(), icon = Icons.Default.RequestQuote, iconColor = SolennixTheme.colors.kpiOrange, modifier = cardModifier)
                             Spacer(modifier = Modifier.width(4.dp))
                         }
                     }
@@ -251,8 +261,8 @@ fun DashboardScreen(
                 item {
                     Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        QuickActionButton("Nuevo Evento", Icons.Default.Event, SolennixTheme.colors.primary, onNewEventClick, Modifier.weight(1f))
-                        QuickActionButton("Nuevo Cliente", Icons.Default.PersonAdd, SolennixTheme.colors.kpiBlue, onNewClientClick, Modifier.weight(1f))
+                        QuickActionButton(stringResource(R.string.dashboard_quick_new_event), Icons.Default.Event, SolennixTheme.colors.primary, onNewEventClick, Modifier.weight(1f))
+                        QuickActionButton(stringResource(R.string.dashboard_quick_new_client), Icons.Default.PersonAdd, SolennixTheme.colors.kpiBlue, onNewClientClick, Modifier.weight(1f))
                     }
                 }
 
@@ -294,7 +304,7 @@ fun DashboardScreen(
                     item {
                         Spacer(modifier = Modifier.height(24.dp))
                         Text(
-                            text = "Alertas de Inventario",
+                            text = stringResource(R.string.dashboard_inventory_alerts),
                             modifier = Modifier.semantics { heading() },
                             style = MaterialTheme.typography.titleMedium,
                             color = SolennixTheme.colors.primaryText
@@ -310,7 +320,7 @@ fun DashboardScreen(
                     item {
                         Spacer(modifier = Modifier.height(24.dp))
                         Text(
-                            text = "Próximos Eventos",
+                            text = stringResource(R.string.dashboard_upcoming_events),
                             modifier = Modifier.semantics { heading() },
                             style = MaterialTheme.typography.titleMedium,
                             color = SolennixTheme.colors.primaryText
@@ -364,9 +374,9 @@ fun DashboardScreen(
             val isOverdueWithBalance =
                 pe.reason == PendingEventReason.OVERDUE_EVENT && pe.pendingAmount > MIN_PENDING_AMOUNT
             val (modalTitle, confirmLabel) = if (isOverdueWithBalance) {
-                "Registrar pago y completar" to "Pagar y completar"
+                stringResource(R.string.dashboard_attention_register_payment_and_complete) to stringResource(R.string.dashboard_attention_pay_and_complete)
             } else {
-                "Registrar pago" to "Guardar Pago"
+                stringResource(R.string.dashboard_attention_register_payment) to stringResource(R.string.dashboard_payment_save)
             }
             PaymentModal(
                 remaining = pe.pendingAmount,
@@ -394,6 +404,7 @@ fun EventStatusDistributionCard(
     statusCounts: List<StatusCount>,
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     Card(
         modifier = modifier
             .fillMaxWidth()
@@ -406,7 +417,7 @@ fun EventStatusDistributionCard(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(
-                "Estado de Eventos",
+                stringResource(R.string.dashboard_event_status),
                 style = MaterialTheme.typography.titleSmall,
                 color = SolennixTheme.colors.primaryText,
                 fontWeight = FontWeight.SemiBold
@@ -446,13 +457,17 @@ fun EventStatusDistributionCard(
                                 .background(statusColor(statusCount.status))
                         )
                         Text(
-                            text = statusLabel(statusCount.status),
+                            text = statusLabel(statusCount.status, context),
                             style = MaterialTheme.typography.bodyMedium,
                             color = SolennixTheme.colors.primaryText
                         )
                     }
                     Text(
-                        text = "${statusCount.count} (${(statusCount.percentage * 100).toInt()}%)",
+                        text = stringResource(
+                            R.string.dashboard_chart_count_percentage,
+                            statusCount.count,
+                            (statusCount.percentage * 100).toInt()
+                        ),
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         color = SolennixTheme.colors.secondaryText
@@ -473,12 +488,12 @@ private fun statusColor(status: EventStatus): Color {
     }
 }
 
-private fun statusLabel(status: EventStatus): String {
+private fun statusLabel(status: EventStatus, context: Context): String {
     return when (status) {
-        EventStatus.QUOTED -> "Cotizado"
-        EventStatus.CONFIRMED -> "Confirmado"
-        EventStatus.COMPLETED -> "Completado"
-        EventStatus.CANCELLED -> "Cancelado"
+        EventStatus.QUOTED -> context.getString(R.string.dashboard_status_quoted)
+        EventStatus.CONFIRMED -> context.getString(R.string.dashboard_status_confirmed)
+        EventStatus.COMPLETED -> context.getString(R.string.dashboard_status_completed)
+        EventStatus.CANCELLED -> context.getString(R.string.dashboard_status_cancelled)
     }
 }
 
@@ -491,13 +506,14 @@ fun PendingEventItem(
     onCancel: () -> Unit = {},
     onRegisterPayment: () -> Unit = {}
 ) {
+    val context = LocalContext.current
     val hasPending = pendingEvent.pendingAmount > MIN_PENDING_AMOUNT
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
             .semantics(mergeDescendants = true) {
-                contentDescription = pendingEventTalkBackLabel(pendingEvent)
+                contentDescription = pendingEventTalkBackLabel(pendingEvent, context)
             }
             .clickable(enabled = !isUpdating, onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
@@ -577,8 +593,8 @@ private fun PendingEventActions(
                     onClick = onRegisterPayment,
                     enabled = !isUpdating,
                     colors = ButtonDefaults.buttonColors(containerColor = SolennixTheme.colors.primary)
-                ) { Text("Registrar pago") }
-                TextButton(onClick = onViewDetail, enabled = !isUpdating) { Text("Ver") }
+                ) { Text(stringResource(R.string.dashboard_attention_register_payment)) }
+                TextButton(onClick = onViewDetail, enabled = !isUpdating) { Text(stringResource(R.string.dashboard_attention_view)) }
             }
             PendingEventReason.OVERDUE_EVENT -> {
                 if (hasPending) {
@@ -586,28 +602,28 @@ private fun PendingEventActions(
                         onClick = onRegisterPayment,
                         enabled = !isUpdating,
                         colors = ButtonDefaults.buttonColors(containerColor = SolennixTheme.colors.primary)
-                    ) { Text("Pagar y completar") }
+                    ) { Text(stringResource(R.string.dashboard_attention_pay_and_complete)) }
                     OutlinedButton(
                         onClick = onCancel,
                         enabled = !isUpdating,
                         colors = ButtonDefaults.outlinedButtonColors(contentColor = SolennixTheme.colors.error)
-                    ) { Text("Cancelar") }
-                    TextButton(onClick = onComplete, enabled = !isUpdating) { Text("Solo completar") }
+                    ) { Text(stringResource(R.string.dashboard_action_cancel)) }
+                    TextButton(onClick = onComplete, enabled = !isUpdating) { Text(stringResource(R.string.dashboard_attention_complete_only)) }
                 } else {
                     Button(
                         onClick = onComplete,
                         enabled = !isUpdating,
                         colors = ButtonDefaults.buttonColors(containerColor = SolennixTheme.colors.success)
-                    ) { Text("Completar") }
+                    ) { Text(stringResource(R.string.dashboard_attention_complete)) }
                     OutlinedButton(
                         onClick = onCancel,
                         enabled = !isUpdating,
                         colors = ButtonDefaults.outlinedButtonColors(contentColor = SolennixTheme.colors.error)
-                    ) { Text("Cancelar") }
+                    ) { Text(stringResource(R.string.dashboard_action_cancel)) }
                 }
             }
             PendingEventReason.QUOTE_URGENT -> {
-                TextButton(onClick = onViewDetail, enabled = !isUpdating) { Text("Ver detalle") }
+                TextButton(onClick = onViewDetail, enabled = !isUpdating) { Text(stringResource(R.string.dashboard_attention_view_detail)) }
             }
         }
 
@@ -624,12 +640,13 @@ private fun PendingEventActions(
 
 @Composable
 fun EventListItem(event: Event, clientName: String? = null, onClick: () -> Unit = {}) {
+    val context = LocalContext.current
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
             .semantics(mergeDescendants = true) {
-                contentDescription = dashboardEventTalkBackLabel(event, clientName)
+                contentDescription = dashboardEventTalkBackLabel(event, clientName, context)
             }
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
@@ -665,10 +682,12 @@ private fun DashboardGreetingHeader(
     userName: String,
     modifier: Modifier = Modifier
 ) {
-    val today = remember {
-        val now = java.time.LocalDate.now()
-        val formatter = java.time.format.DateTimeFormatter
-            .ofPattern("EEEE d 'de' MMMM", java.util.Locale("es", "MX"))
+    val context = LocalContext.current
+    val locale = currentAppLocale(context)
+    val today = remember(locale) {
+        val now = LocalDate.now()
+        val formatter = DateTimeFormatter
+            .ofPattern(context.getString(R.string.dashboard_greeting_date_pattern), locale)
         now.format(formatter).replaceFirstChar { it.uppercase() }
     }
     Row(
@@ -677,7 +696,7 @@ private fun DashboardGreetingHeader(
     ) {
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = if (userName.isNotEmpty()) "Hola, $userName" else "Hola",
+                text = if (userName.isNotEmpty()) context.getString(R.string.dashboard_greeting_with_name, userName) else context.getString(R.string.dashboard_greeting_generic),
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = SolennixTheme.colors.primaryText
@@ -721,13 +740,16 @@ private fun QuickActionButton(
 
 @Composable
 private fun DateBox(dateString: String, modifier: Modifier = Modifier) {
-    val (month, day) = remember(dateString) {
+    val context = LocalContext.current
+    val locale = currentAppLocale(context)
+    val (month, day) = remember(dateString, locale) {
         val parsed = try {
             parseFlexibleDate(dateString)
         } catch (_: Exception) { null }
         if (parsed != null) {
             val monthAbbr = parsed.month.getDisplayName(
-                java.time.format.TextStyle.SHORT, java.util.Locale("es", "MX")
+                TextStyle.SHORT,
+                locale
             ).replaceFirstChar { it.uppercase() }
             monthAbbr to parsed.dayOfMonth.toString()
         } else "" to ""
@@ -746,9 +768,11 @@ private fun DateBox(dateString: String, modifier: Modifier = Modifier) {
 
 @Composable
 private fun MonthlyRevenueTrendCard(points: List<com.creapolis.solennix.core.model.DashboardRevenuePoint>) {
+    val context = LocalContext.current
+    val locale = currentAppLocale(context)
     val maxRevenue = points.maxOfOrNull { it.revenue }?.takeIf { it > 0 } ?: 1.0
-    val monthLabelFormatter = remember {
-        java.time.format.DateTimeFormatter.ofPattern("MMM", java.util.Locale("es", "MX"))
+    val monthLabelFormatter = remember(locale) {
+        DateTimeFormatter.ofPattern(context.getString(R.string.dashboard_month_short_pattern), locale)
     }
     // 4 gridlines + baseline at $0 → matches iOS's AxisMarks(leading) look.
     // We pick nice round fractions of the max so labels are "$0", "2k",
@@ -757,14 +781,7 @@ private fun MonthlyRevenueTrendCard(points: List<com.creapolis.solennix.core.mod
         listOf(0.0, 0.25, 0.5, 0.75, 1.0).map { it * maxRevenue }
     }
     val yAxisLabelFormatter: (Double) -> String = remember {
-        { value ->
-            when {
-                value == 0.0 -> "$0"
-                value >= 1_000_000 -> "${(value / 1_000_000).toInt()}M"
-                value >= 1_000 -> "${(value / 1_000).toInt()}k"
-                else -> "${value.toInt()}"
-            }
-        }
+        { value -> formatAxisCurrencyLabel(value, locale) }
     }
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -773,7 +790,7 @@ private fun MonthlyRevenueTrendCard(points: List<com.creapolis.solennix.core.mod
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Text(
-                "Ingresos — Últimos 6 meses",
+                stringResource(R.string.dashboard_revenue_last_6_months),
                 style = MaterialTheme.typography.titleSmall,
                 color = SolennixTheme.colors.primaryText,
                 fontWeight = FontWeight.SemiBold
@@ -814,7 +831,7 @@ private fun MonthlyRevenueTrendCard(points: List<com.creapolis.solennix.core.mod
                     points.forEach { point ->
                         val fraction = (point.revenue / maxRevenue).coerceIn(0.0, 1.0).toFloat()
                         val monthLabel = try {
-                            val parsed = java.time.YearMonth.parse(point.month)
+                            val parsed = YearMonth.parse(point.month)
                             parsed.format(monthLabelFormatter).replaceFirstChar { it.uppercase() }
                         } catch (_: Exception) {
                             point.month
@@ -864,11 +881,11 @@ private fun FinancialComparisonCard(
         colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
         shape = MaterialTheme.shapes.large) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Text("Comparativa Financiera", style = MaterialTheme.typography.titleSmall,
+            Text(stringResource(R.string.dashboard_financial_comparison), style = MaterialTheme.typography.titleSmall,
                 color = SolennixTheme.colors.primaryText, fontWeight = FontWeight.SemiBold)
-            FinancialBar("Ventas Netas", revenueThisMonth, maxValue, SolennixTheme.colors.kpiGreen)
-            FinancialBar("Cobrado Real", cashCollected, maxValue, SolennixTheme.colors.primary)
-            FinancialBar("IVA por Cobrar", vatOutstanding, maxValue, SolennixTheme.colors.kpiRed)
+            FinancialBar(stringResource(R.string.dashboard_kpi_net_sales), revenueThisMonth, maxValue, SolennixTheme.colors.kpiGreen)
+            FinancialBar(stringResource(R.string.dashboard_kpi_collected), cashCollected, maxValue, SolennixTheme.colors.primary)
+            FinancialBar(stringResource(R.string.dashboard_kpi_vat_outstanding), vatOutstanding, maxValue, SolennixTheme.colors.kpiRed)
         }
     }
 }
@@ -892,12 +909,13 @@ private fun FinancialBar(label: String, value: Double, maxValue: Double, barColo
 
 @Composable
 fun InventoryAlertItem(item: InventoryItem, onClick: () -> Unit = {}) {
+    val context = LocalContext.current
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
             .semantics(mergeDescendants = true) {
-                contentDescription = inventoryAlertTalkBackLabel(item)
+                contentDescription = inventoryAlertTalkBackLabel(item, context)
             }
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card),
@@ -921,7 +939,7 @@ fun InventoryAlertItem(item: InventoryItem, onClick: () -> Unit = {}) {
                     color = SolennixTheme.colors.primaryText
                 )
                 Text(
-                    text = "Stock actual: ${item.currentStock} ${item.unit}",
+                    text = stringResource(R.string.dashboard_low_stock_current, item.currentStock.toString(), item.unit),
                     style = MaterialTheme.typography.bodySmall,
                     color = SolennixTheme.colors.error
                 )
@@ -930,24 +948,62 @@ fun InventoryAlertItem(item: InventoryItem, onClick: () -> Unit = {}) {
     }
 }
 
-internal fun pendingEventTalkBackLabel(pendingEvent: PendingEvent): String {
-    return buildString {
-        append("Evento pendiente")
-        append(": ${pendingEvent.event.serviceType}")
-        append(", fecha ${pendingEvent.event.eventDate}")
-        append(", motivo ${pendingEvent.reasonLabel}")
-    }
+internal fun pendingEventTalkBackLabel(pendingEvent: PendingEvent, context: Context): String {
+    return context.getString(
+        R.string.dashboard_a11y_pending_event,
+        pendingEvent.reasonLabel,
+        pendingEvent.event.serviceType,
+        pendingEvent.event.eventDate,
+        pendingEvent.reasonLabel
+    )
 }
 
-internal fun dashboardEventTalkBackLabel(event: Event, clientName: String?): String {
-    return buildString {
-        clientName?.takeIf { it.isNotBlank() }?.let { append("$it, ") }
-        append(event.serviceType)
-        append(", fecha ${event.eventDate}")
-        append(", estado ${statusLabel(event.status)}")
-    }
+internal fun dashboardEventTalkBackLabel(event: Event, clientName: String?, context: Context): String {
+    return clientName
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+            context.getString(
+                R.string.dashboard_a11y_event_with_client,
+                it,
+                event.serviceType,
+                event.eventDate,
+                statusLabel(event.status, context)
+            )
+        }
+        ?: context.getString(
+            R.string.dashboard_a11y_event,
+            event.serviceType,
+            event.eventDate,
+            statusLabel(event.status, context)
+        )
 }
 
-internal fun inventoryAlertTalkBackLabel(item: InventoryItem): String {
-    return "Stock bajo: ${item.ingredientName}, actual ${item.currentStock} ${item.unit}"
+internal fun inventoryAlertTalkBackLabel(item: InventoryItem, context: Context): String {
+    return context.getString(
+        R.string.dashboard_a11y_inventory_alert,
+        item.ingredientName,
+        item.currentStock.toString(),
+        item.unit
+    )
+}
+
+private fun currentAppLocale(context: Context): Locale {
+    return context.resources.configuration.locales[0] ?: Locale.getDefault()
+}
+
+private fun formatAxisCurrencyLabel(value: Double, locale: Locale): String {
+    val currencySymbol = Currency.getInstance("MXN").getSymbol(locale)
+    if (value == 0.0) return "${currencySymbol}0"
+    val absValue = kotlin.math.abs(value)
+    val (divisor, suffix) = when {
+        absValue >= 1_000_000 -> 1_000_000.0 to "M"
+        absValue >= 1_000 -> 1_000.0 to "K"
+        else -> 1.0 to ""
+    }
+    val formatter = NumberFormat.getNumberInstance(locale).apply {
+        maximumFractionDigits = if (divisor == 1.0 || absValue / divisor >= 10) 0 else 1
+        minimumFractionDigits = 0
+    }
+
+    return "$currencySymbol${formatter.format(value / divisor)}$suffix"
 }

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/ForecastWidget.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/ForecastWidget.kt
@@ -11,11 +11,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.ForecastDataPoint
 import com.creapolis.solennix.core.model.extensions.asMXNCompact
+import com.creapolis.solennix.feature.dashboard.R
 
 @Composable
 fun ForecastWidget(
@@ -30,7 +33,7 @@ fun ForecastWidget(
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                "Pronóstico de Ingresos",
+                stringResource(R.string.dashboard_widget_forecast_title),
                 style = MaterialTheme.typography.titleSmall,
                 color = SolennixTheme.colors.primaryText,
                 fontWeight = FontWeight.SemiBold
@@ -60,7 +63,7 @@ fun ForecastWidget(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            "No hay datos aún",
+                            stringResource(R.string.dashboard_widget_forecast_empty),
                             style = MaterialTheme.typography.bodySmall,
                             color = SolennixTheme.colors.secondaryText
                         )
@@ -95,7 +98,7 @@ fun ForecastWidget(
                                             fontWeight = FontWeight.Medium
                                         )
                                         Text(
-                                            "${point.confirmedEvents} eventos proyectados",
+                                            pluralStringResource(R.plurals.dashboard_widget_forecast_events, point.confirmedEvents, point.confirmedEvents),
                                             style = MaterialTheme.typography.labelSmall,
                                             color = SolennixTheme.colors.secondaryText
                                         )

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/ProductDemandWidget.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/ProductDemandWidget.kt
@@ -11,10 +11,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.ProductDemandItem
+import com.creapolis.solennix.feature.dashboard.R
 
 @Composable
 fun ProductDemandWidget(
@@ -29,7 +32,7 @@ fun ProductDemandWidget(
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                "Productos en Demanda",
+                stringResource(R.string.dashboard_widget_product_demand_title),
                 style = MaterialTheme.typography.titleSmall,
                 color = SolennixTheme.colors.primaryText,
                 fontWeight = FontWeight.SemiBold
@@ -59,7 +62,7 @@ fun ProductDemandWidget(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            "No hay datos aún",
+                            stringResource(R.string.dashboard_widget_product_demand_empty),
                             style = MaterialTheme.typography.bodySmall,
                             color = SolennixTheme.colors.secondaryText
                         )
@@ -94,7 +97,7 @@ fun ProductDemandWidget(
                                             fontWeight = FontWeight.Medium
                                         )
                                         Text(
-                                            "${product.timesUsed} en cotizaciones",
+                                            pluralStringResource(R.plurals.dashboard_widget_product_demand_uses, product.timesUsed, product.timesUsed),
                                             style = MaterialTheme.typography.labelSmall,
                                             color = SolennixTheme.colors.secondaryText
                                         )

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/TopClientsWidget.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/ui/TopClientsWidget.kt
@@ -11,11 +11,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
 import com.creapolis.solennix.core.model.TopClient
 import com.creapolis.solennix.core.model.extensions.asMXNCompact
+import com.creapolis.solennix.feature.dashboard.R
 
 @Composable
 fun TopClientsWidget(
@@ -30,7 +33,7 @@ fun TopClientsWidget(
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                "Clientes Principales",
+                stringResource(R.string.dashboard_widget_top_clients_title),
                 style = MaterialTheme.typography.titleSmall,
                 color = SolennixTheme.colors.primaryText,
                 fontWeight = FontWeight.SemiBold
@@ -60,7 +63,7 @@ fun TopClientsWidget(
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            "No hay datos aún",
+                            stringResource(R.string.dashboard_widget_top_clients_empty),
                             style = MaterialTheme.typography.bodySmall,
                             color = SolennixTheme.colors.secondaryText
                         )
@@ -95,7 +98,7 @@ fun TopClientsWidget(
                                             fontWeight = FontWeight.Medium
                                         )
                                         Text(
-                                            "${client.totalEvents} eventos",
+                                            pluralStringResource(R.plurals.dashboard_widget_top_clients_events, client.totalEvents, client.totalEvents),
                                             style = MaterialTheme.typography.labelSmall,
                                             color = SolennixTheme.colors.secondaryText
                                         )

--- a/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/viewmodel/DashboardViewModel.kt
+++ b/android/feature/dashboard/src/main/java/com/creapolis/solennix/feature/dashboard/viewmodel/DashboardViewModel.kt
@@ -1,8 +1,10 @@
 package com.creapolis.solennix.feature.dashboard.viewmodel
 
+import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.creapolis.solennix.feature.dashboard.R
 import com.creapolis.solennix.core.data.repository.ClientRepository
 import com.creapolis.solennix.core.data.repository.DashboardRepository
 import com.creapolis.solennix.core.data.repository.EventRepository
@@ -25,6 +27,7 @@ import com.creapolis.solennix.core.model.ProductDemandItem
 import com.creapolis.solennix.core.model.ForecastDataPoint
 import com.creapolis.solennix.core.network.AuthManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -99,6 +102,7 @@ data class DashboardUiState(
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
+    @ApplicationContext private val appContext: Context,
     private val eventRepository: EventRepository,
     private val inventoryRepository: InventoryRepository,
     private val clientRepository: ClientRepository,
@@ -107,6 +111,8 @@ class DashboardViewModel @Inject constructor(
     private val dashboardRepository: DashboardRepository,
     private val authManager: AuthManager
 ) : ViewModel() {
+
+    private fun tr(id: Int, vararg args: Any): String = appContext.getString(id, *args)
 
     private val _isRefreshing = MutableStateFlow(false)
     private val _updatingEventId = MutableStateFlow<String?>(null)
@@ -219,19 +225,19 @@ class DashboardViewModel @Inject constructor(
                     hasPending
                 ) {
                     pendingEvents.add(
-                        PendingEvent(event, PendingEventReason.PAYMENT_DUE, "Cobro por cerrar", pendingAmount)
+                        PendingEvent(event, PendingEventReason.PAYMENT_DUE, tr(R.string.dashboard_attention_confirmed_payment_title), pendingAmount)
                     )
                 } else if (eventDate.isBefore(now) &&
                     (event.status == EventStatus.QUOTED || event.status == EventStatus.CONFIRMED)
                 ) {
                     pendingEvents.add(
-                        PendingEvent(event, PendingEventReason.OVERDUE_EVENT, "Evento vencido", pendingAmount)
+                        PendingEvent(event, PendingEventReason.OVERDUE_EVENT, tr(R.string.dashboard_attention_overdue_event_kind), pendingAmount)
                     )
                 } else if (event.status == EventStatus.QUOTED &&
                     !eventDate.isBefore(now) && !eventDate.isAfter(fourteenDaysFromNow)
                 ) {
                     pendingEvents.add(
-                        PendingEvent(event, PendingEventReason.QUOTE_URGENT, "Cotización urgente", pendingAmount)
+                        PendingEvent(event, PendingEventReason.QUOTE_URGENT, tr(R.string.dashboard_attention_quote_urgent_kind), pendingAmount)
                     )
                 }
             } catch (_: Exception) { }
@@ -428,13 +434,13 @@ class DashboardViewModel @Inject constructor(
                 val event = eventRepository.getEvent(eventId) ?: return@launch
                 eventRepository.updateEvent(event.copy(status = newStatus))
                 _transientMessage.value = when (newStatus) {
-                    EventStatus.COMPLETED -> "Evento marcado como completado"
-                    EventStatus.CANCELLED -> "Evento cancelado"
+                    EventStatus.COMPLETED -> tr(R.string.dashboard_message_event_completed)
+                    EventStatus.CANCELLED -> tr(R.string.dashboard_message_event_cancelled)
                     else -> null
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "updateEventStatus failed for event=$eventId", e)
-                _transientMessage.value = "No pudimos actualizar el estado del evento. Reintentá en un momento."
+                _transientMessage.value = tr(R.string.dashboard_error_status_change_failed)
             } finally {
                 _updatingEventId.value = null
             }
@@ -450,7 +456,7 @@ class DashboardViewModel @Inject constructor(
         autoComplete: Boolean
     ) {
         if (amount <= 0 || method.isBlank()) {
-            _transientMessage.value = "Monto y método de pago son requeridos"
+            _transientMessage.value = tr(R.string.dashboard_error_payment_requirements)
             return
         }
         // Auto-complete only when the entered amount actually settles the
@@ -478,18 +484,18 @@ class DashboardViewModel @Inject constructor(
                     try {
                         val refreshed = eventRepository.getEvent(pendingEvent.event.id) ?: pendingEvent.event
                         eventRepository.updateEvent(refreshed.copy(status = EventStatus.COMPLETED))
-                        _transientMessage.value = "Pago registrado y evento completado"
+                        _transientMessage.value = tr(R.string.dashboard_message_payment_registered_and_completed)
                     } catch (statusErr: Exception) {
                         Log.w(TAG, "Auto-complete after payment failed for event=${pendingEvent.event.id}", statusErr)
-                        _transientMessage.value = "Pago registrado. Marcá el evento como completado manualmente."
+                        _transientMessage.value = tr(R.string.dashboard_message_payment_complete_manual)
                     }
                 } else {
-                    _transientMessage.value = "Pago registrado correctamente"
+                    _transientMessage.value = tr(R.string.dashboard_message_payment_registered)
                 }
                 _paymentModalEvent.value = null
             } catch (e: Exception) {
                 Log.e(TAG, "registerPayment failed for event=${pendingEvent.event.id}", e)
-                _transientMessage.value = "No pudimos registrar el pago. Reintentá en un momento."
+                _transientMessage.value = tr(R.string.dashboard_error_payment_failed)
             } finally {
                 _updatingEventId.value = null
             }

--- a/android/feature/dashboard/src/main/res/values-en/strings.xml
+++ b/android/feature/dashboard/src/main/res/values-en/strings.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dashboard_title">Home</string>
+    <string name="dashboard_refresh">Refresh</string>
+    <string name="dashboard_upgrade_banner">Grow your business with the Pro plan: unlimited events, inventory, and more.</string>
+    <string name="dashboard_attention_title">Need attention</string>
+    <string name="dashboard_attention_title_with_count">Need attention (%1$d)</string>
+    <string name="dashboard_attention_confirmed_payment_title">Upcoming balances</string>
+    <string name="dashboard_attention_overdue_event_kind">Overdue event</string>
+    <string name="dashboard_attention_quote_urgent_kind">Urgent quote</string>
+    <string name="dashboard_attention_register_payment">Record payment</string>
+    <string name="dashboard_attention_register_payment_and_complete">Record payment and complete</string>
+    <string name="dashboard_attention_pay_and_complete">Pay &amp; complete</string>
+    <string name="dashboard_attention_complete_only">Complete only</string>
+    <string name="dashboard_attention_complete">Complete</string>
+    <string name="dashboard_attention_view">View</string>
+    <string name="dashboard_attention_view_detail">View details</string>
+    <string name="dashboard_action_cancel">Cancel</string>
+    <string name="dashboard_message_event_completed">Event marked as completed</string>
+    <string name="dashboard_message_event_cancelled">Event cancelled</string>
+    <string name="dashboard_message_payment_registered">Payment recorded</string>
+    <string name="dashboard_message_payment_registered_and_completed">Payment recorded and event completed</string>
+    <string name="dashboard_message_payment_complete_manual">Payment recorded. Mark the event as completed manually.</string>
+    <string name="dashboard_error_status_change_failed">We couldn’t update the event status. Please try again soon.</string>
+    <string name="dashboard_error_payment_failed">We couldn’t record the payment. Please try again soon.</string>
+    <string name="dashboard_error_payment_requirements">Amount and payment method are required</string>
+    <string name="dashboard_kpi_net_sales">Net sales</string>
+    <string name="dashboard_kpi_collected">Collected</string>
+    <string name="dashboard_kpi_vat_collected">VAT collected</string>
+    <string name="dashboard_kpi_vat_outstanding">VAT due</string>
+    <string name="dashboard_kpi_events_this_month">Events this month</string>
+    <string name="dashboard_kpi_low_stock">Low stock</string>
+    <string name="dashboard_kpi_clients">Clients</string>
+    <string name="dashboard_kpi_quotes">Quotes</string>
+    <string name="dashboard_kpi_confirmed_completed">Confirmed and completed events</string>
+    <string name="dashboard_kpi_this_month">This month</string>
+    <string name="dashboard_kpi_due">Due</string>
+    <string name="dashboard_kpi_total">Total</string>
+    <string name="dashboard_quick_new_event">New event</string>
+    <string name="dashboard_quick_new_client">New client</string>
+    <string name="dashboard_inventory_alerts">Inventory alerts</string>
+    <string name="dashboard_upcoming_events">Upcoming events</string>
+    <string name="dashboard_event_status">Event status</string>
+    <string name="dashboard_financial_comparison">Financial comparison</string>
+    <string name="dashboard_revenue_last_6_months">Revenue — last 6 months</string>
+    <string name="dashboard_chart_count_percentage">%1$d (%2$d%%)</string>
+    <string name="dashboard_this_month">This month</string>
+    <string name="dashboard_status_quoted">Quoted</string>
+    <string name="dashboard_status_confirmed">Confirmed</string>
+    <string name="dashboard_status_completed">Completed</string>
+    <string name="dashboard_status_cancelled">Cancelled</string>
+    <string name="dashboard_low_stock_current">Current stock: %1$s %2$s</string>
+    <string name="dashboard_greeting_with_name">Hello, %1$s</string>
+    <string name="dashboard_greeting_generic">Hello</string>
+    <string name="dashboard_greeting_date_pattern">EEEE, MMMM d</string>
+    <string name="dashboard_month_short_pattern">MMM</string>
+    <string name="dashboard_payment_save">Save payment</string>
+    <string name="dashboard_a11y_pending_event">%1$s: %2$s, date %3$s, reason %4$s</string>
+    <string name="dashboard_a11y_event_with_client">%1$s, %2$s, date %3$s, status %4$s</string>
+    <string name="dashboard_a11y_event">%1$s, date %2$s, status %3$s</string>
+    <string name="dashboard_a11y_inventory_alert">%1$s, %2$s %3$s</string>
+
+    <string name="dashboard_widget_top_clients_title">Top clients</string>
+    <string name="dashboard_widget_top_clients_empty">No client data yet</string>
+    <plurals name="dashboard_widget_top_clients_events">
+        <item quantity="one">%1$d event</item>
+        <item quantity="other">%1$d events</item>
+    </plurals>
+
+    <string name="dashboard_widget_product_demand_title">Product demand</string>
+    <string name="dashboard_widget_product_demand_empty">No product data yet</string>
+    <plurals name="dashboard_widget_product_demand_uses">
+        <item quantity="one">%1$d use</item>
+        <item quantity="other">%1$d uses</item>
+    </plurals>
+
+    <string name="dashboard_widget_forecast_title">Revenue forecast</string>
+    <string name="dashboard_widget_forecast_empty">No forecast available</string>
+    <plurals name="dashboard_widget_forecast_events">
+        <item quantity="one">%1$d event</item>
+        <item quantity="other">%1$d events</item>
+    </plurals>
+</resources>

--- a/android/feature/dashboard/src/main/res/values/strings.xml
+++ b/android/feature/dashboard/src/main/res/values/strings.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dashboard_title">Inicio</string>
+    <string name="dashboard_refresh">Actualizar</string>
+    <string name="dashboard_upgrade_banner">Potenciá tu negocio con el plan Pro: eventos ilimitados, inventario y más.</string>
+    <string name="dashboard_attention_title">Requieren atención</string>
+    <string name="dashboard_attention_title_with_count">Requieren atención (%1$d)</string>
+    <string name="dashboard_attention_confirmed_payment_title">Saldos próximos</string>
+    <string name="dashboard_attention_overdue_event_kind">Evento vencido</string>
+    <string name="dashboard_attention_quote_urgent_kind">Cotización urgente</string>
+    <string name="dashboard_attention_register_payment">Registrar pago</string>
+    <string name="dashboard_attention_register_payment_and_complete">Registrar pago y completar</string>
+    <string name="dashboard_attention_pay_and_complete">Pagar y completar</string>
+    <string name="dashboard_attention_complete_only">Solo completar</string>
+    <string name="dashboard_attention_complete">Completar</string>
+    <string name="dashboard_attention_view">Ver</string>
+    <string name="dashboard_attention_view_detail">Ver detalle</string>
+    <string name="dashboard_action_cancel">Cancelar</string>
+    <string name="dashboard_message_event_completed">Evento marcado como completado</string>
+    <string name="dashboard_message_event_cancelled">Evento cancelado</string>
+    <string name="dashboard_message_payment_registered">Pago registrado correctamente</string>
+    <string name="dashboard_message_payment_registered_and_completed">Pago registrado y evento completado</string>
+    <string name="dashboard_message_payment_complete_manual">Pago registrado. Marcá el evento como completado manualmente.</string>
+    <string name="dashboard_error_status_change_failed">No pudimos actualizar el estado del evento. Reintentá en un momento.</string>
+    <string name="dashboard_error_payment_failed">No pudimos registrar el pago. Reintentá en un momento.</string>
+    <string name="dashboard_error_payment_requirements">Monto y método de pago son requeridos</string>
+    <string name="dashboard_kpi_net_sales">Ventas netas</string>
+    <string name="dashboard_kpi_collected">Cobrado</string>
+    <string name="dashboard_kpi_vat_collected">IVA cobrado</string>
+    <string name="dashboard_kpi_vat_outstanding">IVA pendiente</string>
+    <string name="dashboard_kpi_events_this_month">Eventos del mes</string>
+    <string name="dashboard_kpi_low_stock">Stock bajo</string>
+    <string name="dashboard_kpi_clients">Clientes</string>
+    <string name="dashboard_kpi_quotes">Cotizaciones</string>
+    <string name="dashboard_kpi_confirmed_completed">Eventos confirmados y completados</string>
+    <string name="dashboard_kpi_this_month">Este mes</string>
+    <string name="dashboard_kpi_due">Por cobrar</string>
+    <string name="dashboard_kpi_total">Total</string>
+    <string name="dashboard_quick_new_event">Nuevo evento</string>
+    <string name="dashboard_quick_new_client">Nuevo cliente</string>
+    <string name="dashboard_inventory_alerts">Alertas de inventario</string>
+    <string name="dashboard_upcoming_events">Próximos eventos</string>
+    <string name="dashboard_event_status">Estado de eventos</string>
+    <string name="dashboard_financial_comparison">Comparativa financiera</string>
+    <string name="dashboard_revenue_last_6_months">Ingresos — últimos 6 meses</string>
+    <string name="dashboard_chart_count_percentage">%1$d (%2$d%%)</string>
+    <string name="dashboard_this_month">Este mes</string>
+    <string name="dashboard_status_quoted">Cotizado</string>
+    <string name="dashboard_status_confirmed">Confirmado</string>
+    <string name="dashboard_status_completed">Completado</string>
+    <string name="dashboard_status_cancelled">Cancelado</string>
+    <string name="dashboard_low_stock_current">Stock actual: %1$s %2$s</string>
+    <string name="dashboard_greeting_with_name">Hola, %1$s</string>
+    <string name="dashboard_greeting_generic">Hola</string>
+    <string name="dashboard_greeting_date_pattern">"EEEE d 'de' MMMM"</string>
+    <string name="dashboard_month_short_pattern">MMM</string>
+    <string name="dashboard_payment_save">Guardar pago</string>
+    <string name="dashboard_a11y_pending_event">%1$s: %2$s, fecha %3$s, motivo %4$s</string>
+    <string name="dashboard_a11y_event_with_client">%1$s, %2$s, fecha %3$s, estado %4$s</string>
+    <string name="dashboard_a11y_event">%1$s, fecha %2$s, estado %3$s</string>
+    <string name="dashboard_a11y_inventory_alert">%1$s, %2$s %3$s</string>
+
+    <string name="dashboard_widget_top_clients_title">Clientes principales</string>
+    <string name="dashboard_widget_top_clients_empty">Sin datos de clientes aún</string>
+    <plurals name="dashboard_widget_top_clients_events">
+        <item quantity="one">%1$d evento</item>
+        <item quantity="other">%1$d eventos</item>
+    </plurals>
+
+    <string name="dashboard_widget_product_demand_title">Demanda de productos</string>
+    <string name="dashboard_widget_product_demand_empty">Sin datos de productos aún</string>
+    <plurals name="dashboard_widget_product_demand_uses">
+        <item quantity="one">%1$d uso</item>
+        <item quantity="other">%1$d usos</item>
+    </plurals>
+
+    <string name="dashboard_widget_forecast_title">Proyección de ingresos</string>
+    <string name="dashboard_widget_forecast_empty">Sin proyecciones disponibles</string>
+    <plurals name="dashboard_widget_forecast_events">
+        <item quantity="one">%1$d evento</item>
+        <item quantity="other">%1$d eventos</item>
+    </plurals>
+</resources>

--- a/docs/PRD/02_FEATURES.md
+++ b/docs/PRD/02_FEATURES.md
@@ -496,7 +496,7 @@ Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente cu
 
 - **[iOS]**: `DashboardView`, `KPICardView`, `EventStatusChart`, `PendingEventsModalView` (modal bloqueante con CTAs por categoria), `PaymentEntrySheet` (sheet reusable para registrar pago)
 - **[Android]**: `DashboardScreen`, `PendingEventItem` (banner inline en LazyColumn con CTAs por categoria), `PaymentModal` (extraido a `core:designsystem` para reuso)
-- **[Web]**: `Dashboard`, `DashboardAttentionSection` (seccion inline con las 3 categorias y navegacion al detalle del evento). Las acciones rapidas inline (Registrar pago / Completar / Cancelar / Pagar y completar / Solo completar) estan **pendientes de re-implementacion** — la version inicial fue reverted por bugs financieros (ver tarea cross-platform "Bug 5: auto-complete sin verificar monto" para el contexto). Mientras tanto, las acciones se ejecutan desde el detalle del evento.
+- **[Web]**: `Dashboard`, `DashboardAttentionSection` (seccion inline con las 3 categorias y navegacion al detalle del evento). Las acciones inline de atención ya volvieron a estar activas (`Registrar pago` / `Completar` / `Cancelar` / `Pagar y completar` / `Solo completar`) con copy alineada al slice i18n de Dashboard (#94).
 
 **Endpoints usados por las acciones inline:**
 

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -20,7 +20,7 @@ status: active
 > [!info] 2026-04-29 — i18n parity planning reset (issue #202 + #203–#209)
 > La estrategia de multilanguage dejó de organizarse por plataforma y pasó a slices cross-platform con una copy matrix canónica. Objetivo: asegurar misma intención y terminología entre iOS, Android y Web, permitiendo variantes mobile más cortas sólo cuando el espacio lo exija.
 > - **Epic**: #202 `feat(cross-platform): complete product-wide i18n parity`
-> - **Slices activos**: #94 Dashboard, #95 Events list, #203 governance/matrix, #204 event detail + form, #205 auth + settings, #206 clients, #207 products + inventory, #208 public flows, #209 final sweep.
+> - **Slices**: #94 Dashboard ✅ cerrado, #95 Events list, #203 governance/matrix, #204 event detail + form, #205 auth + settings, #206 clients, #207 products + inventory, #208 public flows, #209 final sweep.
 > - **Documento fuente**: [[19_I18N_STRATEGY]] ahora define copy governance, canonical vs compact variants y checklist de review por slice.
 
 > [!success] 2026-04-29 — Sprint 7.E: Payment Submissions Phase 1 (issue #191, backend + web service ✅)
@@ -1946,3 +1946,8 @@ Si queremos parar las alertas temporal o definitivamente:
 - **Pausa temporal:** Dashboard → Monitoring → cada monitor → botón **Pause**
 - **Eliminar definitivo:** Monitoring → `⋮` → **Delete** (ids 802870461 y 802870486)
 - **Cerrar cuenta:** Settings → Account → Delete account (elimina también la status page 1067498)
+> [!success] 2026-04-29 — i18n slice #94 dashboard ✅
+> Paridad real de i18n cerrada para Dashboard en Web, iOS y Android.
+> - **Web**: `Dashboard.tsx` y widgets (`ForecastWidget`, `ProductDemandWidget`, `TopClientsWidget`) ya consumen `dashboard.json` ES/EN, incluyendo acciones inline de atención y labels accesibles.
+> - **iOS**: Dashboard principal, KPIs, alertas, modal de eventos pendientes, charts y widgets consumen catálogo localizado; además se removieron locales fijos para fechas y montos con `DashboardFormatting` + `FeatureL10n.locale`.
+> - **Android**: `DashboardScreen`, widgets y `DashboardViewModel` migrados a `stringResource` / resources ES+EN, con labels alineadas a la copy matrix.

--- a/docs/PRD/19_I18N_STRATEGY.md
+++ b/docs/PRD/19_I18N_STRATEGY.md
@@ -6,8 +6,8 @@
 ## Tracker de ejecución
 
 - **Epic**: #202 — `feat(cross-platform): complete product-wide i18n parity`
-- **Slices activos**:
-  - #94 — Dashboard
+- **Slices**:
+  - #94 — Dashboard ✅ implementado en web + iOS + Android; issue cerrado
   - #95 — Events list
   - #203 — Canonical copy matrix + governance
   - #204 — Event detail + event form

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/DashboardViewModel.swift
@@ -13,11 +13,11 @@ public enum DashboardAttentionEventKind: String, Sendable, Hashable {
     public var title: String {
         switch self {
         case .pendingPayment:
-            return "Pago pendiente"
+            return FeatureL10n.text("dashboard.attention.pending_payment_kind", "Pago pendiente")
         case .overdueEvent:
-            return "Evento vencido"
+            return FeatureL10n.text("dashboard.attention.overdue_event_kind", "Vencido")
         case .unconfirmedEvent:
-            return "Sin confirmar"
+            return FeatureL10n.text("dashboard.attention.unconfirmed_event_kind", "Sin confirmar")
         }
     }
 
@@ -146,9 +146,13 @@ public final class DashboardViewModel {
     public var vatCollectedThisMonth: Double { kpis?.vatCollectedThisMonth ?? 0 }
     public var vatOutstandingThisMonth: Double { kpis?.vatOutstandingThisMonth ?? 0 }
 
+    private static func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     /// Resolve a client name from the client map.
     public func clientName(for clientId: String) -> String {
-        clientMap[clientId]?.name ?? "Cliente"
+        clientMap[clientId]?.name ?? Self.tr("dashboard.event.no_client", "Cliente")
     }
 
     // MARK: - Data Loading
@@ -165,7 +169,7 @@ public final class DashboardViewModel {
         guard let startOfMonth = calendar.date(from: components),
               let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth)
         else {
-            errorMessage = "Error calculando rango de fechas"
+            errorMessage = Self.tr("dashboard.error.invalid_date_range", "Rango de fechas inválido")
             isLoading = false
             return
         }
@@ -304,9 +308,9 @@ public final class DashboardViewModel {
 
         if encounteredError {
             if clients.isEmpty && loadedAllEvents.isEmpty && products.isEmpty {
-                errorMessage = "No se pudo cargar el dashboard"
+                errorMessage = Self.tr("dashboard.error.load_failed", "Error al cargar dashboard")
             } else {
-                errorMessage = "Algunos datos no se pudieron cargar"
+                errorMessage = Self.tr("dashboard.error.partial_load", "Algunos datos no se pudieron cargar")
             }
         }
 
@@ -343,9 +347,9 @@ public final class DashboardViewModel {
             HapticsHelper.play(.error)
 
             if let apiError = error as? APIError {
-                errorMessage = apiError.errorDescription ?? "Error al cambiar el estado"
+                errorMessage = apiError.errorDescription ?? Self.tr("dashboard.error.status_change_failed", "No se pudo cambiar el estado")
             } else {
-                errorMessage = "Error al cambiar el estado"
+                errorMessage = Self.tr("dashboard.error.status_change_failed", "No se pudo cambiar el estado")
             }
         }
     }
@@ -446,7 +450,7 @@ public final class DashboardViewModel {
             return DashboardAttentionEvent(
                 event: event,
                 kind: kind,
-                clientName: clientMap[event.clientId]?.name ?? "Cliente",
+                clientName: clientMap[event.clientId]?.name ?? Self.tr("dashboard.event.no_client", "Cliente"),
                 totalPaid: totalPaid,
                 outstandingAmount: outstandingAmount,
                 daysFromToday: daysFromToday
@@ -545,10 +549,6 @@ public final class DashboardViewModel {
         keyFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         keyFormatter.dateFormat = "yyyy-MM"
 
-        let labelFormatter = DateFormatter()
-        labelFormatter.dateFormat = "MMM"
-        labelFormatter.locale = Locale(identifier: "es_MX")
-
         let byMonth: [String: DashboardRevenuePoint] = Dictionary(
             uniqueKeysWithValues: serverPoints.map { ($0.month, $0) }
         )
@@ -562,7 +562,7 @@ public final class DashboardViewModel {
             let key = keyFormatter.string(from: monthStart)
             let point = byMonth[key]
             return MonthlyRevenueTrendPoint(
-                month: labelFormatter.string(from: monthStart).capitalized,
+                month: DashboardFormatting.monthYear(from: key),
                 monthDate: monthStart,
                 revenue: point?.revenue ?? 0,
                 eventCount: point?.eventCount ?? 0
@@ -628,19 +628,5 @@ public final class DashboardViewModel {
         } catch {
             NSLog("[Dashboard] ⚠️ forecast failed: %@", String(describing: error))
         }
-    }
-}
-
-// MARK: - Currency Formatting
-
-public extension Double {
-    /// Format as Mexican Peso currency string.
-    var asMXN: String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "MXN"
-        formatter.currencySymbol = "$"
-        formatter.maximumFractionDigits = 0
-        return formatter.string(from: NSNumber(value: self)) ?? "$0"
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/PendingEventsViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/PendingEventsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import SolennixCore
 import SolennixNetwork
 
@@ -33,6 +34,10 @@ public struct PendingEventWithReason: Identifiable {
 @Observable
 public final class PendingEventsViewModel {
     let apiClient: APIClient
+
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
 
     public var pendingEvents: [PendingEventWithReason] = []
     public var isLoading: Bool = true
@@ -88,7 +93,7 @@ public final class PendingEventsViewModel {
                         PendingEventWithReason(
                             event: event,
                             reason: .paymentDue,
-                            reasonLabel: "Cobro por cerrar",
+                            reasonLabel: tr("dashboard.attention.confirmed_payment_title", "Pago pendiente"),
                             pendingAmount: pendingAmount
                         )
                     )
@@ -101,7 +106,7 @@ public final class PendingEventsViewModel {
                         PendingEventWithReason(
                             event: event,
                             reason: .overdueEvent,
-                            reasonLabel: "Evento vencido",
+                            reasonLabel: tr("dashboard.attention.overdue_event_kind", "Vencido"),
                             pendingAmount: pendingAmount
                         )
                     )
@@ -114,7 +119,7 @@ public final class PendingEventsViewModel {
                         PendingEventWithReason(
                             event: event,
                             reason: .quoteUrgent,
-                            reasonLabel: "Cotización urgente",
+                            reasonLabel: tr("dashboard.attention.quote_urgent_kind", "Cotización urgente"),
                             pendingAmount: pendingAmount
                         )
                     )
@@ -143,10 +148,10 @@ public final class PendingEventsViewModel {
                 isPresented = false
             }
             transientMessage = newStatus == .completed
-                ? "Evento marcado como completado"
-                : "Evento cancelado"
+                ? tr("dashboard.messages.event_completed", "Evento completado")
+                : tr("dashboard.messages.event_cancelled", "Evento cancelado")
         } catch {
-            transientMessage = "Error al actualizar el estado"
+            transientMessage = tr("dashboard.error.status_change_failed", "No se pudo cambiar el estado")
             print("Error updating event status: \(error)")
         }
         updatingEventId = nil
@@ -181,7 +186,7 @@ public final class PendingEventsViewModel {
     public func registerPayment() async {
         guard let pendingEvent = paymentSheetEvent else { return }
         guard let amount = Double(paymentAmount.replacingOccurrences(of: ",", with: ".")), amount > 0 else {
-            transientMessage = "Monto inválido"
+            transientMessage = tr("dashboard.error.invalid_amount", "Monto inválido")
             return
         }
 
@@ -224,7 +229,7 @@ public final class PendingEventsViewModel {
                 userInfo: [
                     "payment_id": payment.id,
                     "event_id": pendingEvent.event.id,
-                    "client_name": "Cliente",
+                    "client_name": tr("dashboard.event.no_client", "Cliente"),
                     "amount": payment.amount
                 ]
             )
@@ -234,12 +239,12 @@ public final class PendingEventsViewModel {
                     let statusBody = ["status": EventStatus.completed.rawValue]
                     let _: Event = try await apiClient.put(Endpoint.event(pendingEvent.event.id), body: statusBody)
                     pendingEvents.removeAll { $0.event.id == pendingEvent.event.id }
-                    transientMessage = "Pago registrado y evento completado"
+                    transientMessage = tr("dashboard.messages.payment_registered_and_completed", "Pago registrado y evento completado")
                 } catch {
-                    transientMessage = "Pago registrado. Marcá el evento como completado manualmente."
+                    transientMessage = tr("dashboard.messages.payment_complete_manual", "Pago registrado. Completa el evento manualmente")
                 }
             } else {
-                transientMessage = "Pago registrado correctamente"
+                transientMessage = tr("dashboard.messages.payment_registered", "Pago registrado")
                 // Reload to reflect the new balance: the affected pending
                 // event may now be fully paid (and should drop off the list)
                 // or simply show a smaller pendingAmount on the next open.
@@ -252,7 +257,7 @@ public final class PendingEventsViewModel {
             dismissPaymentSheet()
         } catch {
             HapticsHelper.play(.error)
-            transientMessage = "Error al registrar el pago"
+            transientMessage = tr("dashboard.error.payment_failed", "No se pudo registrar el pago")
         }
 
         isSavingPayment = false

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/AttentionEventsCard.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/AttentionEventsCard.swift
@@ -6,6 +6,10 @@ struct AttentionEventsCard: View {
 
     let events: [DashboardAttentionEvent]
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     var body: some View {
         if !events.isEmpty {
             VStack(alignment: .leading, spacing: Spacing.md) {
@@ -39,7 +43,7 @@ struct AttentionEventsCard: View {
                     .foregroundStyle(SolennixColors.warning)
             }
 
-            Text("Requieren atencion")
+            Text(tr("dashboard.attention.title", "Requieren atención"))
                 .font(.headline)
                 .foregroundStyle(SolennixColors.text)
 
@@ -75,7 +79,7 @@ struct AttentionEventsCard: View {
                         .foregroundStyle(SolennixColors.textTertiary)
 
                     if shouldShowPendingAmount(for: attentionEvent) {
-                        Text(attentionEvent.outstandingAmount.asMXN)
+                        Text(DashboardFormatting.currencyMXN(attentionEvent.outstandingAmount))
                             .font(.caption)
                             .fontWeight(.semibold)
                             .foregroundStyle(SolennixColors.warning)
@@ -101,18 +105,28 @@ struct AttentionEventsCard: View {
         // chip, label, icon.
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel(for: attentionEvent))
-        .accessibilityHint("Abrir detalle del evento")
+        .accessibilityHint(tr("dashboard.attention.open_detail_hint", "Abrir detalle del evento"))
     }
 
     private func accessibilityLabel(for attentionEvent: DashboardAttentionEvent) -> String {
         var parts = [
             attentionEvent.kind.title,
             attentionEvent.event.serviceType,
-            "de \(attentionEvent.clientName)",
+            String(
+                format: tr("dashboard.attention.from_client", "de %@"),
+                locale: FeatureL10n.locale,
+                attentionEvent.clientName
+            ),
             compactDate(for: attentionEvent.event.eventDate),
         ]
         if shouldShowPendingAmount(for: attentionEvent) {
-            parts.append("restan \(attentionEvent.outstandingAmount.asMXN)")
+            parts.append(
+                String(
+                    format: tr("dashboard.attention.remaining_amount", "restan %@"),
+                    locale: FeatureL10n.locale,
+                    DashboardFormatting.currencyMXN(attentionEvent.outstandingAmount)
+                )
+            )
         }
         return parts.joined(separator: ", ")
     }
@@ -133,11 +147,7 @@ struct AttentionEventsCard: View {
     }
 
     private func compactDate(for dateString: String) -> String {
-        guard let date = Self.inputDateFormatter.date(from: String(dateString.prefix(10))) else {
-            return String(dateString.prefix(10))
-        }
-
-        return Self.outputDateFormatter.string(from: date)
+        DashboardFormatting.compactDate(from: dateString)
     }
 
     private func reasonForegroundColor(for kind: DashboardAttentionEventKind) -> Color {
@@ -161,23 +171,6 @@ struct AttentionEventsCard: View {
             return SolennixColors.primaryLight
         }
     }
-
-    private static let inputDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
-    }()
-
-    private static let outputDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = Locale(identifier: "es_MX")
-        formatter.dateFormat = "d MMM"
-        return formatter
-    }()
 }
 
 #Preview("Attention Events Card") {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/DashboardFormatting.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/DashboardFormatting.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SolennixCore
+
+enum DashboardFormatting {
+    private static let posixMonthFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM"
+        return formatter
+    }()
+
+    private static func currencyFormatter(locale: Locale) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "MXN"
+        formatter.locale = locale
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }
+
+    static func currencyMXN(_ amount: Double, locale: Locale = FeatureL10n.locale) -> String {
+        currencyFormatter(locale: locale).string(from: NSNumber(value: amount))
+            ?? amount.formatted(.currency(code: "MXN").locale(locale).precision(.fractionLength(0)))
+    }
+
+    static func compactCurrencyMXN(_ amount: Double, locale: Locale = FeatureL10n.locale) -> String {
+        let symbol = currencyFormatter(locale: locale).currencySymbol ?? "$"
+        let compactNumber = amount.formatted(
+            .number
+                .locale(locale)
+                .notation(.compactName)
+                .precision(.fractionLength(0))
+        )
+        return "\(symbol)\(compactNumber)"
+    }
+
+    static func greetingDate(_ date: Date = Date(), locale: Locale = FeatureL10n.locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("EEEE d MMMM")
+        let value = formatter.string(from: date)
+        return value.prefix(1).uppercased() + value.dropFirst()
+    }
+
+    static func monthDayComponents(from serverDay: String, locale: Locale = FeatureL10n.locale) -> (month: String, day: String) {
+        guard let date = Date.fromServerDay(serverDay) else {
+            return ("---", "--")
+        }
+
+        let monthFormatter = DateFormatter()
+        monthFormatter.locale = locale
+        monthFormatter.setLocalizedDateFormatFromTemplate("MMM")
+
+        let dayFormatter = DateFormatter()
+        dayFormatter.locale = locale
+        dayFormatter.setLocalizedDateFormatFromTemplate("d")
+
+        return (
+            monthFormatter.string(from: date).uppercased(),
+            dayFormatter.string(from: date)
+        )
+    }
+
+    static func compactDate(from serverDay: String, locale: Locale = FeatureL10n.locale) -> String {
+        guard let date = Date.fromServerDay(serverDay) else {
+            return String(serverDay.prefix(10))
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("dMMM")
+        return formatter.string(from: date)
+    }
+
+    static func monthYear(from yearMonth: String, locale: Locale = FeatureL10n.locale) -> String {
+        guard let date = posixMonthFormatter.date(from: yearMonth) else {
+            return yearMonth
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("MMM yyyy")
+        return formatter.string(from: date).capitalized(with: locale)
+    }
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/DashboardView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/DashboardView.swift
@@ -19,6 +19,10 @@ public struct DashboardView: View {
 
     private var isIPad: Bool { sizeClass == .regular }
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     public init() {}
 
     public var body: some View {
@@ -103,26 +107,26 @@ public struct DashboardView: View {
                 Spacer(minLength: Spacing.xxl)
             }
         }
-        .navigationTitle("Inicio")
+        .navigationTitle(tr("dashboard.title", "Inicio"))
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     NavigationLink(value: Route.eventForm()) {
-                        Label("Nuevo Evento", systemImage: "calendar.badge.plus")
+                        Label(tr("dashboard.quick_new_event", "Nuevo evento"), systemImage: "calendar.badge.plus")
                     }
                     .disabled(!planLimitsManager.canCreateEvent)
 
                     Button {
                         showQuickQuote = true
                     } label: {
-                        Label("Cotización Rápida", systemImage: "doc.text.magnifyingglass")
+                        Label(tr("dashboard.quick_quote", "Cotización rápida"), systemImage: "doc.text.magnifyingglass")
                     }
                 } label: {
                     Image(systemName: "plus")
                         .font(.body)
                         .foregroundStyle(SolennixColors.primary)
-                        .accessibilityLabel("Crear evento o cotización")
+                        .accessibilityLabel(tr("dashboard.create_event_or_quote", "Crear evento o cotización"))
                 }
             }
         }
@@ -167,7 +171,7 @@ public struct DashboardView: View {
         if !planLimitsManager.canCreateEvent {
             UpgradeBannerView(
                 type: .limitReached,
-                resource: "Eventos",
+                resource: tr("dashboard.plan_limit_resource", "Eventos"),
                 currentUsage: planLimitsManager.eventsThisMonth,
                 limit: PlanLimitsManager.freePlanEventLimit
             ) {
@@ -206,14 +210,17 @@ public struct DashboardView: View {
     private var greetingText: String {
         if case .authenticated(let user) = authManager.authState {
             let firstName = user.name.components(separatedBy: " ").first ?? user.name
-            return "Hola, \(firstName)"
+            return String(
+                format: tr("dashboard.welcome", "Hola, %@"),
+                locale: FeatureL10n.locale,
+                firstName
+            )
         }
-        return "Hola"
+        return tr("dashboard.greeting.generic", "Hola")
     }
 
     private var currentDateString: String {
-        let str = Date().formatted(style: "EEEE d 'de' MMMM")
-        return str.prefix(1).uppercased() + str.dropFirst()
+        DashboardFormatting.greetingDate()
     }
 
     // MARK: - Quick Actions
@@ -225,7 +232,7 @@ public struct DashboardView: View {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: Spacing.md)], spacing: Spacing.md) {
                     quickActionItem(
                         icon: "plus.circle.fill",
-                        label: "Nuevo Evento",
+                        label: tr("dashboard.quick_new_event", "Nuevo evento"),
                         color: planLimitsManager.canCreateEvent ? SolennixColors.primary : SolennixColors.textTertiary,
                         enabled: planLimitsManager.canCreateEvent,
                         destination: Route.eventForm()
@@ -233,7 +240,7 @@ public struct DashboardView: View {
 
                     quickActionItem(
                         icon: "person.badge.plus",
-                        label: "Nuevo Cliente",
+                        label: tr("dashboard.quick_new_client", "Nuevo cliente"),
                         color: planLimitsManager.canCreateClient ? SolennixColors.statusConfirmed : SolennixColors.textTertiary,
                         enabled: planLimitsManager.canCreateClient,
                         destination: Route.clientForm()
@@ -244,7 +251,7 @@ public struct DashboardView: View {
                 HStack(spacing: Spacing.md) {
                     quickActionItem(
                         icon: "plus.circle.fill",
-                        label: "Nuevo Evento",
+                        label: tr("dashboard.quick_new_event", "Nuevo evento"),
                         color: planLimitsManager.canCreateEvent ? SolennixColors.primary : SolennixColors.textTertiary,
                         enabled: planLimitsManager.canCreateEvent,
                         destination: Route.eventForm()
@@ -252,7 +259,7 @@ public struct DashboardView: View {
 
                     quickActionItem(
                         icon: "person.badge.plus",
-                        label: "Nuevo Cliente",
+                        label: tr("dashboard.quick_new_client", "Nuevo cliente"),
                         color: planLimitsManager.canCreateClient ? SolennixColors.statusConfirmed : SolennixColors.textTertiary,
                         enabled: planLimitsManager.canCreateClient,
                         destination: Route.clientForm()
@@ -323,8 +330,8 @@ public struct DashboardView: View {
     @ViewBuilder
     private func kpiCardItems(flexible: Bool) -> some View {
         KPICardView(
-            title: "Ventas Netas",
-            value: viewModel?.netSalesThisMonth.asMXN ?? "$0",
+            title: tr("dashboard.kpi.net_sales", "Ventas netas"),
+            value: DashboardFormatting.currencyMXN(viewModel?.netSalesThisMonth ?? 0),
             icon: "dollarsign.circle",
             iconColor: SolennixColors.kpiGreen,
             iconBgColor: SolennixColors.kpiGreenBg,
@@ -332,8 +339,8 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "Cobrado",
-            value: viewModel?.cashCollectedThisMonth.asMXN ?? "$0",
+            title: tr("dashboard.kpi.collected", "Cobrado"),
+            value: DashboardFormatting.currencyMXN(viewModel?.cashCollectedThisMonth ?? 0),
             icon: "banknote",
             iconColor: SolennixColors.kpiOrange,
             iconBgColor: SolennixColors.kpiOrangeBg,
@@ -341,8 +348,8 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "IVA Cobrado",
-            value: viewModel?.vatCollectedThisMonth.asMXN ?? "$0",
+            title: tr("dashboard.kpi.vat_collected", "IVA cobrado"),
+            value: DashboardFormatting.currencyMXN(viewModel?.vatCollectedThisMonth ?? 0),
             icon: "percent",
             iconColor: SolennixColors.kpiBlue,
             iconBgColor: SolennixColors.kpiBlueBg,
@@ -350,8 +357,8 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "IVA Pendiente",
-            value: viewModel?.vatOutstandingThisMonth.asMXN ?? "$0",
+            title: tr("dashboard.kpi.vat_outstanding", "IVA pendiente"),
+            value: DashboardFormatting.currencyMXN(viewModel?.vatOutstandingThisMonth ?? 0),
             icon: "exclamationmark.circle",
             iconColor: SolennixColors.kpiBlue,
             iconBgColor: SolennixColors.kpiBlueBg,
@@ -359,7 +366,7 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "Eventos del Mes",
+            title: tr("dashboard.kpi.events_this_month", "Eventos del mes"),
             value: "\(viewModel?.eventsThisMonthCount ?? 0)",
             icon: "calendar",
             iconColor: SolennixColors.kpiOrange,
@@ -368,7 +375,7 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "Stock Bajo",
+            title: tr("dashboard.kpi.low_stock", "Stock bajo"),
             value: "\(viewModel?.lowStockCount ?? 0)",
             icon: "archivebox",
             iconColor: (viewModel?.lowStockCount ?? 0) > 0
@@ -381,7 +388,7 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "Clientes",
+            title: tr("dashboard.kpi.clients_total", "Clientes"),
             value: "\(viewModel?.totalClients ?? 0)",
             icon: "person.2",
             iconColor: SolennixColors.kpiBlue,
@@ -390,7 +397,7 @@ public struct DashboardView: View {
         )
 
         KPICardView(
-            title: "Cotizaciones",
+            title: tr("dashboard.kpi.quotes", "Cotizaciones"),
             value: "\(viewModel?.pendingQuotes ?? 0)",
             icon: "doc.text.magnifyingglass",
             iconColor: SolennixColors.kpiOrange,
@@ -444,7 +451,7 @@ public struct DashboardView: View {
             HStack {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(SolennixColors.warning)
-                Text("Alertas de Stock")
+                Text(tr("dashboard.inventory_alerts", "Alertas de inventario"))
                     .font(.headline)
                     .foregroundStyle(SolennixColors.text)
             }
@@ -479,7 +486,7 @@ public struct DashboardView: View {
                     .fontWeight(.medium)
                     .foregroundStyle(SolennixColors.text)
 
-                Text("Stock: \(Int(item.currentStock))/\(Int(item.minimumStock)) \(item.unit)")
+                Text("\(Int(item.currentStock))/\(Int(item.minimumStock)) \(item.unit)")
                     .font(.caption)
                     .foregroundStyle(SolennixColors.textSecondary)
             }
@@ -500,7 +507,7 @@ public struct DashboardView: View {
 
     private var upcomingEventsSection: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            Text("Proximos Eventos")
+            Text(tr("dashboard.upcoming_events", "Próximos eventos"))
                 .font(.headline)
                 .foregroundStyle(SolennixColors.text)
                 .padding(.horizontal, isIPad ? 0 : Spacing.md)
@@ -528,7 +535,7 @@ public struct DashboardView: View {
 
                     // Event info
                     VStack(alignment: .leading, spacing: Spacing.xs) {
-                        Text(viewModel?.clientName(for: event.clientId) ?? "Cliente")
+                        Text(viewModel?.clientName(for: event.clientId) ?? tr("dashboard.event.no_client", "Cliente"))
                             .font(.subheadline)
                             .fontWeight(.semibold)
                             .foregroundStyle(SolennixColors.text)
@@ -538,7 +545,13 @@ public struct DashboardView: View {
                                 .font(.caption)
                                 .foregroundStyle(SolennixColors.textSecondary)
 
-                            Text("\(event.numPeople) personas")
+                            Text(
+                                String(
+                                    format: tr("dashboard.event.people", "%lld personas"),
+                                    locale: FeatureL10n.locale,
+                                    event.numPeople
+                                )
+                            )
                                 .font(.caption)
                                 .foregroundStyle(SolennixColors.textTertiary)
                         }
@@ -562,10 +575,10 @@ public struct DashboardView: View {
         let isUpdating = viewModel?.updatingEventId == event.id
 
         return Menu {
-            upcomingEventStatusButton(title: "Cotizado", status: .quoted, event: event)
-            upcomingEventStatusButton(title: "Confirmado", status: .confirmed, event: event)
-            upcomingEventStatusButton(title: "Completado", status: .completed, event: event)
-            upcomingEventStatusButton(title: "Cancelado", status: .cancelled, event: event, role: .destructive)
+            upcomingEventStatusButton(title: tr("dashboard.status.quoted", "Cotizado"), status: .quoted, event: event)
+            upcomingEventStatusButton(title: tr("dashboard.status.confirmed", "Confirmado"), status: .confirmed, event: event)
+            upcomingEventStatusButton(title: tr("dashboard.status.completed", "Completado"), status: .completed, event: event)
+            upcomingEventStatusButton(title: tr("dashboard.status.cancelled", "Cancelado"), status: .cancelled, event: event, role: .destructive)
         } label: {
             HStack(spacing: Spacing.xs) {
                 if isUpdating {
@@ -608,8 +621,8 @@ public struct DashboardView: View {
             }
         }
         .accessibilityLabel(event.status == status
-            ? "\(title), estado actual"
-            : "Cambiar a \(title.lowercased())")
+            ? String(format: tr("dashboard.status.current", "%@, estado actual"), locale: FeatureL10n.locale, title)
+            : String(format: tr("dashboard.status.change_to", "Cambiar a %@"), locale: FeatureL10n.locale, title.lowercased()))
     }
 
     private func dateBox(for dateString: String) -> some View {
@@ -632,10 +645,7 @@ public struct DashboardView: View {
     }
 
     private func parseDateComponents(_ dateString: String) -> (month: String, day: String) {
-        guard let date = Date.fromServerDay(dateString) else {
-            return ("---", "--")
-        }
-        return (date.formatted(style: "MMM"), date.formatted(style: "d"))
+        DashboardFormatting.monthDayComponents(from: dateString)
     }
 
     private var emptyEventsState: some View {
@@ -644,7 +654,7 @@ public struct DashboardView: View {
                 .font(.system(size: 40))
                 .foregroundStyle(SolennixColors.textTertiary)
 
-            Text("Sin eventos proximos")
+            Text(tr("dashboard.upcoming.empty", "Sin eventos próximos"))
                 .font(.subheadline)
                 .foregroundStyle(SolennixColors.textSecondary)
         }
@@ -666,14 +676,14 @@ public struct DashboardView: View {
             VStack(alignment: .leading, spacing: Spacing.md) {
                 // No leading icon — Android and Web use a plain title,
                 // keeping the three dashboards visually consistent.
-                Text("Ingresos — Últimos 6 meses")
+                Text(tr("dashboard.revenue_last_6_months", "Ingresos — últimos 6 meses"))
                     .font(.headline)
                     .foregroundStyle(SolennixColors.text)
 
                 Chart(vm.monthlyRevenueTrend) { point in
                     BarMark(
-                        x: .value("Mes", point.month),
-                        y: .value("Ingresos", point.revenue)
+                        x: .value(tr("dashboard.chart.month", "Mes"), point.month),
+                        y: .value(tr("dashboard.chart.revenue", "Ingresos"), point.revenue)
                     )
                     .foregroundStyle(SolennixGradient.premium)
                     .cornerRadius(6)
@@ -682,7 +692,7 @@ public struct DashboardView: View {
                     AxisMarks(position: .leading) { value in
                         AxisValueLabel {
                             if let d = value.as(Double.self) {
-                                Text(d == 0 ? "$0" : "\(Int(d / 1000))k")
+                                Text(DashboardFormatting.compactCurrencyMXN(d))
                                     .font(.caption2)
                                     .foregroundStyle(SolennixColors.textTertiary)
                             }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/EventStatusChart.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/EventStatusChart.swift
@@ -17,6 +17,10 @@ public struct EventStatusChart: View {
         statusCounts.values.reduce(0, +)
     }
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     /// Ordered statuses for consistent display.
     private var orderedStatuses: [EventStatus] {
         [.quoted, .confirmed, .completed, .cancelled].filter { statusCounts[$0, default: 0] > 0 }
@@ -24,7 +28,7 @@ public struct EventStatusChart: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            Text("Estado de Eventos")
+            Text(tr("dashboard.event_status", "Estado de eventos"))
                 .font(.subheadline)
                 .fontWeight(.semibold)
                 .foregroundStyle(SolennixColors.text)
@@ -73,7 +77,7 @@ public struct EventStatusChart: View {
         // the user hears "Estado de Eventos: 3 cotizados, 5 confirmados, 2
         // completados, 1 cancelado" instead of ~12 unlabeled pieces.
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Estado de eventos del mes")
+        .accessibilityLabel(tr("dashboard.event_status_accessibility", "Estado de eventos del mes"))
         .accessibilityValue(accessibilitySummary)
     }
 
@@ -96,10 +100,10 @@ public struct EventStatusChart: View {
 
     private func labelForStatus(_ status: EventStatus) -> String {
         switch status {
-        case .quoted:    return "Cotizado"
-        case .confirmed: return "Confirmado"
-        case .completed: return "Completado"
-        case .cancelled: return "Cancelado"
+        case .quoted:    return tr("dashboard.status.quoted", "Cotizado")
+        case .confirmed: return tr("dashboard.status.confirmed", "Confirmado")
+        case .completed: return tr("dashboard.status.completed", "Completado")
+        case .cancelled: return tr("dashboard.status.cancelled", "Cancelado")
         }
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/FinancialComparisonChart.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/FinancialComparisonChart.swift
@@ -20,18 +20,22 @@ public struct FinancialComparisonChart: View {
         max(netSales, cashCollected, vatOutstanding, 1)
     }
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     public var body: some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             // Header
             HStack {
-                Text("Comparativa Financiera")
+                Text(tr("dashboard.financial_comparison", "Comparativa financiera"))
                     .font(.subheadline)
                     .fontWeight(.semibold)
                     .foregroundStyle(SolennixColors.text)
 
                 Spacer()
 
-                Text("Este mes")
+                Text(tr("dashboard.this_month", "Este mes"))
                     .font(.caption2)
                     .foregroundStyle(SolennixColors.primary)
                     .padding(.horizontal, Spacing.sm)
@@ -44,21 +48,21 @@ public struct FinancialComparisonChart: View {
             GeometryReader { geometry in
                 VStack(alignment: .leading, spacing: Spacing.sm) {
                     barRow(
-                        label: "Ventas Netas",
+                        label: tr("dashboard.kpi.net_sales", "Ventas netas"),
                         value: netSales,
                         color: SolennixColors.kpiGreen,
                         maxWidth: geometry.size.width
                     )
 
                     barRow(
-                        label: "Cobrado Real",
+                        label: tr("dashboard.kpi.collected", "Cobrado"),
                         value: cashCollected,
                         color: SolennixColors.primary,
                         maxWidth: geometry.size.width
                     )
 
                     barRow(
-                        label: "IVA por Cobrar",
+                        label: tr("dashboard.kpi.vat_outstanding", "IVA pendiente"),
                         value: vatOutstanding,
                         color: SolennixColors.error,
                         maxWidth: geometry.size.width
@@ -84,7 +88,7 @@ public struct FinancialComparisonChart: View {
 
                 Spacer()
 
-                Text(value.asMXN)
+                Text(DashboardFormatting.currencyMXN(value))
                     .font(.caption)
                     .fontWeight(.semibold)
                     .foregroundStyle(SolennixColors.text)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/ForecastWidgetView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/ForecastWidgetView.swift
@@ -5,10 +5,14 @@ struct ForecastWidgetView: View {
     let forecast: [ForecastDataPoint]
     let isLoading: Bool
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Label("Proyección de Ingresos", systemImage: "chart.line.uptrend.xyaxis")
+                Label(tr("dashboard.widgets.forecast.title", "Pronóstico"), systemImage: "chart.line.uptrend.xyaxis")
                     .font(.subheadline)
                     .fontWeight(.semibold)
                 Spacer()
@@ -23,7 +27,7 @@ struct ForecastWidgetView: View {
                 }
                 .padding(.vertical, 8)
             } else if forecast.isEmpty {
-                Text("Sin proyecciones disponibles")
+                Text(tr("dashboard.widgets.forecast.empty", "Sin pronóstico disponible"))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -32,10 +36,10 @@ struct ForecastWidgetView: View {
                 // Summary grid
                 HStack(spacing: 12) {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Ingresos Proyectados")
+                        Text(tr("dashboard.widgets.forecast.projected_revenue", "Ingresos proyectados"))
                             .font(.caption)
                             .foregroundColor(.secondary)
-                        Text(formatMXN(forecast.reduce(0) { $0 + $1.confirmedRevenue }))
+                        Text(DashboardFormatting.currencyMXN(forecast.reduce(0) { $0 + $1.confirmedRevenue }))
                             .font(.headline)
                             .fontWeight(.semibold)
                     }
@@ -45,7 +49,7 @@ struct ForecastWidgetView: View {
                     .cornerRadius(8)
 
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Confirmados")
+                        Text(tr("dashboard.widgets.forecast.confirmed_events", "Eventos confirmados"))
                             .font(.caption)
                             .foregroundColor(.secondary)
                         Text("\(forecast.reduce(0) { $0 + $1.confirmedEventCount })")
@@ -62,16 +66,24 @@ struct ForecastWidgetView: View {
                     ForEach(forecast.prefix(6), id: \.month) { point in
                         VStack(alignment: .leading, spacing: 4) {
                             HStack {
-                                Text(formatMonth(point.month))
+                                Text(DashboardFormatting.monthYear(from: point.month))
                                     .font(.subheadline)
                                     .fontWeight(.medium)
                                 Spacer()
-                                Text(formatMXN(point.confirmedRevenue))
+                                Text(DashboardFormatting.currencyMXN(point.confirmedRevenue))
                                     .font(.subheadline)
                                     .fontWeight(.semibold)
                             }
                             HStack {
-                                Text("\(point.confirmedEventCount) evento\(point.confirmedEventCount == 1 ? "" : "s")")
+                                Text(String.localizedStringWithFormat(
+                                    tr(
+                                        point.confirmedEventCount == 1
+                                            ? "dashboard.widgets.forecast.events_one"
+                                            : "dashboard.widgets.forecast.events_other",
+                                        point.confirmedEventCount == 1 ? "%lld evento" : "%lld eventos"
+                                    ),
+                                    point.confirmedEventCount
+                                ))
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                 Spacer()
@@ -92,29 +104,6 @@ struct ForecastWidgetView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(.systemGray5), lineWidth: 1)
         )
-    }
-
-    private func formatMXN(_ amount: Double) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "MXN"
-        formatter.currencySymbol = "$"
-        formatter.maximumFractionDigits = 0
-        return formatter.string(from: NSNumber(value: amount)) ?? "$0"
-    }
-
-    private func formatMonth(_ monthStr: String) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM"
-        formatter.locale = Locale(identifier: "es_MX")
-        
-        if let date = formatter.date(from: monthStr) {
-            let displayFormatter = DateFormatter()
-            displayFormatter.dateFormat = "MMM yyyy"
-            displayFormatter.locale = Locale(identifier: "es_MX")
-            return displayFormatter.string(from: date).capitalized
-        }
-        return monthStr
     }
 }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/PendingEventsModalView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/PendingEventsModalView.swift
@@ -6,6 +6,10 @@ import SolennixNetwork
 public struct PendingEventsModalView: View {
     @State private var viewModel: PendingEventsViewModel
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     public init(apiClient: APIClient) {
         _viewModel = State(initialValue: PendingEventsViewModel(apiClient: apiClient))
     }
@@ -37,7 +41,7 @@ public struct PendingEventsModalView: View {
                 set: { if !$0 { viewModel.consumeTransientMessage() } }
             )
         ) {
-            Button("OK", role: .cancel) { viewModel.consumeTransientMessage() }
+            Button(tr("dashboard.action.ok", "OK"), role: .cancel) { viewModel.consumeTransientMessage() }
         }
     }
 
@@ -58,12 +62,18 @@ public struct PendingEventsModalView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Eventos Pendientes de Cierre")
+                    Text(tr("dashboard.pending_modal.title", "Eventos pendientes de cierre"))
                         .font(.title3)
                         .fontWeight(.bold)
                         .foregroundStyle(SolennixColors.text)
 
-                    Text("Tienes \(viewModel.pendingEvents.count) evento(s) que requieren tu atencion.")
+                    Text(
+                        String(
+                            format: tr("dashboard.pending_modal.description", "Tienes %@ evento(s) que requieren tu atención."),
+                            locale: FeatureL10n.locale,
+                            String(viewModel.pendingEvents.count)
+                        )
+                    )
                         .font(.caption)
                         .foregroundStyle(SolennixColors.textSecondary)
                 }
@@ -103,7 +113,7 @@ public struct PendingEventsModalView: View {
                     viewModel.isPresented = false
                 }
             } label: {
-                Text("Cerrar por ahora")
+                Text(tr("dashboard.pending_modal.close_for_now", "Cerrar por ahora"))
                     .font(.body)
                     .fontWeight(.medium)
                     .foregroundStyle(SolennixColors.textSecondary)
@@ -160,7 +170,7 @@ public struct PendingEventsModalView: View {
         case .paymentDue:
             HStack(spacing: Spacing.sm) {
                 primaryButton(
-                    title: "Registrar pago",
+                    title: tr("dashboard.attention.register_payment", "Registrar pago"),
                     icon: "dollarsign.circle",
                     isLoading: isUpdating,
                     disabled: disabled
@@ -173,7 +183,7 @@ public struct PendingEventsModalView: View {
             VStack(spacing: Spacing.sm) {
                 if pendingEvent.hasPendingPayment {
                     primaryButton(
-                        title: "Pagar y completar",
+                        title: tr("dashboard.attention.pay_and_complete", "Pagar y completar"),
                         icon: "dollarsign.circle",
                         isLoading: isUpdating,
                         disabled: disabled
@@ -191,7 +201,7 @@ public struct PendingEventsModalView: View {
                                 await viewModel.updateEventStatus(eventId: pendingEvent.event.id, newStatus: .completed)
                             }
                         } label: {
-                            Text("Solo completar")
+                            Text(tr("dashboard.attention.complete_only", "Solo completar"))
                                 .font(.caption)
                                 .fontWeight(.semibold)
                                 .foregroundStyle(SolennixColors.textSecondary)
@@ -213,7 +223,7 @@ public struct PendingEventsModalView: View {
                                     ProgressView().controlSize(.small).tint(.white)
                                 } else {
                                     Image(systemName: "checkmark.circle")
-                                    Text("Completar")
+                                    Text(tr("dashboard.attention.complete", "Completar"))
                                 }
                             }
                             .font(.caption)
@@ -238,7 +248,7 @@ public struct PendingEventsModalView: View {
         case .quoteUrgent:
             HStack {
                 Spacer()
-                Text("Pendiente de confirmar")
+                Text(tr("dashboard.attention.unconfirmed_event_kind", "Sin confirmar"))
                     .font(.caption)
                     .foregroundStyle(SolennixColors.textSecondary)
                 Spacer()
@@ -279,7 +289,7 @@ public struct PendingEventsModalView: View {
         Button(action: action) {
             HStack(spacing: 4) {
                 Image(systemName: "xmark.circle")
-                Text("Cancelar")
+                Text(tr("dashboard.action.cancel", "Cancelar"))
             }
             .font(.caption)
             .fontWeight(.bold)
@@ -300,11 +310,11 @@ public struct PendingEventsModalView: View {
 
     private func paymentSheet(for pendingEvent: PendingEventWithReason) -> some View {
         let confirmLabel = pendingEvent.reason == .overdueEvent && pendingEvent.hasPendingPayment
-            ? "Pagar y completar"
-            : "Guardar Pago"
+            ? tr("dashboard.attention.pay_and_complete", "Pagar y completar")
+            : tr("dashboard.payment.save_payment", "Guardar pago")
         let title = pendingEvent.reason == .overdueEvent && pendingEvent.hasPendingPayment
-            ? "Registrar pago y completar"
-            : "Registrar Pago"
+            ? tr("dashboard.attention.register_payment_and_complete", "Registrar pago y completar")
+            : tr("dashboard.attention.register_payment", "Registrar pago")
 
         return PaymentEntrySheet(
             amount: $viewModel.paymentAmount,

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/ProductDemandWidgetView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/ProductDemandWidgetView.swift
@@ -5,10 +5,14 @@ struct ProductDemandWidgetView: View {
     let products: [ProductDemandItem]
     let isLoading: Bool
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Label("Demanda de Productos", systemImage: "chart.bar")
+                Label(tr("dashboard.widgets.product_demand.title", "Demanda de productos"), systemImage: "chart.bar")
                     .font(.subheadline)
                     .fontWeight(.semibold)
                 Spacer()
@@ -23,7 +27,7 @@ struct ProductDemandWidgetView: View {
                     .padding(.vertical, 8)
                 }
             } else if products.isEmpty {
-                Text("Sin datos de productos aún")
+                Text(tr("dashboard.widgets.product_demand.empty", "Sin demanda registrada"))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -37,11 +41,19 @@ struct ProductDemandWidgetView: View {
                                 .fontWeight(.medium)
                                 .lineLimit(1)
                             HStack {
-                                Text("\(product.timesUsed) uso\(product.timesUsed == 1 ? "" : "s")")
+                                Text(String.localizedStringWithFormat(
+                                    tr(
+                                        product.timesUsed == 1
+                                            ? "dashboard.widgets.product_demand.uses_one"
+                                            : "dashboard.widgets.product_demand.uses_other",
+                                        product.timesUsed == 1 ? "%lld uso" : "%lld usos"
+                                    ),
+                                    product.timesUsed
+                                ))
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                 Spacer()
-                                Text(formatMXN(product.totalRevenue))
+                                Text(DashboardFormatting.currencyMXN(product.totalRevenue))
                                     .font(.caption)
                                     .fontWeight(.semibold)
                                     .foregroundColor(.primary)
@@ -62,15 +74,6 @@ struct ProductDemandWidgetView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(.systemGray5), lineWidth: 1)
         )
-    }
-
-    private func formatMXN(_ amount: Double) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "MXN"
-        formatter.currencySymbol = "$"
-        formatter.maximumFractionDigits = 0
-        return formatter.string(from: NSNumber(value: amount)) ?? "$0"
     }
 }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/TopClientsWidgetView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/Views/TopClientsWidgetView.swift
@@ -5,10 +5,14 @@ struct TopClientsWidgetView: View {
     let clients: [TopClient]
     let isLoading: Bool
 
+    private func tr(_ key: String, _ value: String) -> String {
+        FeatureL10n.text(key, value)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Label("Top Clientes", systemImage: "person.2")
+                Label(tr("dashboard.widgets.top_clients.title", "Top clientes"), systemImage: "person.2")
                     .font(.subheadline)
                     .fontWeight(.semibold)
                 Spacer()
@@ -23,7 +27,7 @@ struct TopClientsWidgetView: View {
                     .padding(.vertical, 8)
                 }
             } else if clients.isEmpty {
-                Text("Sin datos de clientes aún")
+                Text(tr("dashboard.widgets.top_clients.empty", "Sin clientes destacados"))
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .frame(maxWidth: .infinity, alignment: .center)
@@ -37,11 +41,19 @@ struct TopClientsWidgetView: View {
                                 .fontWeight(.medium)
                                 .lineLimit(1)
                             HStack {
-                                Text("\(client.eventCount) evento\(client.eventCount == 1 ? "" : "s")")
+                                Text(String.localizedStringWithFormat(
+                                    tr(
+                                        client.eventCount == 1
+                                            ? "dashboard.widgets.top_clients.events_one"
+                                            : "dashboard.widgets.top_clients.events_other",
+                                        client.eventCount == 1 ? "%lld evento" : "%lld eventos"
+                                    ),
+                                    client.eventCount
+                                ))
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                                 Spacer()
-                                Text(formatMXN(client.totalSpent))
+                                Text(DashboardFormatting.currencyMXN(client.totalSpent))
                                     .font(.caption)
                                     .fontWeight(.semibold)
                                     .foregroundColor(.primary)
@@ -62,15 +74,6 @@ struct TopClientsWidgetView: View {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color(.systemGray5), lineWidth: 1)
         )
-    }
-
-    private func formatMXN(_ amount: Double) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "MXN"
-        formatter.currencySymbol = "$"
-        formatter.maximumFractionDigits = 0
-        return formatter.string(from: NSNumber(value: amount)) ?? "$0"
     }
 }
 

--- a/web/src/components/ForecastWidget.tsx
+++ b/web/src/components/ForecastWidget.tsx
@@ -4,16 +4,16 @@ import { useTranslation } from "react-i18next";
 import { TrendingUp, AlertTriangle } from "lucide-react";
 import { formatCurrency } from "@/lib/finance";
 import { format, parse } from "date-fns";
-import { es } from "date-fns/locale";
+import { enUS, es } from "date-fns/locale";
 
 export function ForecastWidget() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { data, isLoading, error } = useForecast();
 
   const formatMonthYear = (monthStr: string) => {
     try {
       const parsed = parse(monthStr, "yyyy-MM", new Date());
-      return format(parsed, "MMM yyyy", { locale: es });
+      return format(parsed, "MMM yyyy", { locale: i18n.language === "en" ? enUS : es });
     } catch {
       return monthStr;
     }
@@ -25,7 +25,7 @@ export function ForecastWidget() {
         <div className="flex items-center gap-3 mb-4">
           <TrendingUp className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.forecast", "Revenue Forecast")}
+            {t("dashboard:widgets.forecast.title")}
           </h3>
         </div>
         <div className="space-y-3">
@@ -43,12 +43,12 @@ export function ForecastWidget() {
         <div className="flex items-center gap-3 mb-4">
           <TrendingUp className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.forecast", "Revenue Forecast")}
+            {t("dashboard:widgets.forecast.title")}
           </h3>
         </div>
         <div className="flex items-center gap-3 text-error text-sm">
           <AlertTriangle className="w-4 h-4 shrink-0" />
-          <span>{t("common.error", "Error loading data")}</span>
+          <span>{t("common:error.generic")}</span>
         </div>
       </div>
     );
@@ -60,11 +60,11 @@ export function ForecastWidget() {
         <div className="flex items-center gap-3 mb-4">
           <TrendingUp className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.forecast", "Revenue Forecast")}
+            {t("dashboard:widgets.forecast.title")}
           </h3>
         </div>
         <p className="text-sm text-foreground-secondary">
-          {t("dashboard.noForecast", "No forecast data yet")}
+          {t("dashboard:widgets.forecast.empty")}
         </p>
       </div>
     );
@@ -78,7 +78,7 @@ export function ForecastWidget() {
       <div className="flex items-center gap-3 mb-4">
         <TrendingUp className="w-5 h-5 text-primary" />
         <h3 className="text-sm font-semibold text-foreground">
-          {t("dashboard.forecast", "Revenue Forecast")}
+          {t("dashboard:widgets.forecast.title")}
         </h3>
       </div>
 
@@ -86,7 +86,7 @@ export function ForecastWidget() {
       <div className="grid grid-cols-2 gap-3 mb-4 p-3 bg-surface-alt rounded-lg">
         <div>
           <p className="text-xs text-foreground-secondary">
-            {t("dashboard.totalRevenue", "Total Revenue")}
+            {t("dashboard:widgets.forecast.projected_revenue")}
           </p>
           <p className="text-sm font-semibold text-primary">
             {formatCurrency(totalRevenue)}
@@ -94,7 +94,7 @@ export function ForecastWidget() {
         </div>
         <div>
           <p className="text-xs text-foreground-secondary">
-            {t("dashboard.confirmedEvents", "Confirmed")}
+            {t("dashboard:widgets.forecast.confirmed_events")}
           </p>
           <p className="text-sm font-semibold text-primary">{totalEvents}</p>
         </div>

--- a/web/src/components/ProductDemandWidget.tsx
+++ b/web/src/components/ProductDemandWidget.tsx
@@ -14,7 +14,7 @@ export function ProductDemandWidget() {
         <div className="flex items-center gap-3 mb-4">
           <Package className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.productDemand", "Product Demand")}
+            {t("dashboard:widgets.product_demand.title")}
           </h3>
         </div>
         <div className="space-y-3">
@@ -32,12 +32,12 @@ export function ProductDemandWidget() {
         <div className="flex items-center gap-3 mb-4">
           <Package className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.productDemand", "Product Demand")}
+            {t("dashboard:widgets.product_demand.title")}
           </h3>
         </div>
         <div className="flex items-center gap-3 text-error text-sm">
           <AlertTriangle className="w-4 h-4 shrink-0" />
-          <span>{t("common.error", "Error loading data")}</span>
+          <span>{t("common:error.generic")}</span>
         </div>
       </div>
     );
@@ -49,11 +49,11 @@ export function ProductDemandWidget() {
         <div className="flex items-center gap-3 mb-4">
           <Package className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.productDemand", "Product Demand")}
+            {t("dashboard:widgets.product_demand.title")}
           </h3>
         </div>
         <p className="text-sm text-foreground-secondary">
-          {t("dashboard.noProducts", "No product data yet")}
+          {t("dashboard:widgets.product_demand.empty")}
         </p>
       </div>
     );
@@ -64,7 +64,7 @@ export function ProductDemandWidget() {
       <div className="flex items-center gap-3 mb-4">
         <Package className="w-5 h-5 text-primary" />
         <h3 className="text-sm font-semibold text-foreground">
-          {t("dashboard.productDemand", "Product Demand")}
+          {t("dashboard:widgets.product_demand.title")}
         </h3>
       </div>
       <div className="space-y-3">
@@ -79,7 +79,7 @@ export function ProductDemandWidget() {
               </p>
               <p className="text-xs text-foreground-secondary">
                 {item.times_used}{" "}
-                {t("common.uses", "use", { count: item.times_used })}
+                {t("dashboard:widgets.product_demand.uses", { count: item.times_used })}
               </p>
             </div>
             <p className="text-sm font-semibold text-primary whitespace-nowrap ml-2">

--- a/web/src/components/TopClientsWidget.tsx
+++ b/web/src/components/TopClientsWidget.tsx
@@ -14,7 +14,7 @@ export function TopClientsWidget() {
         <div className="flex items-center gap-3 mb-4">
           <Users className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.topClients", "Top Clients")}
+            {t("dashboard:widgets.top_clients.title")}
           </h3>
         </div>
         <div className="space-y-3">
@@ -32,12 +32,12 @@ export function TopClientsWidget() {
         <div className="flex items-center gap-3 mb-4">
           <Users className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.topClients", "Top Clients")}
+            {t("dashboard:widgets.top_clients.title")}
           </h3>
         </div>
         <div className="flex items-center gap-3 text-error text-sm">
           <AlertTriangle className="w-4 h-4 shrink-0" />
-          <span>{t("common.error", "Error loading data")}</span>
+          <span>{t("common:error.generic")}</span>
         </div>
       </div>
     );
@@ -49,11 +49,11 @@ export function TopClientsWidget() {
         <div className="flex items-center gap-3 mb-4">
           <Users className="w-5 h-5 text-primary" />
           <h3 className="text-sm font-semibold text-foreground">
-            {t("dashboard.topClients", "Top Clients")}
+            {t("dashboard:widgets.top_clients.title")}
           </h3>
         </div>
         <p className="text-sm text-foreground-secondary">
-          {t("dashboard.noClients", "No client data yet")}
+          {t("dashboard:widgets.top_clients.empty")}
         </p>
       </div>
     );
@@ -64,7 +64,7 @@ export function TopClientsWidget() {
       <div className="flex items-center gap-3 mb-4">
         <Users className="w-5 h-5 text-primary" />
         <h3 className="text-sm font-semibold text-foreground">
-          {t("dashboard.topClients", "Top Clients")}
+          {t("dashboard:widgets.top_clients.title")}
         </h3>
       </div>
       <div className="space-y-3">
@@ -79,7 +79,7 @@ export function TopClientsWidget() {
               </p>
               <p className="text-xs text-foreground-secondary">
                 {client.total_events}{" "}
-                {t("common.events", "event", { count: client.total_events })}
+                {t("dashboard:widgets.top_clients.events", { count: client.total_events })}
               </p>
             </div>
             <p className="text-sm font-semibold text-primary whitespace-nowrap ml-2">

--- a/web/src/i18n/locales/en/dashboard.json
+++ b/web/src/i18n/locales/en/dashboard.json
@@ -1,66 +1,107 @@
 {
-  "title": "Dashboard",
-  "welcome": "Welcome, {{name}}",
+  "title": "Home",
+  "welcome": "Hello, {{name}}",
+  "greeting": {
+    "generic": "Hello"
+  },
   "kpis": {
-    "net_sales": "Net Sales",
-    "cash_collected": "Cash Collected",
-    "vat_outstanding": "VAT Outstanding",
-    "total_revenue": "Total revenue",
-    "active_events": "Active events",
-    "new_clients": "New clients",
-    "average_ticket": "Average ticket"
+    "net_sales": "Net sales",
+    "cash_collected": "Collected",
+    "vat_collected": "VAT collected",
+    "vat_outstanding": "VAT due",
+    "active_events": "Events this month",
+    "low_stock": "Low stock",
+    "new_clients": "Clients",
+    "average_ticket": "Average ticket",
+    "quotes": "Quotes",
+    "subtitle": {
+      "confirmed_completed": "Confirmed and completed events",
+      "this_month": "This month",
+      "due": "Due",
+      "total": "Total"
+    }
   },
   "status_chart": {
-    "title": "Event Status",
+    "title": "Event status",
     "events_this_month": "events this month",
-    "no_data": "No data to display this month",
-    "create_first": "Create first event"
+    "no_data": "No events this month",
+    "create_first": "Create your first event",
+    "distribution_aria": "Event status: {{segments}}",
+    "segment_title": "{{name}}: {{value}}"
   },
   "revenue_chart": {
-    "title": "Revenue — Last 6 months",
+    "title": "Revenue — last 6 months",
     "aria_label": "Revenue chart for the last 6 months",
-    "revenue": "Revenue"
+    "revenue": "Revenue",
+    "pro_title": "Pro trends",
+    "pro_description": "Upgrade your plan to view monthly revenue charts.",
+    "view_plans": "View plans"
   },
   "attention": {
-    "title": "Need Attention",
-    "description": "Upcoming or past-due events with pending actions.",
+    "title": "Need attention",
+    "description": "Upcoming or overdue events with pending follow-up.",
     "alerts_count_one": "1 alert",
     "alerts_count_other": "{{count}} alerts",
     "pending_balance": "Pending balance {{pending}} of {{total}}",
+    "pending_balance_label": "Pending balance",
     "past_confirmed": "Past event still confirmed",
     "past_quoted": "Expired quote without closing",
-    "register_payment": "Register payment",
-    "pay_and_complete": "Pay and complete",
-    "complete_only": "Just complete",
-    "view_detail": "View detail",
+    "register_payment": "Record payment",
+    "register_payment_and_complete": "Record payment and complete",
+    "pay_and_complete": "Pay & complete",
+    "complete_only": "Complete only",
+    "complete": "Complete",
+    "view": "View",
+    "view_detail": "View details",
     "confirmed_payment_title": "Upcoming balances",
     "confirmed_payment_desc": "Confirmed events in the next 7 days with pending balance.",
-    "past_active_title": "Past-due events",
-    "past_active_desc": "Events that already passed but haven't been completed or cancelled."
+    "past_active_title": "Overdue events",
+    "past_active_desc": "Events that already passed but haven't been completed or cancelled.",
+    "pending_event_talkback": "Pending event: {{service}}, date {{date}}, reason {{reason}}"
   },
   "upcoming": {
-    "no_events": "No upcoming events"
+    "title": "Upcoming events",
+    "empty": "No upcoming events",
+    "view": "View"
   },
   "inventory": {
-    "no_items": "Healthy stock in all items"
+    "title": "Inventory alerts",
+    "stock_current": "Current stock: {{current}} {{unit}}",
+    "low_stock_talkback": "Low stock: {{name}}, current {{current}} {{unit}}",
+    "no_items": "Healthy stock across all items"
   },
-  "topClients": "Top Clients",
-  "noClients": "No client data yet",
-  "productDemand": "Product Demand",
-  "noProducts": "No product data yet",
-  "forecast": "Revenue Forecast",
-  "noForecast": "No forecast data available",
-  "totalRevenue": "Projected Revenue",
-  "confirmedEvents": "Confirmed",
+  "widgets": {
+    "top_clients": {
+      "title": "Top clients",
+      "empty": "No client data yet",
+      "events_one": "{{count}} event",
+      "events_other": "{{count}} events"
+    },
+    "product_demand": {
+      "title": "Product demand",
+      "empty": "No product data yet",
+      "uses_one": "{{count}} use",
+      "uses_other": "{{count}} uses"
+    },
+    "forecast": {
+      "title": "Revenue forecast",
+      "empty": "No forecast available",
+      "projected_revenue": "Projected revenue",
+      "confirmed_events": "Confirmed",
+      "events_one": "{{count}} event",
+      "events_other": "{{count}} events"
+    }
+  },
   "messages": {
     "event_completed": "Event marked as completed.",
     "event_cancelled": "Event cancelled.",
-    "payment_registered": "Payment registered.",
-    "payment_partial": "Partial payment registered. Pay full balance to mark event as completed.",
-    "payment_complete_manual": "Payment registered. Mark event as completed manually."
+    "payment_registered": "Payment recorded.",
+    "payment_partial": "Partial payment recorded. Pay the full balance to mark the event as completed.",
+    "payment_complete_manual": "Payment recorded. Mark the event as completed manually."
   },
   "event": {
-    "no_client": "No client",
-    "pax": "pax"
+    "no_client": "Client",
+    "pax": "pax",
+    "summary_talkback": "{{client}}{{separator}}{{service}}, date {{date}}, status {{status}}"
   }
 }

--- a/web/src/i18n/locales/es/dashboard.json
+++ b/web/src/i18n/locales/es/dashboard.json
@@ -1,25 +1,41 @@
 {
-  "title": "Dashboard",
-  "welcome": "Bienvenido, {{name}}",
+  "title": "Inicio",
+  "welcome": "Hola, {{name}}",
+  "greeting": {
+    "generic": "Hola"
+  },
   "kpis": {
-    "net_sales": "Ventas Netas",
-    "cash_collected": "Cobrado Real",
-    "vat_outstanding": "IVA por Cobrar",
-    "total_revenue": "Ingresos totales",
-    "active_events": "Eventos activos",
-    "new_clients": "Nuevos clientes",
-    "average_ticket": "Ticket promedio"
+    "net_sales": "Ventas netas",
+    "cash_collected": "Cobrado",
+    "vat_collected": "IVA cobrado",
+    "vat_outstanding": "IVA pendiente",
+    "active_events": "Eventos del mes",
+    "low_stock": "Stock bajo",
+    "new_clients": "Clientes",
+    "average_ticket": "Ticket promedio",
+    "quotes": "Cotizaciones",
+    "subtitle": {
+      "confirmed_completed": "Eventos confirmados y completados",
+      "this_month": "Este mes",
+      "due": "Por cobrar",
+      "total": "Total"
+    }
   },
   "status_chart": {
-    "title": "Estado de Eventos",
+    "title": "Estado de eventos",
     "events_this_month": "eventos este mes",
-    "no_data": "Sin datos para graficar este mes",
-    "create_first": "Crear primer evento"
+    "no_data": "Sin eventos este mes",
+    "create_first": "Crea tu primer evento",
+    "distribution_aria": "Estado de eventos: {{segments}}",
+    "segment_title": "{{name}}: {{value}}"
   },
   "revenue_chart": {
-    "title": "Ingresos — Últimos 6 meses",
+    "title": "Ingresos — últimos 6 meses",
     "aria_label": "Gráfico de ingresos por mes en los últimos 6 meses",
-    "revenue": "Ingresos"
+    "revenue": "Ingresos",
+    "pro_title": "Tendencias Pro",
+    "pro_description": "Mejorá tu plan para ver gráficos de ingresos mensuales.",
+    "view_plans": "Ver planes"
   },
   "attention": {
     "title": "Requieren atención",
@@ -27,31 +43,55 @@
     "alerts_count_one": "1 alerta",
     "alerts_count_other": "{{count}} alertas",
     "pending_balance": "Saldo pendiente {{pending}} de {{total}}",
+    "pending_balance_label": "Saldo pendiente",
     "past_confirmed": "Evento pasado aún confirmado",
     "past_quoted": "Cotización vencida sin cerrar",
     "register_payment": "Registrar pago",
+    "register_payment_and_complete": "Registrar pago y completar",
     "pay_and_complete": "Pagar y completar",
     "complete_only": "Solo completar",
+    "complete": "Completar",
+    "view": "Ver",
     "view_detail": "Ver detalle",
     "confirmed_payment_title": "Saldos próximos",
     "confirmed_payment_desc": "Eventos confirmados en los próximos 7 días con saldo pendiente.",
     "past_active_title": "Eventos vencidos",
-    "past_active_desc": "Eventos que ya pasaron pero no han sido completados o cancelados."
+    "past_active_desc": "Eventos que ya pasaron pero no han sido completados o cancelados.",
+    "pending_event_talkback": "Evento pendiente: {{service}}, fecha {{date}}, motivo {{reason}}"
   },
   "upcoming": {
-    "no_events": "No hay eventos próximos"
+    "title": "Próximos eventos",
+    "empty": "Sin eventos próximos",
+    "view": "Ver"
   },
   "inventory": {
+    "title": "Alertas de inventario",
+    "stock_current": "Stock actual: {{current}} {{unit}}",
+    "low_stock_talkback": "Stock bajo: {{name}}, actual {{current}} {{unit}}",
     "no_items": "Stock saludable en todos los ítems"
   },
-  "topClients": "Top Clientes",
-  "noClients": "Sin datos de clientes aún",
-  "productDemand": "Demanda de Productos",
-  "noProducts": "Sin datos de productos aún",
-  "forecast": "Proyección de Ingresos",
-  "noForecast": "Sin proyecciones disponibles",
-  "totalRevenue": "Ingresos Proyectados",
-  "confirmedEvents": "Eventos Confirmados",
+  "widgets": {
+    "top_clients": {
+      "title": "Clientes principales",
+      "empty": "Sin datos de clientes aún",
+      "events_one": "{{count}} evento",
+      "events_other": "{{count}} eventos"
+    },
+    "product_demand": {
+      "title": "Demanda de productos",
+      "empty": "Sin datos de productos aún",
+      "uses_one": "{{count}} uso",
+      "uses_other": "{{count}} usos"
+    },
+    "forecast": {
+      "title": "Proyección de ingresos",
+      "empty": "Sin proyecciones disponibles",
+      "projected_revenue": "Ingresos proyectados",
+      "confirmed_events": "Confirmados",
+      "events_one": "{{count}} evento",
+      "events_other": "{{count}} eventos"
+    }
+  },
   "messages": {
     "event_completed": "Evento marcado como completado.",
     "event_cancelled": "Evento cancelado.",
@@ -60,7 +100,8 @@
     "payment_complete_manual": "Pago registrado. Marcá el evento como completado manualmente."
   },
   "event": {
-    "no_client": "Sin cliente",
-    "pax": "pax"
+    "no_client": "Cliente",
+    "pax": "pax",
+    "summary_talkback": "{{client}}{{separator}}{{service}}, fecha {{date}}, estado {{status}}"
   }
 }

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -95,6 +95,37 @@ function parseDashboardEventDate(eventDate: string) {
   return new Date(`${eventDate}T12:00:00`);
 }
 
+function capitalizeFirst(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatDashboardHeaderDate(date: Date, locale: string) {
+  return capitalizeFirst(
+    new Intl.DateTimeFormat(locale, {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+    }).format(date),
+  );
+}
+
+function formatCompactCurrency(value: number, locale: string) {
+  const compact = new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits: 0,
+  }).format(value);
+
+  const currencySymbol = new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "MXN",
+    maximumFractionDigits: 0,
+  })
+    .formatToParts(0)
+    .find((part) => part.type === "currency")?.value ?? "$";
+
+  return `${currencySymbol}${compact}`;
+}
+
 // ── Skeleton loader ──────────────────────────────────────────────
 function SkeletonKpi({ compact = false }: { compact?: boolean }) {
   if (compact) {
@@ -212,17 +243,17 @@ function EventStatusBar({ data, loading }: { data: StatusSegment[]; loading: boo
     );
   }
   return (
-    <div className="flex-1 flex flex-col justify-center gap-6">
-      <div className="text-center">
-        <span className="text-4xl font-black text-text">{total}</span>
-        <p className="text-xs text-text-secondary mt-1">{t('dashboard:status_chart.events_this_month')}</p>
-      </div>
+      <div className="flex-1 flex flex-col justify-center gap-6">
+        <div className="text-center">
+          <span className="text-4xl font-black text-text">{total}</span>
+          <p className="text-xs text-text-secondary mt-1">{t('dashboard:status_chart.events_this_month')}</p>
+        </div>
       <div className="flex h-3 rounded-full overflow-hidden w-full" role="img"
-        aria-label={`Distribución: ${data.map(d => `${d.name} ${d.value}`).join(', ')}`}>
+        aria-label={t('dashboard:status_chart.distribution_aria', { segments: data.map(d => `${d.name} ${d.value}`).join(', ') })}>
         {data.map((seg) => (
           <div key={seg.name} className="h-full transition-all duration-500"
             style={{ width: `${(seg.value / total) * 100}%`, backgroundColor: seg.color }}
-            title={`${seg.name}: ${seg.value}`} />
+            title={t('dashboard:status_chart.segment_title', { name: seg.name, value: seg.value })} />
         ))}
       </div>
       <div className="flex flex-wrap gap-x-4 gap-y-2 justify-center">
@@ -239,7 +270,7 @@ function EventStatusBar({ data, loading }: { data: StatusSegment[]; loading: boo
 
 // ── Upcoming Event Card ─────────────────────────────────────────
 function UpcomingEventCard({ event }: { event: DashboardEvent }) {
-  const { i18n } = useTranslation();
+  const { i18n, t } = useTranslation(['dashboard']);
   const navigate = useNavigate();
   const dateObj = new Date(event.event_date + "T12:00:00");
   const dateLocale = i18n.language === 'en' ? enUS : es;
@@ -254,8 +285,8 @@ function UpcomingEventCard({ event }: { event: DashboardEvent }) {
         <span className="text-lg font-bold text-primary leading-tight">{format(dateObj, "d")}</span>
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold text-text truncate">{event.client?.name ?? "—"}</p>
-        <p className="text-xs text-text-secondary truncate mt-0.5">{event.service_type} · {event.num_people} pax</p>
+        <p className="text-sm font-semibold text-text truncate">{event.client?.name ?? t('dashboard:event.no_client')}</p>
+        <p className="text-xs text-text-secondary truncate mt-0.5">{event.service_type} · {event.num_people} {t('dashboard:event.pax')}</p>
       </div>
       <div onClick={(e) => e.stopPropagation()}>
         <StatusDropdown eventId={event.id} currentStatus={event.status as EventStatus} />
@@ -477,27 +508,25 @@ function DashboardAttentionSection({
 // ── Monthly Revenue Trend Card (premium only) ────────────────────
 function MonthlyRevenueTrendCard({ points }: { points: DashboardRevenuePoint[] }) {
   const { t, i18n } = useTranslation(['dashboard']);
+  const localeCode = i18n.language === 'en' ? 'en-US' : 'es-MX';
 
   const chartData = useMemo(() => {
-    const monthLabels = i18n.language === 'en' 
-      ? ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
-      : ["ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"];
     const byMonth = new Map(points.map((p) => [p.month, p.revenue]));
     const today = new Date();
     const bars: { name: string; value: number }[] = [];
     for (let offset = 5; offset >= 0; offset--) {
       const d = new Date(today.getFullYear(), today.getMonth() - offset, 1);
       const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
-      const label = monthLabels[d.getMonth()];
+      const label = new Intl.DateTimeFormat(localeCode, { month: 'short' }).format(d);
       bars.push({
-        name: label.charAt(0).toUpperCase() + label.slice(1),
+        name: capitalizeFirst(label.replace('.', '')),
         value: byMonth.get(key) ?? 0,
       });
     }
     return bars;
-  }, [points, i18n.language]);
+  }, [points, localeCode]);
 
-  const moneyLocale = i18n.language === 'en' ? 'en-US' : 'es-MX';
+  const moneyLocale = localeCode;
 
   return (
     <div className="bg-card shadow-sm border border-border rounded-2xl p-6 flex flex-col">
@@ -518,7 +547,7 @@ function MonthlyRevenueTrendCard({ points }: { points: DashboardRevenuePoint[] }
               axisLine={false}
               tickLine={false}
               tick={{ fill: "var(--color-text-tertiary)", fontSize: 11 }}
-              tickFormatter={(value: number) => value === 0 ? "$0" : `${Math.round(value / 1000)}k`}
+              tickFormatter={(value: number) => formatCompactCurrency(value, moneyLocale)}
               width={48}
             />
             <Tooltip
@@ -788,7 +817,7 @@ export const Dashboard: React.FC = () => {
             {t('dashboard:welcome', { name: firstName })}
           </h1>
           <p className="text-text-secondary text-sm font-medium">
-            {format(today, "EEEE, d 'de' MMMM", { locale: i18n.language === 'en' ? enUS : es })}
+            {formatDashboardHeaderDate(today, moneyLocale)}
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
@@ -888,15 +917,15 @@ export const Dashboard: React.FC = () => {
                  <div className="w-12 h-12 rounded-full bg-surface-alt flex items-center justify-center">
                    <TrendingUp className="h-6 w-6 text-text-tertiary" />
                  </div>
-                 <div className="max-w-50">
-                   <p className="text-sm font-bold text-text mb-1">Tendencias Pro</p>
-                   <p className="text-xs text-text-secondary leading-relaxed">
-                     Mejorá tu plan para ver gráficos de ingresos mensuales.
-                   </p>
-                 </div>
-                 <button onClick={() => navigate("/profile/pricing")} className="text-xs font-bold text-primary hover:underline">Ver planes</button>
-               </div>
-            )}
+                  <div className="max-w-50">
+                    <p className="text-sm font-bold text-text mb-1">{t('dashboard:revenue_chart.pro_title')}</p>
+                    <p className="text-xs text-text-secondary leading-relaxed">
+                      {t('dashboard:revenue_chart.pro_description')}
+                    </p>
+                  </div>
+                  <button onClick={() => navigate("/profile/pricing")} className="text-xs font-bold text-primary hover:underline">{t('dashboard:revenue_chart.view_plans')}</button>
+                </div>
+             )}
           </div>
 
           <RecentActivityCard />
@@ -1008,7 +1037,7 @@ export const Dashboard: React.FC = () => {
               </div>
               <p className="text-base font-bold text-text">{paymentModal.event.client?.name ?? t('dashboard:event.no_client')}</p>
               <div className="mt-4 flex items-center justify-between border-t border-border pt-4">
-                <span className="text-sm text-text-secondary">{t('dashboard:attention.pending_balance').split('{{pending}}')[0]}</span>
+                <span className="text-sm text-text-secondary">{t('dashboard:attention.pending_balance_label')}</span>
                 <span className="text-lg font-black text-error">{fmt(paymentModal.pendingAmount)}</span>
               </div>
             </div>


### PR DESCRIPTION
## What
- localize dashboard copy across Web, iOS, and Android
- add ES/EN resources for dashboard widgets, alerts, and KPI labels
- update PRD tracking for slice #94 completion

## Why
- close issue #94 with real cross-platform i18n parity
- eliminate hardcoded dashboard strings and locale drift across platforms
- align dashboard terminology with the canonical i18n strategy

## Scope
- [ ] Backend
- [x] Web
- [x] iOS
- [x] Android
- [x] Docs/PRD

## Checklist
- [x] Issue linked
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [x] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: low; changes are localized to presentation strings, formatting helpers, and resource catalogs.
- Rollback: revert commit `3b396eee` or close this branch/PR.

Closes #94