### PR TITLE
fix(web): restore quick client modal translations (#226)

### DIFF
--- a/web/src/i18n/locales/en/events.json
+++ b/web/src/i18n/locales/en/events.json
@@ -65,5 +65,22 @@
         "city": "City"
       }
     }
+  },
+  "quick_client": {
+    "title": "Quick Client",
+    "name": "Full Name",
+    "name_placeholder": "e.g. Maria Gonzalez",
+    "phone": "Phone",
+    "phone_placeholder": "e.g. 5551234567",
+    "email": "Email",
+    "email_placeholder": "e.g. maria@email.com",
+    "save": "Save client",
+    "saving": "Saving client...",
+    "error_creating": "Error creating client",
+    "validation": {
+      "name_min": "Name must be at least 2 characters",
+      "phone_min": "Phone must be at least 10 digits",
+      "email_invalid": "Invalid email"
+    }
   }
 }

--- a/web/src/i18n/locales/es/events.json
+++ b/web/src/i18n/locales/es/events.json
@@ -65,5 +65,22 @@
         "city": "Ciudad"
       }
     }
+  },
+  "quick_client": {
+    "title": "Nuevo Cliente Rápido",
+    "name": "Nombre Completo",
+    "name_placeholder": "Ej. María González",
+    "phone": "Teléfono",
+    "phone_placeholder": "Ej. 5551234567",
+    "email": "Email",
+    "email_placeholder": "Ej. maria@email.com",
+    "save": "Guardar cliente",
+    "saving": "Guardando cliente...",
+    "error_creating": "Error al crear el cliente",
+    "validation": {
+      "name_min": "El nombre debe tener al menos 2 caracteres",
+      "phone_min": "El teléfono debe tener al menos 10 dígitos",
+      "email_invalid": "Email inválido"
+    }
   }
 }


### PR DESCRIPTION
## What
- Add the missing `events.quick_client` translation namespace in Spanish and English.
- Restore localized labels, placeholders, validation copy, and submit button aria text used by `QuickClientModal`.

## Why
- Closes #226
- `QuickClientModal` tests and CI were failing because the component rendered unresolved i18n keys instead of translated strings.

## Scope
- [ ] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Low — localized copy only for the web quick client modal.
- Rollback: Revert commit `e0ec52aa`.