### PR TITLE
feat(calendar): full cross-platform parity — status filter, iCal export, FAB, retry, event nav

### DIFF
--- a/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
+++ b/android/app/src/main/java/com/creapolis/solennix/ui/navigation/CompactBottomNavLayout.kt
@@ -180,6 +180,7 @@ fun CompactBottomNavLayout(initialDeepLinkRoute: String? = null) {
                 CalendarScreen(
                     viewModel = hiltViewModel(),
                     onEventClick = { id -> navController.navigate("event_detail/$id") },
+                    onCreateEventClick = { date -> navController.navigate("event_form?eventId=&date=${date}") },
                     onSearchClick = { navController.navigate(buildSearchRoute()) }
                 )
             }

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/ApiService.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/ApiService.kt
@@ -132,6 +132,15 @@ class ApiService @Inject constructor(
         }.body(type)
     }
 
+    suspend fun getRawText(
+        endpoint: String,
+        params: Map<String, String> = emptyMap()
+    ): String = wrapError {
+        client.httpClient.get(endpoint) {
+            params.forEach { (key, value) -> parameter(key, value) }
+        }.body()
+    }
+
     suspend fun upload(
         endpoint: String,
         fileBytes: ByteArray,

--- a/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
+++ b/android/core/network/src/main/java/com/creapolis/solennix/core/network/Endpoints.kt
@@ -31,6 +31,7 @@ object Endpoints {
     const val EVENTS = "events"
     const val UPCOMING_EVENTS = "events/upcoming"
     const val EVENTS_SEARCH = "events/search"
+    const val EVENTS_ICAL = "events/ical"
     fun event(id: String) = "events/$id"
     fun eventProducts(id: String) = "events/$id/products"
     fun eventExtras(id: String) = "events/$id/extras"

--- a/android/feature/calendar/src/main/java/com/creapolis/solennix/feature/calendar/ui/CalendarScreen.kt
+++ b/android/feature/calendar/src/main/java/com/creapolis/solennix/feature/calendar/ui/CalendarScreen.kt
@@ -55,8 +55,14 @@ import com.creapolis.solennix.feature.calendar.viewmodel.CalendarError
 import com.creapolis.solennix.feature.calendar.viewmodel.CalendarUiState
 import com.creapolis.solennix.feature.calendar.viewmodel.CalendarViewModel
 import kotlinx.coroutines.launch
+import java.io.File
 import java.time.LocalDate
 import java.time.YearMonth
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.FileProvider
+import android.content.Intent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import com.creapolis.solennix.core.model.extensions.parseFlexibleDate
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
@@ -67,11 +73,14 @@ import java.util.*
 fun CalendarScreen(
     viewModel: CalendarViewModel,
     onEventClick: (String) -> Unit,
+    onCreateEventClick: (LocalDate) -> Unit = {},
     onSearchClick: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
+    val isExportingCalendar by viewModel.isExportingCalendar.collectAsStateWithLifecycle()
     val isWideScreen = LocalIsWideScreen.current
+    val context = LocalContext.current
     var showBlockDialog by remember { mutableStateOf(false) }
 
     LifecycleResumeEffect(viewModel) {
@@ -91,12 +100,14 @@ fun CalendarScreen(
     val loadFailedMessage = stringResource(R.string.calendar_error_load_failed)
     val blockFailedMessage = stringResource(R.string.calendar_error_block_failed)
     val unblockFailedMessage = stringResource(R.string.calendar_error_unblock_failed)
+    val exportFailedMessage = stringResource(R.string.calendar_error_export_failed)
 
     LaunchedEffect(error) {
         val message = when (error) {
             CalendarError.LoadFailed -> loadFailedMessage
             CalendarError.BlockFailed -> blockFailedMessage
             CalendarError.UnblockFailed -> unblockFailedMessage
+            CalendarError.ExportFailed -> exportFailedMessage
             null -> null
         }
         if (message != null) {
@@ -107,12 +118,46 @@ fun CalendarScreen(
         }
     }
 
+    // Share .ics file when the ViewModel emits a successful export
+    LaunchedEffect(Unit) {
+        viewModel.exportIcalResult.collect { icsContent ->
+            val file = withContext(Dispatchers.IO) {
+                File(context.cacheDir, "solennix-calendar.ics").also { it.writeText(icsContent) }
+            }
+            val uri = FileProvider.getUriForFile(
+                context, "${context.packageName}.fileprovider", file
+            )
+            val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/calendar"
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(Intent.createChooser(sendIntent, null))
+        }
+    }
+
     Scaffold(
         topBar = {
             SolennixSectionTopAppBar(
                 title = stringResource(R.string.calendar_title),
                 onSearchClick = onSearchClick,
                 actions = {
+                    IconButton(
+                        onClick = { viewModel.exportCalendar() },
+                        enabled = !isExportingCalendar
+                    ) {
+                        if (isExportingCalendar) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(
+                                Icons.Default.IosShare,
+                                contentDescription = stringResource(R.string.calendar_export_ical)
+                            )
+                        }
+                    }
                     IconButton(onClick = {
                         viewModel.loadAllUnavailableDates()
                         showManageUnavailableSheet = true
@@ -125,7 +170,19 @@ fun CalendarScreen(
                 }
             )
         },
-        snackbarHost = { SnackbarHost(snackbarHostState) }
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { onCreateEventClick(uiState.selectedDate) },
+                containerColor = SolennixTheme.colors.primary,
+                contentColor = androidx.compose.ui.graphics.Color.White
+            ) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = stringResource(R.string.calendar_new_event)
+                )
+            }
+        }
     ) { padding ->
         Column(modifier = Modifier.padding(padding)) {
             StatusFilterChips(

--- a/android/feature/calendar/src/main/java/com/creapolis/solennix/feature/calendar/viewmodel/CalendarViewModel.kt
+++ b/android/feature/calendar/src/main/java/com/creapolis/solennix/feature/calendar/viewmodel/CalendarViewModel.kt
@@ -31,7 +31,8 @@ private const val TAG = "CalendarViewModel"
 enum class CalendarError {
     LoadFailed,
     BlockFailed,
-    UnblockFailed
+    UnblockFailed,
+    ExportFailed
 }
 
 data class CalendarUiState(
@@ -72,6 +73,12 @@ class CalendarViewModel @Inject constructor(
     fun clearError() {
         _error.value = null
     }
+
+    private val _isExportingCalendar = MutableStateFlow(false)
+    val isExportingCalendar: StateFlow<Boolean> = _isExportingCalendar.asStateFlow()
+
+    private val _exportIcalResult = MutableSharedFlow<String>()
+    val exportIcalResult: SharedFlow<String> = _exportIcalResult.asSharedFlow()
 
     fun setStatusFilter(filter: EventStatus?) {
         _statusFilter.value = filter
@@ -264,6 +271,27 @@ class CalendarViewModel @Inject constructor(
     fun isDateBlocked(date: LocalDate): Boolean = existingBlockFor(date) != null
 
     fun getUnavailableDateFor(date: LocalDate): UnavailableDate? = existingBlockFor(date)
+
+    fun exportCalendar() {
+        viewModelScope.launch {
+            _isExportingCalendar.value = true
+            try {
+                val month = _currentMonth.value
+                val start = month.atDay(1).toString()
+                val end = month.atEndOfMonth().toString()
+                val content = apiService.getRawText(
+                    Endpoints.EVENTS_ICAL,
+                    mapOf("start" to start, "end" to end)
+                )
+                _exportIcalResult.emit(content)
+            } catch (e: Exception) {
+                Log.e(TAG, "exportCalendar failed", e)
+                _error.value = CalendarError.ExportFailed
+            } finally {
+                _isExportingCalendar.value = false
+            }
+        }
+    }
 
     private fun existingBlockFor(date: LocalDate): UnavailableDate? {
         val dateStr = date.toString()

--- a/android/feature/calendar/src/main/res/values/strings.xml
+++ b/android/feature/calendar/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="calendar_previous_month">Mes anterior</string>
     <string name="calendar_next_month">Mes siguiente</string>
     <string name="calendar_manage_blocks">Gestionar Bloqueos</string>
+    <string name="calendar_new_event">Nuevo evento</string>
 
     <!-- Empty / day states -->
     <string name="calendar_no_events_scheduled">No hay eventos programados</string>
@@ -55,7 +56,9 @@
     <string name="calendar_error_load_failed">No se pudieron cargar los eventos</string>
     <string name="calendar_error_block_failed">No se pudo bloquear la fecha</string>
     <string name="calendar_error_unblock_failed">No se pudo desbloquear</string>
+    <string name="calendar_error_export_failed">No se pudo exportar el calendario</string>
     <string name="calendar_error_retry">Reintentar</string>
+    <string name="calendar_export_ical">Exportar .ics</string>
 
     <!-- Shared dialog actions (scoped to the calendar module to avoid
          cross-module R dependencies on :app or :core:designsystem which

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventListScreen.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/ui/EventListScreen.kt
@@ -456,14 +456,24 @@ fun EventListScreen(
             confirmButton = {
                 TextButton(onClick = {
                     val removed = viewModel.softDeleteEvent(event)
+<<<<<<< HEAD
                     deleteConfirmEvent = null
                     if (removed != null) {
                         val (deletedEvent, index) = removed
+=======
+                    if (removed != null) {
+                        val (deletedEvent, index) = removed
+                        deleteConfirmEvent = null
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
                         // Show undo snackbar
                         viewModel.showUndoSnackbar(
                             snackbarHostState = snackbarHostState,
                             onUndo = { viewModel.restoreEvent(deletedEvent, index) },
+<<<<<<< HEAD
                             onExpire = { viewModel.confirmDeleteEvent(deletedEvent) { viewModel.restoreEvent(deletedEvent, index) } }
+=======
+                            onExpire = { viewModel.confirmDeleteEvent(deletedEvent) }
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
                         )
                     }
                 }) {

--- a/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
+++ b/android/feature/events/src/main/java/com/creapolis/solennix/feature/events/viewmodel/EventListViewModel.kt
@@ -20,7 +20,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+<<<<<<< HEAD
 import kotlinx.coroutines.Job
+=======
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -84,6 +87,11 @@ class EventListViewModel @Inject constructor(
     private val _isRefreshing = MutableStateFlow(false)
     private val _error = MutableStateFlow<String?>(null)
     private val _updatingStatusEventId = MutableStateFlow<String?>(null)
+<<<<<<< HEAD
+=======
+    /** Events pending hard delete after undo window expires. */
+    private val _pendingDelete = MutableStateFlow<Event?>(null)
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
     /** Local events list for soft-delete modifications. */
     private val _localEvents = MutableStateFlow<List<Event>>(emptyList())
 
@@ -124,11 +132,16 @@ class EventListViewModel @Inject constructor(
         filterState,
         sortAndStatusFlow
     ) { localEvents, repoEvents, clients, filters, sortTriple ->
+<<<<<<< HEAD
         // Merge local modifications with repo events - local overrides take precedence
         // but new repo updates are still visible (except for soft-deleted IDs)
         val softDeletedIds = localEvents.map { it.id }.toSet()
         val mergedRepo = repoEvents.filter { it.id !in softDeletedIds }
         val events = localEvents + mergedRepo
+=======
+        // Prefer local events if modified, otherwise repo events
+        val events = localEvents.ifEmpty { repoEvents }
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
         val (sortField, sortAscending, updatingId) = sortTriple
         val clientMap = clients.associateBy { it.id }
         val statusFilters = buildStatusFilters(events)
@@ -305,7 +318,11 @@ class EventListViewModel @Inject constructor(
      * Hard delete an event via the repository. Call this after the undo
      * window expires OR if the caller knows there's no undo needed.
      */
+<<<<<<< HEAD
     fun confirmDeleteEvent(event: Event, onRestore: () -> Unit) {
+=======
+    fun confirmDeleteEvent(event: Event) {
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
         viewModelScope.launch {
             try {
                 eventRepository.deleteEvent(event.id)
@@ -322,7 +339,11 @@ class EventListViewModel @Inject constructor(
 
     /**
      * Show an undo snackbar with 30-second expiry.
+<<<<<<< HEAD
      * Timer starts concurrently when snackbar is shown, not after it returns.
+=======
+     * After 30s, calls onExpire() to do the hard delete.
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
      */
     fun showUndoSnackbar(
         snackbarHostState: SnackbarHostState,
@@ -330,6 +351,7 @@ class EventListViewModel @Inject constructor(
         onExpire: () -> Unit
     ) {
         viewModelScope.launch {
+<<<<<<< HEAD
             // Start 30s timer concurrently with snackbar display
             val expiryJob = launch {
                 delay(30_000)
@@ -346,6 +368,20 @@ class EventListViewModel @Inject constructor(
             if (result == SnackbarResult.ActionPerformed) {
                 expiryJob.cancel()
                 onUndo()
+=======
+            val result = snackbarHostState.showSnackbar(
+                message = tr(R.string.events_list_delete_undone),
+                actionLabel = tr(R.string.events_list_delete_undo),
+                duration = SnackbarDuration.Short // ~4s, we handle expiry manually below
+            )
+            if (result == SnackbarResult.ActionPerformed) {
+                onUndo()
+            } else {
+                // User didn't undo — this shouldn't happen because we use Short duration
+                // but we trigger hard delete after 30s instead (matching iOS)
+                delay(30_000)
+                onExpire()
+>>>>>>> b156e3ff (feat(android): add soft-delete + undo snackbar to events list)
             }
         }
     }

--- a/backend/internal/handlers/crud_handler.go
+++ b/backend/internal/handlers/crud_handler.go
@@ -34,10 +34,10 @@ type CRUDHandler struct {
 	paymentRepo     FullPaymentRepository
 	userRepo        FullUserRepository
 	unavailRepo     UnavailableDateRepository
-	staffTeamRepo   StaffTeamRepository         // optional, may be nil (Ola 3)
-	notifier        NotificationSender          // optional, may be nil
-	emailService    *services.EmailService      // optional, may be nil
-	liveActivitySvc LiveActivityNotifier        // optional, may be nil
+	staffTeamRepo   StaffTeamRepository    // optional, may be nil (Ola 3)
+	notifier        NotificationSender     // optional, may be nil
+	emailService    *services.EmailService // optional, may be nil
+	liveActivitySvc LiveActivityNotifier   // optional, may be nil
 }
 
 // LiveActivityNotifier is the subset of services.LiveActivityService the handler needs.
@@ -334,7 +334,7 @@ func (h *CRUDHandler) SearchEvents(w http.ResponseWriter, r *http.Request) {
 		FromDate: q.Get("from"),
 		ToDate:   q.Get("to"),
 		Offset:   0,
-		Limit:   50,
+		Limit:    50,
 	}
 
 	// Parse pagination params (optional, defaults above)
@@ -414,6 +414,151 @@ func (h *CRUDHandler) GetEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, event)
+}
+
+// GetCalendarExport handles GET /api/events/ical
+// Returns a .ics file (RFC 5545) for the authenticated user's events within
+// the given date range. Defaults to the current calendar month.
+//
+// Query params:
+//
+//	start  YYYY-MM-DD  (default: first day of current month)
+//	end    YYYY-MM-DD  (default: last day of current month)
+//	status (optional)  quoted | confirmed | completed | cancelled
+func (h *CRUDHandler) GetCalendarExport(w http.ResponseWriter, r *http.Request) {
+	userID := middleware.GetUserID(r.Context())
+
+	now := time.Now()
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+	if startStr == "" {
+		startStr = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).Format("2006-01-02")
+	}
+	if endStr == "" {
+		endStr = time.Date(now.Year(), now.Month()+1, 0, 0, 0, 0, 0, now.Location()).Format("2006-01-02")
+	}
+
+	startDate, err := normalizeDateParam(startStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid start date")
+		return
+	}
+	endDate, err := normalizeDateParam(endStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid end date")
+		return
+	}
+
+	statusFilter := r.URL.Query().Get("status")
+	if statusFilter != "" {
+		validStatuses := map[string]bool{
+			"quoted": true, "confirmed": true,
+			"completed": true, "cancelled": true,
+		}
+		if !validStatuses[statusFilter] {
+			writeError(w, http.StatusBadRequest, "Invalid status value")
+			return
+		}
+	}
+
+	events, err := h.eventRepo.GetByDateRange(r.Context(), userID, startDate, endDate)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to fetch events")
+		return
+	}
+
+	dtstamp := time.Now().UTC().Format("20060102T150405Z")
+
+	var buf strings.Builder
+	buf.WriteString("BEGIN:VCALENDAR\r\n")
+	buf.WriteString("VERSION:2.0\r\n")
+	buf.WriteString("PRODID:-//Solennix//Solennix Calendar//ES\r\n")
+	buf.WriteString("CALSCALE:GREGORIAN\r\n")
+	buf.WriteString("METHOD:PUBLISH\r\n")
+	buf.WriteString("X-WR-CALNAME:Solennix\r\n")
+
+	for _, event := range events {
+		if statusFilter != "" && event.Status != statusFilter {
+			continue
+		}
+
+		summary := icalEscape(event.ServiceType)
+		if event.Client != nil && event.Client.Name != "" {
+			summary = icalEscape(event.Client.Name) + " — " + icalEscape(event.ServiceType)
+		}
+
+		dateCompact := strings.ReplaceAll(event.EventDate, "-", "")
+		var dtstart, dtend string
+		if event.StartTime != nil && *event.StartTime != "" {
+			stimeStr := strings.ReplaceAll(*event.StartTime, ":", "")
+			if len(stimeStr) > 6 {
+				stimeStr = stimeStr[:6]
+			} else if len(stimeStr) == 4 {
+				stimeStr += "00"
+			}
+			dtstart = "DTSTART:" + dateCompact + "T" + stimeStr
+			if event.EndTime != nil && *event.EndTime != "" {
+				etimeStr := strings.ReplaceAll(*event.EndTime, ":", "")
+				if len(etimeStr) > 6 {
+					etimeStr = etimeStr[:6]
+				} else if len(etimeStr) == 4 {
+					etimeStr += "00"
+				}
+				dtend = "DTEND:" + dateCompact + "T" + etimeStr
+			} else {
+				dtend = dtstart
+			}
+		} else {
+			dtstart = "DTSTART;VALUE=DATE:" + dateCompact
+			t, _ := time.Parse("2006-01-02", event.EventDate)
+			nextDay := t.AddDate(0, 0, 1).Format("20060102")
+			dtend = "DTEND;VALUE=DATE:" + nextDay
+		}
+
+		desc := fmt.Sprintf("Estado: %s\\nPersonas: %d\\nTotal: $%.0f MXN",
+			event.Status, event.NumPeople, event.TotalAmount)
+		if event.Notes != nil && *event.Notes != "" {
+			desc += "\\nNotas: " + icalEscape(*event.Notes)
+		}
+
+		icalStatus := "TENTATIVE"
+		switch event.Status {
+		case "confirmed", "completed":
+			icalStatus = "CONFIRMED"
+		case "cancelled":
+			icalStatus = "CANCELLED"
+		}
+
+		buf.WriteString("BEGIN:VEVENT\r\n")
+		buf.WriteString("UID:" + event.ID.String() + "@solennix.app\r\n")
+		buf.WriteString("DTSTAMP:" + dtstamp + "\r\n")
+		buf.WriteString(dtstart + "\r\n")
+		buf.WriteString(dtend + "\r\n")
+		buf.WriteString("SUMMARY:" + summary + "\r\n")
+		buf.WriteString("DESCRIPTION:" + desc + "\r\n")
+		if event.Location != nil && *event.Location != "" {
+			buf.WriteString("LOCATION:" + icalEscape(*event.Location) + "\r\n")
+		}
+		buf.WriteString("STATUS:" + icalStatus + "\r\n")
+		buf.WriteString("END:VEVENT\r\n")
+	}
+
+	buf.WriteString("END:VCALENDAR\r\n")
+
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="solennix.ics"`)
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, buf.String())
+}
+
+// icalEscape escapes special characters in iCal text values (RFC 5545 §3.3.11).
+func icalEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, ";", `\;`)
+	s = strings.ReplaceAll(s, ",", `\,`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
 }
 
 func (h *CRUDHandler) CreateEvent(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -26,9 +26,9 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 	r := chi.NewRouter()
 
 	// Global middleware
-	r.Use(mw.Recovery)        // Panic recovery — outermost so it catches the repanic from Sentry
-	r.Use(mw.Sentry)          // Per-request Sentry hub; captures panics then repanics (no-op if Sentry DSN unset)
-	r.Use(mw.RequestID)       // X-Request-ID for tracing
+	r.Use(mw.Recovery)  // Panic recovery — outermost so it catches the repanic from Sentry
+	r.Use(mw.Sentry)    // Per-request Sentry hub; captures panics then repanics (no-op if Sentry DSN unset)
+	r.Use(mw.RequestID) // X-Request-ID for tracing
 	r.Use(mw.CORS(corsOrigins))
 	r.Use(mw.SecurityHeaders) // Security headers (X-Frame-Options, CSP, HSTS, etc.)
 	r.Use(mw.Logger)
@@ -142,7 +142,7 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 	apiRouter.Route("/public/events", func(r chi.Router) {
 		r.Use(mw.RateLimit(10, 1*time.Minute))
 		r.Get("/{token}", eventPublicLinkHandler.GetPortalData)
-		
+
 		// Payment submissions (client portal) — tokenized access
 		r.Post("/{token}/payment-submissions", paymentSubmissionHandler.CreatePublic)
 		r.Get("/{token}/payment-submissions", paymentSubmissionHandler.GetHistoryPublic)
@@ -204,7 +204,8 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 		r.Route("/events", func(r chi.Router) {
 			r.Get("/", crudHandler.ListEvents)
 			r.Get("/upcoming", crudHandler.GetUpcomingEvents)
-			r.Get("/search", crudHandler.SearchEvents) // Advanced search — before /{id} to avoid conflict
+			r.Get("/search", crudHandler.SearchEvents)    // Advanced search — before /{id} to avoid conflict
+			r.Get("/ical", crudHandler.GetCalendarExport) // iCal export — before /{id} to avoid conflict
 			r.Post("/", crudHandler.CreateEvent)
 			r.Get("/{id}", crudHandler.GetEvent)
 			r.Put("/{id}", crudHandler.UpdateEvent)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Calendar/ViewModels/CalendarViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Calendar/ViewModels/CalendarViewModel.swift
@@ -44,6 +44,9 @@ public final class CalendarViewModel {
     /// null = no filter ("Todos"). Filters both the grid dots and the
     /// selected-day list to events matching the chosen status.
     public var statusFilter: EventStatus?
+    /// True while the iCal export request is in-flight. Used to show a
+    /// loading indicator on the export button and prevent double-taps.
+    public var isExportingCalendar: Bool = false
 
     /// Map of client ID -> Client for resolving client names.
     public var clientMap: [String: Client] = [:]
@@ -407,6 +410,37 @@ public final class CalendarViewModel {
         }
 
         isLoading = false
+    }
+
+    /// Downloads the iCal export for the current displayed month and writes it
+    /// to a temporary file. Returns the file URL on success, or nil on failure
+    /// (the `.loadFailed` error is also set so the view can show an alert).
+    public func exportCalendarToFile() async -> URL? {
+        isExportingCalendar = true
+        defer { isExportingCalendar = false }
+
+        let firstDay = calendar.date(from: calendar.dateComponents([.year, .month], from: currentMonth)) ?? currentMonth
+        guard let lastDay = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: firstDay) else {
+            self.error = .loadFailed
+            return nil
+        }
+
+        let start = Self.apiDateFormatter.string(from: firstDay)
+        let end = Self.apiDateFormatter.string(from: lastDay)
+
+        do {
+            let data = try await apiClient.getData(
+                Endpoint.events + "/ical",
+                params: ["start": start, "end": end]
+            )
+            let fileName = "solennix-\(start)-\(end).ics"
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+            try data.write(to: url)
+            return url
+        } catch {
+            self.error = .loadFailed
+            return nil
+        }
     }
 }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Calendar/Views/CalendarGridView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Calendar/Views/CalendarGridView.swift
@@ -167,6 +167,9 @@ private struct DayCellView: View {
         .frame(maxWidth: .infinity)
         .frame(height: 52)
         .contentShape(Rectangle())
+        // G10 — accessibility label describing the day's full state:
+        // e.g. "15 de marzo, 2 eventos, confirmado y cotizado"
+        .accessibilityLabel(accessibilityLabelForDay)
     }
 
     private var dayTextColor: Color {
@@ -188,6 +191,32 @@ private struct DayCellView: View {
         case .confirmed: return SolennixColors.statusConfirmed
         case .completed: return SolennixColors.statusCompleted
         case .cancelled: return SolennixColors.statusCancelled
+        }
+    }
+
+    // G10 — human-readable accessibility label for the day cell.
+    // Format: "15 de marzo, confirmado y cotizado"
+    // or "15 de marzo, bloqueado" for blocked days.
+    private var accessibilityLabelForDay: String {
+        if isBlocked {
+            return String(localized: "calendar.a11y.day_blocked", bundle: .module)
+        }
+        if dots.isEmpty {
+            return String(localized: "calendar.a11y.day_no_events", bundle: .module)
+        }
+        let statusDescriptions = dots.map { statusName(for: $0) }.joined(separator: " y ")
+        return String(
+            format: String(localized: "calendar.a11y.day_with_events", bundle: .module),
+            statusDescriptions
+        )
+    }
+
+    private func statusName(for status: EventStatus) -> String {
+        switch status {
+        case .quoted: return String(localized: "calendar.status.quoted", bundle: .module)
+        case .confirmed: return String(localized: "calendar.status.confirmed", bundle: .module)
+        case .completed: return String(localized: "calendar.status.completed", bundle: .module)
+        case .cancelled: return String(localized: "calendar.status.cancelled", bundle: .module)
         }
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Calendar/Views/CalendarView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Calendar/Views/CalendarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import SolennixCore
 import SolennixDesign
 import SolennixNetwork
@@ -18,6 +19,7 @@ public struct CalendarView: View {
     @State private var showBlockedDatesSheet = false
     @State private var showQuickQuote = false
     @State private var hapticTrigger: Int = 0
+    @State private var icsExportURL: URL?
     @Environment(PlanLimitsManager.self) private var planLimitsManager
     @Environment(\.apiClient) private var apiClient
     @Environment(\.horizontalSizeClass) private var sizeClass
@@ -102,6 +104,29 @@ public struct CalendarView: View {
                             .fontWeight(.semibold)
                             .foregroundStyle(SolennixColors.primary)
                     }
+
+                    // iCal export — fetches /api/events/ical for the current
+                    // month and opens the native share sheet. The button
+                    // switches to a spinner while the request is in-flight.
+                    Button {
+                        Task {
+                            if let url = await viewModel.exportCalendarToFile() {
+                                icsExportURL = url
+                            }
+                        }
+                    } label: {
+                        if viewModel.isExportingCalendar {
+                            ProgressView()
+                                .controlSize(.small)
+                                .tint(SolennixColors.primary)
+                        } else {
+                            Image(systemName: "square.and.arrow.up")
+                                .font(.body)
+                                .foregroundStyle(SolennixColors.primary)
+                        }
+                    }
+                    .disabled(viewModel.isExportingCalendar)
+                    .accessibilityLabel(String(localized: "calendar.export_ical", bundle: .module))
                 }
             }
         }
@@ -110,6 +135,17 @@ public struct CalendarView: View {
         }
         .sheet(isPresented: $showQuickQuote) {
             QuickQuoteView(apiClient: apiClient)
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { icsExportURL != nil },
+                set: { if !$0 { icsExportURL = nil } }
+            )
+        ) {
+            if let url = icsExportURL {
+                ActivityView(activityItems: [url])
+                    .ignoresSafeArea()
+            }
         }
         .sheet(isPresented: $showBlockSheet) {
             BlockDateSheet(
@@ -145,12 +181,27 @@ public struct CalendarView: View {
             }
         }
         // Generic error alert — the ViewModel emits a typed `CalendarError`,
-        // we map each case to a localized string. No freetext in-memory.
+        // we map each case to a localized string. Retry re-runs the failed
+        // operation; Cancel dismisses without retrying.
         .alert(
             errorAlertTitle,
             isPresented: $showErrorAlert
         ) {
-            Button(String(localized: "calendar.action.ok", bundle: .module), role: .cancel) {
+            Button(String(localized: "calendar.action.retry", bundle: .module)) {
+                let failedError = viewModel.error
+                viewModel.clearError()
+                Task {
+                    switch failedError {
+                    case .loadFailed:
+                        await viewModel.loadEvents()
+                    case .blockFailed, .unblockFailed:
+                        await viewModel.loadUnavailableDates()
+                    case .none:
+                        break
+                    }
+                }
+            }
+            Button(String(localized: "calendar.action.cancel", bundle: .module), role: .cancel) {
                 viewModel.clearError()
             }
         }
@@ -513,6 +564,20 @@ public struct CalendarView: View {
         case .cancelled: return SolennixColors.statusCancelled
         }
     }
+}
+
+// MARK: - Activity View
+
+/// Thin UIViewControllerRepresentable wrapper over UIActivityViewController.
+/// Used to present the native share sheet for the iCal export file.
+private struct ActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 // MARK: - Preview

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Resources/Localizable.xcstrings
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Resources/Localizable.xcstrings
@@ -264,6 +264,22 @@
         }
       }
     },
+    "calendar.action.retry": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reintentar"
+          }
+        }
+      }
+    },
     "calendar.all_day": {
       "localizations": {
         "en": {
@@ -647,6 +663,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cotizados"
+          }
+        }
+      }
+    },
+    "calendar.export_ical": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export calendar"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportar calendario"
           }
         }
       }

--- a/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/APIClient.swift
+++ b/ios/Packages/SolennixNetwork/Sources/SolennixNetwork/APIClient.swift
@@ -118,6 +118,16 @@ public actor APIClient {
         return try await execute(request)
     }
 
+    /// Perform a GET request and return the raw response `Data`.
+    /// Used for endpoints that return non-JSON content (e.g. iCal `.ics` files).
+    public func getData(
+        _ endpoint: String,
+        params: [String: String]? = nil
+    ) async throws -> Data {
+        let request = try buildRequest(endpoint, method: "GET", params: params)
+        return try await performRaw(request)
+    }
+
     /// Fetch a paginated response, with fallback to plain array.
     /// Use this for list views that expect PaginatedResponse but the backend may return a plain array.
     public func getPaginated<T: Decodable>(

--- a/web/src/i18n/locales/en/calendar.json
+++ b/web/src/i18n/locales/en/calendar.json
@@ -47,11 +47,13 @@
     "completed": "Completed",
     "cancelled": "Cancelled"
   },
+  "export_ics": "Export .ics",
   "error": {
     "load_failed": "Failed to load events",
     "block_failed": "Failed to block date",
     "unblock_failed": "Failed to unblock date",
-    "retry": "Retry"
+    "retry": "Retry",
+    "export_failed": "Failed to export calendar"
   },
   "action": {
     "cancel": "Cancel",

--- a/web/src/i18n/locales/es/calendar.json
+++ b/web/src/i18n/locales/es/calendar.json
@@ -47,11 +47,13 @@
     "completed": "Completado",
     "cancelled": "Cancelado"
   },
+  "export_ics": "Exportar .ics",
   "error": {
     "load_failed": "No se pudieron cargar los eventos",
     "block_failed": "No se pudo bloquear la fecha",
     "unblock_failed": "No se pudo desbloquear",
-    "retry": "Reintentar"
+    "retry": "Reintentar",
+    "export_failed": "No se pudo exportar el calendario"
   },
   "action": {
     "cancel": "Cancelar",

--- a/web/src/pages/Calendar/CalendarView.test.tsx
+++ b/web/src/pages/Calendar/CalendarView.test.tsx
@@ -173,7 +173,7 @@ describe('CalendarView', () => {
     await waitFor(() => {
       expect(screen.getByText('Ana')).toBeInTheDocument();
     });
-    expect(screen.getByText('Confirmado')).toBeInTheDocument();
+    expect(screen.getAllByText('Confirmado').length).toBeGreaterThan(0);
   });
 
   it('navigates to edit on event click', async () => {
@@ -322,10 +322,10 @@ describe('CalendarView', () => {
       expect(screen.getByText('C1')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Confirmado')).toBeInTheDocument();
-    expect(screen.getByText('Completado')).toBeInTheDocument();
-    expect(screen.getByText('Cancelado')).toBeInTheDocument();
-    expect(screen.getByText('Cotizado')).toBeInTheDocument();
+    expect(screen.getAllByText('Confirmado').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Completado').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Cancelado').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Cotizado').length).toBeGreaterThan(0);
   });
 
   it('shows badge count when multiple events on selected date', async () => {

--- a/web/src/pages/Calendar/CalendarView.tsx
+++ b/web/src/pages/Calendar/CalendarView.tsx
@@ -23,8 +23,10 @@ import {
   Lock,
   Unlock,
   AlertTriangle,
+  Download,
 } from "lucide-react";
 import { useToast } from "../../hooks/useToast";
+import { API_URL } from "../../lib/api";
 import { logError } from "../../lib/errorHandler";
 import {
   format,
@@ -108,6 +110,8 @@ export const CalendarView: React.FC = () => {
     startOfMonth(normalizedToday),
   );
   const [isManagingBlocks, setIsManagingBlocks] = useState(false);
+  const [isExportingIcal, setIsExportingIcal] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [isConfirmingUnblock, setIsConfirmingUnblock] = useState(false);
   const [contextMenuDate, setContextMenuDate] = useState<string | undefined>();
 
@@ -115,6 +119,30 @@ export const CalendarView: React.FC = () => {
   // React Query keys, so caching is automatic per month.
   const rangeStart = format(startOfMonth(currentMonth), "yyyy-MM-dd");
   const rangeEnd = format(endOfMonth(currentMonth), "yyyy-MM-dd");
+
+  const handleExportIcal = useCallback(async () => {
+    if (isExportingIcal) return;
+    setIsExportingIcal(true);
+    try {
+      const response = await fetch(
+        `${API_URL}/events/ical?start=${rangeStart}&end=${rangeEnd}`,
+        { credentials: "include" },
+      );
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `solennix-${rangeStart}-${rangeEnd}.ics`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      logError(err, "CalendarView.handleExportIcal");
+      addToast(t("error.export_failed"), "error");
+    } finally {
+      setIsExportingIcal(false);
+    }
+  }, [isExportingIcal, rangeStart, rangeEnd, addToast, t]);
 
   const { data: eventsData, isLoading: eventsLoading, isFetching: eventsFetching, error: eventsError } =
     useEventsByDateRange(rangeStart, rangeEnd);
@@ -138,8 +166,10 @@ export const CalendarView: React.FC = () => {
   // Filtered event list respects the active status chip. Filtering
   // happens client-side from the cached React Query data — no refetch,
   // matching iOS & Android behavior.
-  // FASE 7C: status filter removed (moved to Events section), filteredEvents = events
-  const filteredEvents = events;
+  const filteredEvents = useMemo(
+    () => statusFilter ? events.filter((e) => e.status === statusFilter) : events,
+    [events, statusFilter],
+  );
 
   // Surface query errors via toast (once per transition).
   useEffect(() => {
@@ -293,6 +323,22 @@ export const CalendarView: React.FC = () => {
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <h1 className="text-2xl font-bold text-text">{t("title")}</h1>
          <div className="flex items-center gap-3 flex-wrap">
+           {/* Botón exportar .ics */}
+           <button
+             type="button"
+             onClick={handleExportIcal}
+             disabled={isExportingIcal}
+             className="inline-flex items-center justify-center px-4 py-2 border border-border text-sm font-medium rounded-xl text-text bg-surface hover:bg-surface-alt shadow-sm transition-colors disabled:opacity-50"
+             aria-label={t("export_ics")}
+           >
+             {isExportingIcal ? (
+               <span className="animate-spin rounded-full h-4 w-4 border-2 border-text border-t-transparent mr-2" aria-hidden="true" />
+             ) : (
+               <Download className="h-4 w-4 mr-2" aria-hidden="true" />
+             )}
+             {t("export_ics")}
+           </button>
+
            {/* Botón gestionar bloqueos */}
            <button
              type="button"
@@ -320,7 +366,23 @@ export const CalendarView: React.FC = () => {
          </div>
        </div>
 
-       {/* REFACTOR FASE 7C — Eliminado filtros de estado (pertenecen a sección Eventos) */}
+       {/* Status filter chips — client-side filter, matches iOS & Android behavior */}
+       <div className="flex items-center gap-2 flex-wrap mt-2">
+         {([null, "quoted", "confirmed", "completed", "cancelled"] as const).map((s) => (
+           <button
+             key={s ?? "all"}
+             type="button"
+             onClick={() => setStatusFilter(s)}
+             className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold border transition-colors ${
+               statusFilter === s
+                 ? "bg-primary text-white border-primary"
+                 : "bg-card text-text-secondary border-border hover:border-primary hover:text-primary"
+             }`}
+           >
+             {s === null ? t("filter.all") : t(`status.${s}`)}
+           </button>
+         ))}
+       </div>
 
       {/* Inline error banner with retry — React Query already retried on its
           own, so this is the user-visible recovery affordance for a sticky


### PR DESCRIPTION
Closes #189

## Cambios

### Backend
- `GET /api/events/ical` — endpoint RFC 5545 auth-scoped para exportar eventos como `.ics`

### Web
- Restaura status filter chips en CalendarView (revertir FASE 7C)
- Botón **Exportar .ics** con download handler en el header del calendario

### iOS
- Botón de exportar .ics en toolbar → ShareSheet via `ActivityView` (UIActivityViewController)
- Acción **Reintentar** en todos los `CalendarError` alerts (`loadFailed`, `blockFailed`, `unblockFailed`)
- Fix: `CalendarGridView` — whitespace en `dots. enumerated()` que impedía compilar

### Android
- FAB **Crear Evento** wired con fecha seleccionada → `EventFormScreen`
- `onEventClick` → `event_detail/{id}` conectado en `CompactBottomNavLayout`
- Exportar .ics via `ShareIntent` + `FileProvider`
- `ExportFailed` error case + snackbar feedback

## Tests
- Backend: `go build ./...` ✅
- Web: `tsc --noEmit` → 0 errores ✅