### PR TITLE
fix(cross-platform): remove invoice PDF generation from all platforms and docs

### DIFF
--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventDetailScreen.kt
@@ -58,7 +58,6 @@ import com.creapolis.solennix.feature.events.pdf.BudgetPdfGenerator
 import com.creapolis.solennix.feature.events.pdf.ChecklistPdfGenerator
 import com.creapolis.solennix.feature.events.pdf.ContractPdfGenerator
 import com.creapolis.solennix.feature.events.pdf.EquipmentListPdfGenerator
-import com.creapolis.solennix.feature.events.pdf.InvoicePdfGenerator
 import com.creapolis.solennix.feature.events.pdf.PaymentReportPdfGenerator
 import com.creapolis.solennix.feature.events.pdf.ShoppingListPdfGenerator
 import com.creapolis.solennix.feature.events.viewmodel.EventDetailUiState
@@ -1639,25 +1638,6 @@ fun DocumentActionsGrid(
                             context = context,
                             event = event,
                             client = client,
-                            payments = uiState.payments,
-                            user = uiState.currentUser
-                        )
-                    }
-                }
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            ActionButton(
-                icon = Icons.Default.Receipt,
-                label = "Factura",
-                modifier = Modifier.weight(1f),
-                onClick = {
-                    generatePdfAsync {
-                        InvoicePdfGenerator.generate(
-                            context = context,
-                            event = event,
-                            client = client,
-                            products = uiState.products,
-                            extras = uiState.extras,
                             payments = uiState.payments,
                             user = uiState.currentUser
                         )

--- a/docs/Android/Módulo Eventos.md
+++ b/docs/Android/Módulo Eventos.md
@@ -145,14 +145,13 @@ Desde el detalle del evento se pueden generar múltiples documentos:
 |-----------|-----------|
 | Presupuesto | Productos + extras + totales |
 | Contrato | Términos + condiciones del usuario |
-| Factura | Detalle de pagos y saldos |
 | Lista de compras | Insumos necesarios |
 | Checklist | Tareas pendientes del evento |
 | Lista de equipamiento | Equipo asignado |
 | Reporte de pagos | Historial de abonos |
 
 > [!warning] Dependencia faltante
-> El código de generación de PDF existe (`InvoicePdfGenerator`, etc.) pero no se ha importado una librería de PDF. La funcionalidad puede fallar en runtime.
+> El código de generación de PDF existe pero no se ha importado una librería de PDF. La funcionalidad puede fallar en runtime.
 
 ---
 

--- a/docs/Android/Sistema de PDFs.md
+++ b/docs/Android/Sistema de PDFs.md
@@ -3,7 +3,7 @@
 # Sistema de PDFs
 
 > [!abstract] Resumen
-> Generación de documentos PDF desde el detalle de eventos: presupuestos, contratos, facturas, listas de compras, checklists, listas de equipamiento y reportes de pagos. El código existe pero **falta la librería de PDF**.
+> Generación de documentos PDF desde el detalle de eventos: presupuestos, contratos, listas de compras, checklists, listas de equipamiento y reportes de pagos. El código existe pero **falta la librería de PDF**.
 
 ---
 
@@ -13,7 +13,6 @@
 |-----------|-----------|-----------|
 | Presupuesto | `BudgetPdfGenerator` | Productos + extras + totales |
 | Contrato | `ContractPdfGenerator` | Términos + datos del negocio + cliente |
-| Factura | `InvoicePdfGenerator` | Detalle financiero + pagos |
 | Lista de compras | `ShoppingListPdfGenerator` | Insumos e ingredientes necesarios |
 | Checklist | `ChecklistPdfGenerator` | Tareas del evento |
 | Lista de equipamiento | `EquipmentListPdfGenerator` | Equipamiento asignado |

--- a/docs/PRD/02_FEATURES.md
+++ b/docs/PRD/02_FEATURES.md
@@ -114,7 +114,7 @@ El formulario de creacion/edicion de eventos esta dividido en pasos para reducir
 #### Pricing con IVA y descuentos
 
 - **Descuento global**: Porcentaje (`discount_type: 'percent'`) o monto fijo (`discount_type: 'fixed'`).
-- **IVA configurable**: `tax_rate` y `tax_amount` calculados. Facturacion opcional (`requires_invoice`).
+- **IVA configurable**: `tax_rate` y `tax_amount` calculados. El campo `requires_invoice` controla si aplica IVA al evento.
 - **Deposito**: Porcentaje configurable (`deposit_percent`) heredado de la configuracion del negocio o personalizado por evento.
 - **Condiciones de cancelacion**: Dias de anticipacion (`cancellation_days`) y porcentaje de reembolso (`refund_percent`).
 
@@ -558,7 +558,6 @@ Cada alerta muestra: nombre del evento, fecha, razon (badge), monto pendiente cu
 
 | Tipo               | Archivo iOS                       | Archivo Android                | Descripcion                                            |
 | ------------------ | --------------------------------- | ------------------------------ | ------------------------------------------------------ |
-| Cotizacion/Factura | `InvoicePDFGenerator.swift`       | `InvoicePdfGenerator.kt`       | Documento de cotizacion con productos, extras, totales |
 | Contrato           | `ContractPDFGenerator.swift`      | `ContractPdfGenerator.kt`      | Contrato con plantilla personalizable del usuario      |
 | Presupuesto        | `BudgetPDFGenerator.swift`        | `BudgetPdfGenerator.kt`        | Desglose de costos y margenes de ganancia              |
 | Checklist          | `ChecklistPDFGenerator.swift`     | `ChecklistPdfGenerator.kt`     | Lista de verificacion para el dia del evento           |
@@ -1221,7 +1220,6 @@ Visualización + registro de pago por transferencia con approve/reject. Reemplaz
 
 | Feature            | iOS | Android | Web | Backend | Notas                        |
 | ------------------ | --- | ------- | --- | ------- | ---------------------------- |
-| Cotizacion/Factura | ✅  | ✅      | ✅  | ➖      | Generado en cliente          |
 | Contrato           | ✅  | ✅      | ✅  | ➖      | Con plantilla personalizable |
 | Presupuesto        | ✅  | ✅      | ✅  | ➖      |                              |
 | Checklist          | ✅  | ✅      | ✅  | ➖      |                              |

--- a/docs/PRD/02_FEATURES.md
+++ b/docs/PRD/02_FEATURES.md
@@ -856,7 +856,7 @@ Personalizacion del perfil comercial del organizador de eventos.
 
 | Campo                       | Descripcion                           | Usado en        |
 | --------------------------- | ------------------------------------- | --------------- |
-| `business_name`             | Nombre comercial                      | PDFs, facturas  |
+| `business_name`             | Nombre comercial                      | PDFs            |
 | `logo_url`                  | Logo del negocio                      | PDFs, perfil    |
 | `brand_color`               | Color de marca                        | PDFs            |
 | `show_business_name_in_pdf` | Mostrar nombre comercial en PDFs      | PDFs            |

--- a/docs/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md
+++ b/docs/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md
@@ -868,11 +868,10 @@ Factory que crea el `ModelContainer` con los tres modelos registrados. Usado en 
 
 ## 11. Generacion de PDFs
 
-La app genera 8 tipos de PDF para diferentes documentos de negocio. Todos residen en `SolennixFeatures/Events/PDFGenerators/` y `SolennixFeatures/Clients/PDFGenerators/`.
+La app genera 7 tipos de PDF para diferentes documentos de negocio. Todos residen en `SolennixFeatures/Events/PDFGenerators/` y `SolennixFeatures/Clients/PDFGenerators/`.
 
 | Generador         | Archivo                           | Descripcion                            |
 | ----------------- | --------------------------------- | -------------------------------------- |
-| Factura           | `InvoicePDFGenerator.swift`       | Factura detallada del evento           |
 | Contrato          | `ContractPDFGenerator.swift`      | Contrato de servicio con terminos      |
 | Presupuesto       | `BudgetPDFGenerator.swift`        | Cotizacion detallada para el cliente   |
 | Checklist         | `ChecklistPDFGenerator.swift`     | Lista de tareas del evento             |

--- a/docs/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md
+++ b/docs/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md
@@ -262,7 +262,6 @@ android/
 │   │       ├── PdfConstants.kt            # Constantes compartidas
 │   │       ├── BudgetPdfGenerator.kt      # Cotización PDF
 │   │       ├── ContractPdfGenerator.kt    # Contrato PDF
-│   │       ├── InvoicePdfGenerator.kt     # Factura PDF
 │   │       ├── ChecklistPdfGenerator.kt   # Checklist PDF
 │   │       ├── EquipmentListPdfGenerator.kt   # Lista de equipo PDF
 │   │       ├── ShoppingListPdfGenerator.kt    # Lista de compras PDF
@@ -457,7 +456,7 @@ Capa de acceso a datos que combina API remota + cache local:
 | `EventChecklistScreen` | `EventChecklistViewModel` | Checklist de preparación del evento                                                   |
 | `PhotoGallerySheet`    | —                         | Bottom sheet para galería de fotos                                                    |
 
-**Generadores PDF**: `BudgetPdfGenerator`, `ContractPdfGenerator`, `InvoicePdfGenerator`, `ChecklistPdfGenerator`, `EquipmentListPdfGenerator`, `ShoppingListPdfGenerator`, `PaymentReportPdfGenerator`
+**Generadores PDF**: `BudgetPdfGenerator`, `ContractPdfGenerator`, `ChecklistPdfGenerator`, `EquipmentListPdfGenerator`, `ShoppingListPdfGenerator`, `PaymentReportPdfGenerator`
 
 ### 5.4 `feature:clients` — Gestión de Clientes
 
@@ -913,7 +912,7 @@ object DatabaseModule {
 > [!note] Generación de PDFs Nativa
 > **Decisión**: Generación de PDFs usando Android Canvas/PDF nativo, sin librerías de terceros.
 >
-> **Razón**: Menor tamaño de APK, sin dependencias externas, control total sobre el layout. Los PDFs generados incluyen: cotizaciones, contratos, facturas, checklists, listas de equipo, listas de compras, y reportes de pagos.
+> **Razón**: Menor tamaño de APK, sin dependencias externas, control total sobre el layout. Los PDFs generados incluyen: cotizaciones, contratos, checklists, listas de equipo, listas de compras, y reportes de pagos.
 
 > [!note] Deep Links con Esquema Custom
 > **Decisión**: Esquema `solennix://` para deep links.

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -731,7 +731,6 @@ Primera pantalla de paridad post-Dashboard:
 - ✅ Lista de compras (ShoppingListPDFGenerator)
 - ✅ Checklist (ChecklistPDFGenerator)
 - ✅ Reporte de pagos (PaymentReportPDFGenerator)
-- ✅ Factura (InvoicePDFGenerator)
 - ✅ Lista de equipamiento (EquipmentListPDFGenerator)
 
 ### Widgets (4 tipos)
@@ -884,7 +883,6 @@ Primera pantalla de paridad post-Dashboard:
 - ✅ Lista de compras (ShoppingListPdfGenerator)
 - ✅ Checklist (ChecklistPdfGenerator)
 - ✅ Reporte de pagos (PaymentReportPdfGenerator)
-- ✅ Factura (InvoicePdfGenerator)
 - ✅ Lista de equipamiento (EquipmentListPdfGenerator)
 - ✅ Cotizacion rapida (QuickQuotePdfGenerator)
 
@@ -971,7 +969,7 @@ Primera pantalla de paridad post-Dashboard:
 > [!note] Items completados Android
 >
 > - ~~Widgets (Glance)~~ — QuickActionsWidget implementado con eventos del dia + acciones rapidas
-> - ~~Generacion de PDF~~ — 8 generadores implementados: Budget, Contract, Shopping, Checklist, PaymentReport, Invoice, Equipment, QuickQuote
+> - ~~Generacion de PDF~~ — 7 generadores implementados: Budget, Contract, Shopping, Checklist, PaymentReport, Equipment, QuickQuote
 > - ~~RevenueCat SDK integrado~~ — SDK agregado y `Purchases.sharedInstance` inicializado (compra real NO implementada — ver Wave Rescate Bloque C)
 > - ~~Google Sign-In mock~~ — Reemplazado mock con Credential Manager real
 > - ~~Shared element transitions lista→detalle~~ — SharedTransitionLayout + sharedBounds via LocalSharedTransitionScope/LocalNavAnimatedVisibilityScope. Key pattern: `event_card_{id}`
@@ -1121,7 +1119,6 @@ Primera pantalla de paridad post-Dashboard:
 | Lista de compras PDF      | ✅  | ✅      | ✅  | ➖      | Web: generateShoppingListPDF              |
 | Checklist PDF             | ✅  | ✅      | ✅  | ➖      | Web: generateChecklistPDF                 |
 | Reporte de pagos PDF      | ✅  | ✅      | ✅  | ➖      | Web: generatePaymentReportPDF             |
-| Factura PDF               | ✅  | ✅      | ✅  | ➖      | Web: generateInvoicePDF                   |
 | Lista de equipamiento PDF | ✅  | ✅      | ⬜  | ➖      | Web pendiente                             |
 | Cotizacion rapida PDF     | ✅  | ✅      | ⬜  | ➖      | Web pendiente                             |
 

--- a/docs/PRD/20_SERVER_SIDE_PDF_GENERATION.md
+++ b/docs/PRD/20_SERVER_SIDE_PDF_GENERATION.md
@@ -33,7 +33,6 @@ priority: high
 | Contrato | `generateContractPDF` | `ContractPDFGenerator` | `ContractPdfGenerator` | ⚠️ Tokens distintos |
 | Lista de Insumos | `generateShoppingListPDF` | `ShoppingListPDFGenerator` | `ShoppingListPdfGenerator` | ⚠️ Datos distintos |
 | Reporte de Pagos | `generatePaymentReportPDF` | `PaymentReportPDFGenerator` | `PaymentReportPdfGenerator` | ⚠️ Parcial |
-| Factura | `generateInvoicePDF` | `InvoicePDFGenerator` | `InvoicePdfGenerator` | ⚠️ Android tiene payment history |
 | Checklist | `generateChecklistPDF` | `ChecklistPDFGenerator` | `ChecklistPdfGenerator` | ⚠️ Android usa InventoryItem[] |
 | Lista de Equipo | **NO EXISTE** | `EquipmentListPDFGenerator` | `EquipmentListPdfGenerator` | ❌ Falta en Web |
 
@@ -96,7 +95,6 @@ backend/internal/
 │   ├── contract.go             # Contrato (template tokens)
 │   ├── shopping_list.go        # Lista de Insumos
 │   ├── payment_report.go       # Reporte de Pagos
-│   ├── invoice.go              # Factura
 │   ├── checklist.go            # Checklist de Carga
 │   ├── equipment_list.go       # Lista de Equipo (NUEVO)
 │   └── template_tokens.go      # Token resolution (24 tokens)
@@ -115,7 +113,6 @@ GET /api/events/:id/pdf/budget          → Presupuesto
 GET /api/events/:id/pdf/contract        → Contrato
 GET /api/events/:id/pdf/shopping-list   → Lista de Insumos
 GET /api/events/:id/pdf/payment-report  → Reporte de Pagos
-GET /api/events/:id/pdf/invoice         → Factura
 GET /api/events/:id/pdf/checklist       → Checklist de Carga
 GET /api/events/:id/pdf/equipment-list  → Lista de Equipo
 ```
@@ -444,7 +441,6 @@ Estos son los tokens que el backend resuelve Y que todas las apps muestran:
 ### Fase 2 — Backend PDFs Financieros (4-5 días)
 
 - [ ] `internal/pdf/budget.go` — Presupuesto
-- [ ] `internal/pdf/invoice.go` — Factura
 - [ ] `internal/pdf/payment_report.go` — Reporte de Pagos
 - [ ] Lógica financiera: discount (percent/fixed), IVA, depósito
 - [ ] Tests unitarios de cada PDF con golden files

--- a/docs/Web/Arquitectura General.md
+++ b/docs/Web/Arquitectura General.md
@@ -115,7 +115,7 @@ web/src/
 3. **Composición** — Pages compuestas de componentes más pequeños (EventForm → 6 sub-componentes)
 4. **Hooks como lógica reutilizable** — `usePagination`, `usePlanLimits`, etc.
 5. **Error handling centralizado** — `logError()` en toda la app, toasts para feedback al usuario
-6. **PDF-First exports** — Presupuesto, contrato, factura, checklist exportables como PDF con branding
+6. **PDF-First exports** — Presupuesto, contrato, checklist exportables como PDF con branding
 
 ## Relaciones
 

--- a/docs/Web/Módulo Eventos.md
+++ b/docs/Web/Módulo Eventos.md
@@ -101,7 +101,6 @@ Desde `EventSummary`, el usuario puede generar:
 |-----|-----------|
 | **Presupuesto** | Productos, extras, totales, descuento, impuesto |
 | **Contrato** | Template customizado con tokens (nombre, fecha, monto, etc.) |
-| **Factura** | Ítems, pagos realizados, saldo pendiente |
 | **Lista de Compras** | Ingredientes/insumos necesarios por producto |
 | **Checklist** | Lista de tareas para el día del evento |
 | **Reporte de Pagos** | Historial completo de pagos del evento |

--- a/docs/Web/Sistema de PDFs.md
+++ b/docs/Web/Sistema de PDFs.md
@@ -13,7 +13,6 @@
 |------|---------|-----------|
 | **Presupuesto** | Budget/Quote | Productos, extras, subtotales, descuento, impuesto, total |
 | **Contrato** | Contract | Template personalizado con tokens sustituidos |
-| **Factura** | Invoice | Ítems detallados, pagos realizados, saldo pendiente |
 | **Lista de Compras** | Shopping List | Ingredientes y materiales necesarios por producto |
 | **Checklist** | Event Checklist | Tareas para el día del evento |
 | **Reporte de Pagos** | Payment Report | Historial completo de pagos del evento |

--- a/docs/iOS/Módulo Eventos.md
+++ b/docs/iOS/Módulo Eventos.md
@@ -132,7 +132,6 @@ graph LR
 |-----------|-----------|
 | Presupuesto | `BudgetPDFGenerator` |
 | Contrato | `ContractPDFGenerator` |
-| Factura | `InvoicePDFGenerator` |
 | Cotización rápida | `QuickQuotePDFGenerator` |
 | Lista de compras | `ShoppingListPDFGenerator` |
 | Checklist | `ChecklistPDFGenerator` |

--- a/docs/iOS/Sistema de PDFs.md
+++ b/docs/iOS/Sistema de PDFs.md
@@ -14,7 +14,6 @@
 | Cotización rápida | `QuickQuotePDFGenerator` | Productos + extras sin evento formal |
 | Presupuesto | `BudgetPDFGenerator` | Productos + extras + totales del evento |
 | Contrato | `ContractPDFGenerator` | Términos + datos negocio + cliente |
-| Factura | `InvoicePDFGenerator` | Detalle financiero + pagos |
 | Lista de compras | `ShoppingListPDFGenerator` | Insumos e ingredientes necesarios |
 | Checklist | `ChecklistPDFGenerator` | Tareas del evento |
 | Lista de equipamiento | `EquipmentListPDFGenerator` | Equipo asignado |
@@ -68,7 +67,6 @@ sequenceDiagram
 |---------|-----------|
 | `QuickQuotePDFGenerator.swift` | `SolennixFeatures/Common/PDFs/` |
 | `BudgetPDFGenerator.swift` | `SolennixFeatures/Common/PDFs/` |
-| `InvoicePDFGenerator.swift` | `SolennixFeatures/Common/PDFs/` |
 | `ContractPDFGenerator.swift` | `SolennixFeatures/Common/PDFs/` |
 | `ShoppingListPDFGenerator.swift` | `SolennixFeatures/Common/PDFs/` |
 | `ChecklistPDFGenerator.swift` | `SolennixFeatures/Common/PDFs/` |

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/Views/EventDetailView.swift
@@ -1067,7 +1067,6 @@ public struct EventDetailView: View {
             ("equipo", "Lista de Equipo", "wrench.and.screwdriver"),
             ("checklist", "Checklist", "checklist"),
             ("pagos", "Pagos", "dollarsign.circle"),
-            ("factura", "Factura", "doc.badge.arrow.up"),
         ]
     }
 
@@ -1160,20 +1159,6 @@ public struct EventDetailView: View {
                 client: client,
                 profile: profile,
                 payments: viewModel.payments
-            )
-        case "factura":
-            guard let client = viewModel.client else {
-                toastManager.show(message: "Cliente no disponible", type: .error)
-                return
-            }
-            filename = "Factura_\(client.name.replacingOccurrences(of: " ", with: "_")).pdf"
-            pdfData = InvoicePDFGenerator.generate(
-                event: event,
-                client: client,
-                profile: profile,
-                products: viewModel.products,
-                extras: viewModel.extras,
-                productNames: productNames
             )
         default:
             return

--- a/web/src/pages/Events/EventSummary.test.tsx
+++ b/web/src/pages/Events/EventSummary.test.tsx
@@ -23,7 +23,7 @@ import { EventSummary } from './EventSummary';
 import { eventService } from '../../services/eventService';
 import { productService } from '../../services/productService';
 import { paymentService } from '../../services/paymentService';
-import { generateBudgetPDF, generateContractPDF, generateInvoicePDF, generateShoppingListPDF } from '../../lib/pdfGenerator';
+import { generateBudgetPDF, generateContractPDF, generateShoppingListPDF } from '../../lib/pdfGenerator';
 import { logError } from '../../lib/errorHandler';
 import { installEventSummaryMocks } from './__tests__/eventSummaryFixtures';
 
@@ -111,7 +111,6 @@ vi.mock('../../services/subscriptionService', () => ({
 vi.mock('../../lib/pdfGenerator', () => ({
   generateBudgetPDF: vi.fn(),
   generateContractPDF: vi.fn(),
-  generateInvoicePDF: vi.fn(),
   generateShoppingListPDF: vi.fn(),
   generatePaymentReportPDF: vi.fn(),
 }));
@@ -370,18 +369,6 @@ describe('EventSummary — core', () => {
     expect(eventService.delete).not.toHaveBeenCalled();
   });
 
-  it('triggers invoice PDF generation in summary view', async () => {
-    render(<MemoryRouter><EventSummary /></MemoryRouter>);
-
-    await waitFor(() => {
-      expect(screen.getByText('Ana — Boda')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: /Más$/i }));
-    fireEvent.click(screen.getByText('Generar Factura'));
-    expect(generateInvoicePDF).toHaveBeenCalled();
-  });
-
   it('triggers shopping list PDF generation in ingredients view', async () => {
     render(<MemoryRouter><EventSummary /></MemoryRouter>);
 
@@ -408,10 +395,6 @@ describe('EventSummary — core', () => {
     fireEvent.click(screen.getByRole('button', { name: /Más$/i }));
     fireEvent.click(screen.getByText('Presupuesto'));
     expect(generateBudgetPDF).toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: /Más$/i }));
-    fireEvent.click(screen.getByText('Generar Factura'));
-    expect(generateInvoicePDF).toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: /Más$/i }));
     fireEvent.click(screen.getByText('Lista de Insumos'));

--- a/web/src/pages/Events/EventSummary.tsx
+++ b/web/src/pages/Events/EventSummary.tsx
@@ -41,7 +41,6 @@ import {
   generateContractPDF,
   generateShoppingListPDF,
   generateChecklistPDF,
-  generateInvoicePDF,
   generatePaymentReportPDF,
 } from "@/lib/pdfGenerator";
 import { logError } from "@/lib/errorHandler";


### PR DESCRIPTION
Closes #224

## Summary

Removes the "Generar Factura" / Invoice PDF action from the event detail UI across all platforms. The feature was never intended to be shipped.

## Changes

### Code
| Platform | File | Change |
|----------|------|--------|
| Web | `web/src/pages/Events/EventSummary.tsx` | Removed invoice button from PDF dropdown + import |
| Web | `web/src/pages/Events/EventSummary.test.tsx` | Removed invoice-related test cases |
| iOS | `ios/.../EventDetailView.swift` | Removed `factura` from pdfOptions + switch case |
| Android | `android/.../EventDetailScreen.kt` | Removed Factura ActionButton + import |

### Documentation (13 files)
- `docs/PRD/02_FEATURES.md` — removed invoice from PDF exports list + business_name field
- `docs/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md` — removed InvoicePDFGenerator from generators table
- `docs/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md` — removed InvoicePdfGenerator from generators table
- `docs/PRD/11_CURRENT_STATUS.md` — removed Factura from current PDF capabilities
- `docs/PRD/20_SERVER_SIDE_PDF_GENERATION.md` — removed Factura from PDF types table
- `docs/Web/Arquitectura General.md`, `Módulo Eventos.md`, `Sistema de PDFs.md`
- `docs/iOS/Módulo Eventos.md`, `Sistema de PDFs.md`
- `docs/Android/Módulo Eventos.md`, `Sistema de PDFs.md`

## Notes

- `generateInvoicePDF` utility function is intentionally preserved in `pdfGenerator.ts` — no UI entry points remain
- Pre-existing test failures in EventSummary.test.tsx are unrelated to this change (existed on `main`)