### PR TITLE
chore(infra): enforce approved issue governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,12 @@ name: Bug report
 description: Report something broken in Solennix
 labels: ["bug", "type:bug", "status:ready", "priority:medium"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues start with `status:ready`.
+        Move them to `status:approved` once the fix scope is reviewed and approved for implementation.
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,12 @@ name: Feature request
 description: Propose a product or engineering improvement
 labels: ["enhancement", "type:feature", "status:ready", "priority:medium"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues start with `status:ready`.
+        Move them to `status:approved` once scope is reviewed and approved for implementation.
+
   - type: textarea
     id: problem
     attributes:
@@ -36,3 +42,5 @@ body:
         - Given ...
         - When ...
         - Then ...
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,7 +1,13 @@
 name: Refactor
 description: Technical debt or structural improvement
-labels: ["type:refactor", "type:infra", "status:ready", "priority:medium"]
+labels: ["type:refactor", "status:ready", "priority:medium"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues start with `status:ready`.
+        Move them to `status:approved` once the target architecture and migration plan are approved.
+
   - type: textarea
     id: current
     attributes:
@@ -22,3 +28,5 @@ body:
     attributes:
       label: Risks and migration plan
       description: Include rollback strategy.
+    validations:
+      required: true

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -18,6 +18,10 @@
   color: 5319e7
   description: Code refactor without behavior change
 
+- name: type:chore
+  color: cfd3d7
+  description: Maintenance/tooling
+
 - name: type:docs
   color: 0075ca
   description: Documentation updates
@@ -69,6 +73,10 @@
 - name: status:ready
   color: 0e8a16
   description: Ready for implementation
+
+- name: status:approved
+  color: 0e8a16
+  description: Approved for implementation
 
 - name: status:in-progress
   color: 1d76db

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+## Linked Issue
+- Closes #
+
 ## What
 - 
 
@@ -13,6 +16,8 @@
 
 ## Checklist
 - [ ] Issue linked
+- [ ] Linked issue has `status:approved`
+- [ ] Exactly one `type:*` label on the PR
 - [ ] Tests added/updated
 - [ ] CI green
 - [ ] Cross-platform parity reviewed

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,95 @@
+name: PR Governance
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  issue-reference:
+    name: Check Issue Reference
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate linked issue in PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const match = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/i);
+
+            if (!match) {
+              core.setFailed('PR body must include `Closes #<issue-number>` (or `Fixes` / `Resolves`).');
+              return;
+            }
+
+            core.info(`Linked issue #${match[1]} found in PR body.`);
+
+  issue-approved:
+    name: Check Issue Has status:approved
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate linked issue approval status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const match = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\b/i);
+
+            if (!match) {
+              core.setFailed('Cannot validate issue approval without a linked issue in the PR body.');
+              return;
+            }
+
+            const issue_number = Number(match[1]);
+            const { owner, repo } = context.repo;
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const names = labels.map((label) => label.name);
+            if (!names.includes('status:approved')) {
+              const statusLabels = names.filter((name) => name.startsWith('status:'));
+              core.setFailed(
+                `Linked issue #${issue_number} must have label \'status:approved\'. Current status labels: ${statusLabels.join(', ') || 'none'}.`,
+              );
+              return;
+            }
+
+            core.info(`Issue #${issue_number} is approved.`);
+
+  pr-type-label:
+    name: Check PR Has type:* Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR type label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const typeLabels = labels
+              .map((label) => label.name)
+              .filter((name) => name.startsWith('type:'));
+
+            if (typeLabels.length !== 1) {
+              core.setFailed(
+                `PR must have exactly one type:* label. Found ${typeLabels.length}: ${typeLabels.join(', ') || 'none'}.`,
+              );
+              return;
+            }
+
+            core.info(`PR type label OK: ${typeLabels[0]}`);


### PR DESCRIPTION
## Linked Issue
- Closes #237

## What
- Add `status:approved` to the versioned label catalog and explain the `ready -> approved` transition in issue templates
- Add PR governance checks for linked issues, approved issues, and exactly one `type:*` label
- Update the PR template so contributors follow the same approval workflow documented by the repo

## Why
- The live GitHub labels and the versioned repo process had drifted
- We need a deterministic gate before review so implementation PRs only start from approved issues

## Scope
- [ ] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Linked issue has `status:approved`
- [x] Exactly one `type:*` label on the PR
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: PRs without approved issues will start failing until maintainers apply the right labels
- Rollback: Revert `.github/workflows/pr-governance.yml` and the template/label changes