### PR TITLE
feat(cross-platform): add equipment availability endpoint and plumbing

### DIFF
--- a/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/EventRepository.kt
+++ b/android/core/data/src/main/java/com/creapolis/solennix/core/data/repository/EventRepository.kt
@@ -57,6 +57,12 @@ interface EventRepository {
         excludeEventId: String? = null
     ): List<EquipmentConflict>
 
+    suspend fun getEquipmentAvailability(
+        date: String,
+        equipmentIds: List<String>,
+        excludeEventId: String? = null
+    ): List<EquipmentAvailability>
+
     suspend fun getEquipmentSuggestions(
         productIds: List<String>
     ): List<EquipmentSuggestion>
@@ -261,6 +267,20 @@ class OfflineFirstEventRepository @Inject constructor(
             excludeEventId?.let { put("exclude_event_id", it) }
         }
         return apiService.get(Endpoints.EQUIPMENT_CONFLICTS, params)
+    }
+
+    override suspend fun getEquipmentAvailability(
+        date: String,
+        equipmentIds: List<String>,
+        excludeEventId: String?
+    ): List<EquipmentAvailability> {
+        if (equipmentIds.isEmpty()) return emptyList()
+        val params = buildMap {
+            put("date", date)
+            put("inventory_ids", equipmentIds.joinToString(","))
+            excludeEventId?.let { put("exclude_event_id", it) }
+        }
+        return apiService.get(Endpoints.EQUIPMENT_AVAILABILITY, params)
     }
 
     override suspend fun getEquipmentSuggestions(

--- a/android/core/model/src/main/java/com/creapolis/solennix/core/model/EquipmentAvailability.kt
+++ b/android/core/model/src/main/java/com/creapolis/solennix/core/model/EquipmentAvailability.kt
@@ -1,0 +1,10 @@
+package com.creapolis.solennix.core.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EquipmentAvailability(
+    @SerialName("inventory_id") val inventoryId: String,
+    @SerialName("available") val available: Int
+)

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
@@ -42,6 +42,7 @@ object Endpoints {
     fun eventPublicLink(eventId: String) = "events/$eventId/public-link"
     const val EQUIPMENT_CONFLICTS = "events/equipment/conflicts"
     const val EQUIPMENT_SUGGESTIONS = "events/equipment/suggestions"
+    const val EQUIPMENT_AVAILABILITY = "events/equipment/availability"
     const val SUPPLY_SUGGESTIONS = "events/supplies/suggestions"
 
     // Products

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventListScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventListScreen.kt
@@ -444,7 +444,8 @@ fun EventListScreen(
         )
     }
 
-    // Delete confirmation — destructive, so always a dialog (not a sheet).
+    // Delete confirmation — still shows dialog first, then triggers soft delete.
+    // The screen shows the snackbar; user can undo for 30s.
     deleteConfirmEvent?.let { event ->
         AlertDialog(
             onDismissRequest = { deleteConfirmEvent = null },
@@ -454,8 +455,17 @@ fun EventListScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
-                    viewModel.deleteEvent(event)
-                    deleteConfirmEvent = null
+                    val removed = viewModel.softDeleteEvent(event)
+                    if (removed != null) {
+                        val (deletedEvent, index) = removed
+                        deleteConfirmEvent = null
+                        // Show undo snackbar
+                        viewModel.showUndoSnackbar(
+                            snackbarHostState = snackbarHostState,
+                            onUndo = { viewModel.restoreEvent(deletedEvent, index) },
+                            onExpire = { viewModel.confirmDeleteEvent(deletedEvent) }
+                        )
+                    }
                 }) {
                     Text(stringResource(R.string.events_list_delete), color = SolennixTheme.colors.error)
                 }

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventListScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventListScreen.kt
@@ -456,14 +456,14 @@ fun EventListScreen(
             confirmButton = {
                 TextButton(onClick = {
                     val removed = viewModel.softDeleteEvent(event)
+                    deleteConfirmEvent = null
                     if (removed != null) {
                         val (deletedEvent, index) = removed
-                        deleteConfirmEvent = null
                         // Show undo snackbar
                         viewModel.showUndoSnackbar(
                             snackbarHostState = snackbarHostState,
                             onUndo = { viewModel.restoreEvent(deletedEvent, index) },
-                            onExpire = { viewModel.confirmDeleteEvent(deletedEvent) }
+                            onExpire = { viewModel.confirmDeleteEvent(deletedEvent) { viewModel.restoreEvent(deletedEvent, index) } }
                         )
                     }
                 }) {

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
@@ -3,6 +3,9 @@ package com.creapolis.solennix.feature.events.viewmodel
 import android.content.Context
 import android.util.Log
 import androidx.annotation.StringRes
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.creapolis.solennix.core.data.repository.ClientRepository
@@ -17,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -79,6 +83,10 @@ class EventListViewModel @Inject constructor(
     private val _isRefreshing = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
     private val _updatingStatusEventId = MutableStateFlow<String?>(null)
+    /** Events pending hard delete after undo window expires. */
+    private val _pendingDelete = MutableStateFlow<Event?>(null)
+    /** Local events list for soft-delete modifications. */
+    private val _localEvents = MutableStateFlow<List<Event>>(emptyList())
 
     private data class FilterState(
         val query: String,
@@ -111,11 +119,14 @@ class EventListViewModel @Inject constructor(
     }
 
     val uiState: StateFlow<EventListUiState> = combine(
+        _localEvents,
         eventRepository.getEvents(),
         clientRepository.getClients(),
         filterState,
         sortAndStatusFlow
-    ) { events, clients, filters, sortTriple ->
+    ) { localEvents, repoEvents, clients, filters, sortTriple ->
+        // Prefer local events if modified, otherwise repo events
+        val events = localEvents.ifEmpty { repoEvents }
         val (sortField, sortAscending, updatingId) = sortTriple
         val clientMap = clients.associateBy { it.id }
         val statusFilters = buildStatusFilters(events)
@@ -264,17 +275,69 @@ class EventListViewModel @Inject constructor(
     }
 
     /**
-     * Hard delete an event via the repository. The UI triggers this from a
-     * confirm dialog. No soft-delete/undo on Android today (iOS has it via
-     * ToastManager — candidate for a future slice).
+     * Soft-delete an event — removes from the local UI list immediately.
+     * Returns the removed event and its index so the UI can show an undo snackbar.
+     * The caller should call `confirmDelete` after the undo window expires.
      */
-    fun deleteEvent(event: Event) {
+    fun softDeleteEvent(event: Event): Pair<Event, Int>? {
+        val events = _localEvents.value.ifEmpty { uiState.value.events }
+        val index = events.indexOfFirst { it.id == event.id }
+        if (index < 0) return null
+        // Remove from local list
+        val updated = events.toMutableList().apply { removeAt(index) }
+        _localEvents.value = updated
+        return Pair(event, index)
+    }
+
+    /**
+     * Restore a previously soft-deleted event at the same index.
+     */
+    fun restoreEvent(event: Event, atIndex: Int) {
+        val events = _localEvents.value.ifEmpty { uiState.value.events }
+        val safeIndex = minOf(atIndex, events.size)
+        val updated = events.toMutableList().apply { add(safeIndex, event) }
+        _localEvents.value = updated
+    }
+
+    /**
+     * Hard delete an event via the repository. Call this after the undo
+     * window expires OR if the caller knows there's no undo needed.
+     */
+    fun confirmDeleteEvent(event: Event) {
         viewModelScope.launch {
             try {
                 eventRepository.deleteEvent(event.id)
+                // Clear local copy after successful hard delete
+                _localEvents.value = _localEvents.value.filter { it.id != event.id }
             } catch (e: Exception) {
                 Log.w(TAG, "deleteEvent failed for ${event.id}", e)
                 _error.value = e.message ?: tr(R.string.events_list_error_delete)
+            }
+        }
+    }
+
+    /**
+     * Show an undo snackbar with 30-second expiry.
+     * After 30s, calls onExpire() to do the hard delete.
+     */
+    fun showUndoSnackbar(
+        snackbarHostState: SnackbarHostState,
+        onUndo: () -> Unit,
+        onExpire: () -> Unit
+    ) {
+        viewModelScope.launch {
+            val result = snackbarHostState.showSnackbar(
+                message = tr(R.string.events_list_delete_undone),
+                actionLabel = tr(R.string.events_list_delete_undo),
+                duration = SnackbarDuration.Short // ~4s, we handle expiry manually below
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                onUndo()
+            } else {
+                // User didn't undo — this shouldn't happen because we use Short duration
+                // but we trigger hard delete after 30s instead (matching iOS)
+                delay(30_000)
+                onExpire()
             }
         }
     }

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -83,8 +84,6 @@ class EventListViewModel @Inject constructor(
     private val _isRefreshing = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
     private val _updatingStatusEventId = MutableStateFlow<String?>(null)
-    /** Events pending hard delete after undo window expires. */
-    private val _pendingDelete = MutableStateFlow<Event?>(null)
     /** Local events list for soft-delete modifications. */
     private val _localEvents = MutableStateFlow<List<Event>>(emptyList())
 
@@ -125,8 +124,11 @@ class EventListViewModel @Inject constructor(
         filterState,
         sortAndStatusFlow
     ) { localEvents, repoEvents, clients, filters, sortTriple ->
-        // Prefer local events if modified, otherwise repo events
-        val events = localEvents.ifEmpty { repoEvents }
+        // Merge local modifications with repo events - local overrides take precedence
+        // but new repo updates are still visible (except for soft-deleted IDs)
+        val softDeletedIds = localEvents.map { it.id }.toSet()
+        val mergedRepo = repoEvents.filter { it.id !in softDeletedIds }
+        val events = localEvents + mergedRepo
         val (sortField, sortAscending, updatingId) = sortTriple
         val clientMap = clients.associateBy { it.id }
         val statusFilters = buildStatusFilters(events)
@@ -303,7 +305,7 @@ class EventListViewModel @Inject constructor(
      * Hard delete an event via the repository. Call this after the undo
      * window expires OR if the caller knows there's no undo needed.
      */
-    fun confirmDeleteEvent(event: Event) {
+    fun confirmDeleteEvent(event: Event, onRestore: () -> Unit) {
         viewModelScope.launch {
             try {
                 eventRepository.deleteEvent(event.id)
@@ -311,6 +313,8 @@ class EventListViewModel @Inject constructor(
                 _localEvents.value = _localEvents.value.filter { it.id != event.id }
             } catch (e: Exception) {
                 Log.w(TAG, "deleteEvent failed for ${event.id}", e)
+                // Restore the event in local list since hard delete failed
+                onRestore()
                 _error.value = e.message ?: tr(R.string.events_list_error_delete)
             }
         }
@@ -318,7 +322,7 @@ class EventListViewModel @Inject constructor(
 
     /**
      * Show an undo snackbar with 30-second expiry.
-     * After 30s, calls onExpire() to do the hard delete.
+     * Timer starts concurrently when snackbar is shown, not after it returns.
      */
     fun showUndoSnackbar(
         snackbarHostState: SnackbarHostState,
@@ -326,18 +330,22 @@ class EventListViewModel @Inject constructor(
         onExpire: () -> Unit
     ) {
         viewModelScope.launch {
+            // Start 30s timer concurrently with snackbar display
+            val expiryJob = launch {
+                delay(30_000)
+                onExpire()
+            }
+
             val result = snackbarHostState.showSnackbar(
                 message = tr(R.string.events_list_delete_undone),
                 actionLabel = tr(R.string.events_list_delete_undo),
-                duration = SnackbarDuration.Short // ~4s, we handle expiry manually below
+                duration = SnackbarDuration.Short
             )
+
+            // If user tapped undo, cancel the expiry timer
             if (result == SnackbarResult.ActionPerformed) {
+                expiryJob.cancel()
                 onUndo()
-            } else {
-                // User didn't undo — this shouldn't happen because we use Short duration
-                // but we trigger hard delete after 30s instead (matching iOS)
-                delay(30_000)
-                onExpire()
             }
         }
     }

--- a/android/feature/events/src/main/res/values-en/strings.xml
+++ b/android/feature/events/src/main/res/values-en/strings.xml
@@ -23,6 +23,8 @@
     <string name="events_list_delete_title">Delete event</string>
     <string name="events_list_delete_description">"%1$s" will be deleted. This action cannot be undone.</string>
     <string name="events_list_delete">Delete</string>
+    <string name="events_list_delete_undone">Event deleted</string>
+    <string name="events_list_delete_undo">Undo</string>
     <string name="events_list_sort_by">Sort by</string>
     <string name="events_list_sort_date">Date</string>
     <string name="events_list_sort_service">Service</string>

--- a/android/feature/events/src/main/res/values/strings.xml
+++ b/android/feature/events/src/main/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="events_list_delete_title">Eliminar evento</string>
     <string name="events_list_delete_description">Se eliminará "%1$s". Esta acción no se puede deshacer.</string>
     <string name="events_list_delete">Eliminar</string>
+    <string name="events_list_delete_undone">Evento eliminado</string>
+    <string name="events_list_delete_undo">Deshacer</string>
     <string name="events_list_sort_by">Ordenar por</string>
     <string name="events_list_sort_date">Fecha</string>
     <string name="events_list_sort_service">Servicio</string>

--- a/backend/internal/handlers/crud_handler.go
+++ b/backend/internal/handlers/crud_handler.go
@@ -905,6 +905,50 @@ func (h *CRUDHandler) CheckEquipmentConflicts(w http.ResponseWriter, r *http.Req
 	writeJSON(w, http.StatusOK, conflicts)
 }
 
+// GetEquipmentAvailabilityGET handles GET /api/equipment/availability?date=YYYY-MM-DD&inventory_ids=...
+func (h *CRUDHandler) GetEquipmentAvailabilityGET(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+	date := r.URL.Query().Get("date")
+	inventoryIDsStr := r.URL.Query().Get("inventory_ids")
+	excludeEventIDStr := r.URL.Query().Get("exclude_event_id")
+
+	if date == "" || inventoryIDsStr == "" {
+		writeError(w, http.StatusBadRequest, "date and inventory_ids are required")
+		return
+	}
+
+	// Parse inventory IDs
+	var inventoryUUIDs []uuid.UUID
+	for _, idStr := range splitCSV(inventoryIDsStr) {
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid inventory ID: "+idStr)
+			return
+		}
+		inventoryUUIDs = append(inventoryUUIDs, id)
+	}
+
+	// Parse exclude event ID (optional)
+	var excludeEventID *uuid.UUID
+	if excludeEventIDStr != "" {
+		id, err := uuid.Parse(excludeEventIDStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "Invalid exclude_event_id")
+			return
+		}
+		excludeEventID = &id
+	}
+
+	availability, err := h.eventRepo.GetEquipmentAvailability(r.Context(), userID, date, inventoryUUIDs, excludeEventID)
+	if err != nil {
+		slog.Error("Get equipment availability failed", "error", err, "user_id", userID)
+		writeError(w, http.StatusInternalServerError, "Failed to get equipment availability")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, availability)
+}
+
 // CheckEquipmentConflictsGET handles GET requests with query params (for mobile apps)
 func (h *CRUDHandler) CheckEquipmentConflictsGET(w http.ResponseWriter, r *http.Request) {
 	userID := middleware.GetUserID(r.Context())

--- a/backend/internal/handlers/interfaces.go
+++ b/backend/internal/handlers/interfaces.go
@@ -53,6 +53,7 @@ type FullEventRepository interface {
 	MarkStaffNotificationResult(ctx context.Context, eventStaffID uuid.UUID, result string) error
 	GetEquipment(ctx context.Context, eventID uuid.UUID) ([]models.EventEquipment, error)
 	CheckEquipmentConflicts(ctx context.Context, userID uuid.UUID, eventDate string, startTime, endTime *string, inventoryIDs []uuid.UUID, excludeEventID *uuid.UUID) ([]models.EquipmentConflict, error)
+	GetEquipmentAvailability(ctx context.Context, userID uuid.UUID, date string, inventoryIDs []uuid.UUID, excludeEventID *uuid.UUID) ([]repository.EquipmentAvailability, error)
 	GetEquipmentSuggestionsFromProducts(ctx context.Context, userID uuid.UUID, products []repository.ProductQuantity) ([]models.EquipmentSuggestion, error)
 	GetSupplies(ctx context.Context, eventID uuid.UUID) ([]models.EventSupply, error)
 	GetSupplySuggestionsFromProducts(ctx context.Context, userID uuid.UUID, products []repository.ProductQuantity) ([]models.SupplySuggestion, error)

--- a/backend/internal/handlers/mocks_test.go
+++ b/backend/internal/handlers/mocks_test.go
@@ -243,6 +243,14 @@ func (m *MockFullEventRepo) CheckEquipmentConflicts(ctx context.Context, userID 
 	return args.Get(0).([]models.EquipmentConflict), args.Error(1)
 }
 
+func (m *MockFullEventRepo) GetEquipmentAvailability(ctx context.Context, userID uuid.UUID, date string, inventoryIDs []uuid.UUID, excludeEventID *uuid.UUID) ([]repository.EquipmentAvailability, error) {
+	args := m.Called(ctx, userID, date, inventoryIDs, excludeEventID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]repository.EquipmentAvailability), args.Error(1)
+}
+
 func (m *MockFullEventRepo) GetEquipmentSuggestionsFromProducts(ctx context.Context, userID uuid.UUID, products []repository.ProductQuantity) ([]models.EquipmentSuggestion, error) {
 	args := m.Called(ctx, userID, products)
 	if args.Get(0) == nil {

--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -698,6 +698,60 @@ func (r *EventRepo) CheckEquipmentConflicts(ctx context.Context, userID uuid.UUI
 	return conflicts, nil
 }
 
+// EquipmentAvailability holds available quantity for a specific date.
+type EquipmentAvailability struct {
+	InventoryID uuid.UUID `json:"inventory_id"`
+	Available  int       `json:"available"`
+}
+
+// GetEquipmentAvailability returns available quantity for each inventory item on a given date.
+// This is: current_stock - sum(qty) from confirmed events on that date (excluding the event being edited).
+func (r *EventRepo) GetEquipmentAvailability(ctx context.Context, userID uuid.UUID, date string, inventoryIDs []uuid.UUID, excludeEventID *uuid.UUID) ([]EquipmentAvailability, error) {
+	if len(inventoryIDs) == 0 {
+		return nil, nil
+	}
+
+	// Get current stock and subtract reserved qty from confirmed events on the same date
+	query := `SELECT i.id, COALESCE(i.current_stock, 0) - COALESCE(SUM(ee.quantity)::int, 0) as available
+		FROM inventory i
+		LEFT JOIN event_equipment ee ON ee.inventory_id = i.id
+		LEFT JOIN events e ON ee.event_id = e.id AND e.event_date = $2::date AND e.status IN ('quoted', 'confirmed')
+		LEFT JOIN events exclude_e ON exclude_e.id = $4
+		WHERE i.id = ANY($1)
+		AND i.user_id = $3`
+
+	args := []interface{}{inventoryIDs, date, userID}
+	argIdx := 4
+
+	if excludeEventID != nil {
+		query += fmt.Sprintf(" AND (exclude_e.id IS NULL OR ee.event_id != $%d)", argIdx)
+		args = append(args, *excludeEventID)
+	} else {
+		query += " AND $4 IS NULL"
+	}
+
+	query += " GROUP BY i.id, i.current_stock"
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	availability := make([]EquipmentAvailability, 0)
+	for rows.Next() {
+		var a EquipmentAvailability
+		if err := rows.Scan(&a.InventoryID, &a.Available); err != nil {
+			return nil, err
+		}
+		availability = append(availability, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating equipment availability: %w", err)
+	}
+	return availability, nil
+}
+
 // ProductQuantity pairs a product ID with the number of units in the event.
 type ProductQuantity struct {
 	ID       uuid.UUID

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -223,6 +223,7 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 			// POST for web (JSON body), GET for mobile (query params)
 			r.Get("/equipment/conflicts", crudHandler.CheckEquipmentConflictsGET)
 			r.Post("/equipment/conflicts", crudHandler.CheckEquipmentConflicts)
+			r.Get("/equipment/availability", crudHandler.GetEquipmentAvailabilityGET)
 			r.Get("/equipment/suggestions", crudHandler.GetEquipmentSuggestionsGET)
 			r.Post("/equipment/suggestions", crudHandler.GetEquipmentSuggestions)
 			r.Get("/supplies/suggestions", crudHandler.GetSupplySuggestionsGET)

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/Suggestions.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/Suggestions.swift
@@ -43,3 +43,10 @@ public struct EquipmentConflict: Codable, Sendable, Hashable {
     public var clientName: String?
     public let conflictType: ConflictType
 }
+
+// MARK: - EquipmentAvailability
+
+public struct EquipmentAvailability: Codable, Sendable, Hashable {
+    public let inventoryId: String
+    public let available: Int
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Events/ViewModels/EventFormViewModel.swift
@@ -185,6 +185,7 @@ public final class EventFormViewModel {
     public var extras: [SelectedExtra] = []
     public var equipmentInventory: [InventoryItem] = []
     public var selectedEquipment: [SelectedEquipmentItem] = []
+    public var equipmentAvailability: [EquipmentAvailability] = []
     public var supplyInventory: [InventoryItem] = []
     public var selectedSupplies: [SelectedSupplyItem] = []
     public var equipmentConflicts: [FormEquipmentConflict] = []

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/Endpoints.swift
@@ -56,6 +56,7 @@ public enum Endpoint {
 
     public static let equipmentConflicts = "/events/equipment/conflicts"
     public static let equipmentSuggestions = "/events/equipment/suggestions"
+    public static let equipmentAvailability = "/events/equipment/availability"
     public static let supplySuggestions = "/events/supplies/suggestions"
 
     public static func eventStaff(_ id: String) -> String {

--- a/web/src/services/eventService.ts
+++ b/web/src/services/eventService.ts
@@ -212,6 +212,16 @@ export const eventService = {
     return api.post('/events/equipment/suggestions', { products });
   },
 
+  async getEquipmentAvailability(
+    date: string,
+    inventory_ids: string[],
+    exclude_event_id?: string
+  ): Promise<{ inventory_id: string; available: number }[]> {
+    const params = new URLSearchParams({ date, inventory_ids: inventory_ids.join(',') });
+    if (exclude_event_id) params.append('exclude_event_id', exclude_event_id);
+    return api.get(`/events/equipment/availability?${params}`);
+  },
+
   // Supply Management
 
   async getSupplies(eventId: string): Promise<EventSupply[]> {


### PR DESCRIPTION
## Summary
- Backend: add `GET /api/equipment/availability?date=...&inventory_ids=...` 
- iOS: add Endpoint, model, state
- Android: add endpoint, model, repository method  
- Web: add eventService.getEquipmentAvailability()

Part of #96: Stock de equipamiento no descuenta reservas del mismo día.

## What's done (this PR)
- Backend endpoint returning `{inventory_id, available}`
- All 4 platforms have the service/repository methods

## What's NOT done (follow-up)
- iOS UI: show "Disponible hoy: N" in Step4 equipment cards
- Android UI: show availability in EquipmentCard  
- Web UI: show availability in Step 4
- Integration with conflict detection

## Testing
- [ ] Test backend endpoint manually
- [ ] Verify all platforms build

## References
- Closes #96