### PR TITLE
fix(web): align financial baseline tests with current event copy (#232)

### DIFF
--- a/web/src/pages/Events/EventSummary.variants.test.tsx
+++ b/web/src/pages/Events/EventSummary.variants.test.tsx
@@ -162,13 +162,18 @@ describe('EventSummary — header & display variants', () => {
   });
 
   // Consolidación con it.each — originalmente eran 5 tests separados
-  type DisplayExpectations = { present?: string[]; absent?: string[] };
+  type DisplayExpectations = { present?: string[]; absent?: string[]; customAssert?: () => void };
   const displayVariantCases: Array<[string, Record<string, unknown>, DisplayExpectations]> = [
     ['without time range', { start_time: null, end_time: null }, { absent: ['Horario:'] }],
     ['with only start_time', { start_time: '15:00', end_time: null }, { present: ['Horario', 'No definido'] }],
     ['with location', { location: 'Hacienda del Sol' }, { present: ['Hacienda del Sol'] }],
     ['without location', { location: null }, { absent: ['Ubicación:'] }],
-    ['with requires_invoice false', { requires_invoice: false }, { present: ['No requiere factura'] }],
+    ['with requires_invoice false', { requires_invoice: false, tax_amount: 160 }, {
+      present: ['IVA'],
+      customAssert: () => {
+        expect(screen.getByText('IVA').parentElement).toHaveTextContent('$0.00');
+      },
+    }],
   ];
   it.each(displayVariantCases)('renders event %s', async (_label, overrides, expectations) => {
     setupMocks(overrides);
@@ -184,6 +189,7 @@ describe('EventSummary — header & display variants', () => {
     for (const text of expectations.absent ?? []) {
       expect(screen.queryByText(text)).not.toBeInTheDocument();
     }
+    expectations.customAssert?.();
   });
 
   it.each([

--- a/web/src/pages/Events/components/EventFinancials.test.tsx
+++ b/web/src/pages/Events/components/EventFinancials.test.tsx
@@ -26,7 +26,7 @@ const renderWithForm = (ui: React.ReactNode, defaults?: Record<string, any>) =>
   render(<FormWrapper defaults={defaults}>{ui}</FormWrapper>);
 
 describe('EventFinancials', () => {
-  it('renders tax and totals summary', () => {
+  it('renders totals summary', () => {
     renderWithForm(
       <EventFinancials
         selectedProducts={[{ product_id: 'p1', quantity: 2, price: 100, discount: 0 }]}
@@ -35,7 +35,7 @@ describe('EventFinancials', () => {
       />
     );
 
-    expect(screen.getByText('IVA (16%):')).toBeInTheDocument();
+    expect(screen.getByText('Total del Evento:')).toBeInTheDocument();
     expect(screen.getByText('$232.00')).toBeInTheDocument();
   });
 
@@ -171,10 +171,7 @@ describe('EventFinancials', () => {
     expect(oneHundredFifty.length).toBeGreaterThanOrEqual(1);
   });
 
-  // ---------- BRANCH COVERAGE: tax_rate fallback || 16 ----------
-
-  it('uses default tax_rate of 16 when not provided in form', () => {
-    // By not providing tax_rate as a default, useWatch returns undefined and || 16 kicks in
+  it('renders financial summary when tax_rate is omitted from form defaults', () => {
     const FormWrapperMinimal: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       const methods = useForm({
         defaultValues: {
@@ -202,7 +199,7 @@ describe('EventFinancials', () => {
       </FormWrapperMinimal>,
     );
 
-    // Should still show "IVA (16%)" from the fallback
-    expect(screen.getByText('IVA (16%):')).toBeInTheDocument();
+    expect(screen.getByText('Total del Evento:')).toBeInTheDocument();
+    expect(screen.getByText('$116.00')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What
- align EventFinancials tests with the current financial summary copy rendered by the component
- update EventSummary variant coverage so the no-invoice case asserts the actual IVA card behavior
- keep this slice stacked on top of #230 because it depends on the restored events locale baseline

## Why
- PR #231 exposed additional stale frontend assertions after the i18n baseline was restored, so this follow-up slice isolates the remaining test drift without mixing it into #230

## Scope
- [ ] Backend
- [x] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: low; test-only changes on top of the #230 branch
- Rollback: revert commit `11ec075b`

Closes #232