### PR TITLE
fix(ios): restore dashboard top clients and upcoming events

### DIFF
--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/Event.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/Event.swift
@@ -7,6 +7,12 @@ public enum EventStatus: String, Codable, Sendable, CaseIterable, Hashable {
     case confirmed
     case completed
     case cancelled
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = EventStatus(rawValue: raw.lowercased()) ?? .quoted
+    }
 }
 
 // MARK: - DiscountType
@@ -14,6 +20,12 @@ public enum EventStatus: String, Codable, Sendable, CaseIterable, Hashable {
 public enum DiscountType: String, Codable, Sendable, CaseIterable, Hashable {
     case percent
     case fixed
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = DiscountType(rawValue: raw.lowercased()) ?? .percent
+    }
 }
 
 // MARK: - Event

--- a/ios/Packages/SolennixCore/Sources/SolennixCore/Models/TopClient.swift
+++ b/ios/Packages/SolennixCore/Sources/SolennixCore/Models/TopClient.swift
@@ -6,12 +6,14 @@ public struct TopClient: Codable, Identifiable, Sendable, Hashable {
     public let id: String
     public let name: String
     public let totalSpent: Double
-    public let eventCount: Int
+    public let totalEvents: Int
+
+    public var eventCount: Int { totalEvents }
 
     public init(id: String, name: String, totalSpent: Double, eventCount: Int) {
         self.id = id
         self.name = name
         self.totalSpent = totalSpent
-        self.eventCount = eventCount
+        self.totalEvents = eventCount
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/DashboardViewModel.swift
@@ -237,11 +237,6 @@ public final class DashboardViewModel {
             params: ["start": startStr, "end": endStr],
             label: "month events"
         )
-        let upcoming: [Event] = await loadOrEmpty(
-            Endpoint.upcomingEvents,
-            params: ["limit": "5"],
-            label: "upcoming events"
-        )
         let loadedAllEvents: [Event] = await loadOrEmpty(
             Endpoint.events,
             label: "all events"
@@ -268,7 +263,10 @@ public final class DashboardViewModel {
         allPayments = loadedAllPayments
 
         // Upcoming events
-        upcomingEvents = upcoming
+        let derivedUpcoming = loadedAllEvents
+            .filter { Self.isUpcomingEvent($0) }
+            .sorted(by: Self.compareDashboardEvents)
+        upcomingEvents = Array(derivedUpcoming.prefix(5))
 
         // Low stock items = inventory where current_stock < minimum_stock AND minimum_stock > 0
         lowStockItems = inventory.filter { $0.minimumStock > 0 && $0.currentStock < $0.minimumStock }
@@ -286,8 +284,8 @@ public final class DashboardViewModel {
             now: now
         )
 
-        NSLog("[Dashboard] 📊 Summary: clients=%d, monthEvents=%d, upcoming=%d, allEvents=%d, inventory=%d, products=%d, allPayments=%d, encounteredError=%@",
-              clients.count, monthEvents.count, upcoming.count, loadedAllEvents.count,
+          NSLog("[Dashboard] 📊 Summary: clients=%d, monthEvents=%d, upcoming=%d, allEvents=%d, inventory=%d, products=%d, allPayments=%d, encounteredError=%@",
+              clients.count, monthEvents.count, upcomingEvents.count, loadedAllEvents.count,
               inventory.count, products.count, loadedAllPayments.count,
               encounteredError ? "YES" : "NO")
 
@@ -500,6 +498,19 @@ public final class DashboardViewModel {
         }
 
         return lhs.id < rhs.id
+    }
+
+    private static func isUpcomingEvent(_ event: Event, now: Date = Date()) -> Bool {
+        guard event.status != .cancelled, event.status != .completed else {
+            return false
+        }
+
+        guard let eventDate = dashboardDateFormatter.date(from: String(event.eventDate.prefix(10))) else {
+            return false
+        }
+
+        let today = dashboardDateFormatter.date(from: dashboardDateFormatter.string(from: now)) ?? now
+        return eventDate >= today
     }
 
     private static let dashboardDateFormatter: DateFormatter = {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/DashboardViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Dashboard/ViewModels/DashboardViewModel.swift
@@ -501,10 +501,6 @@ public final class DashboardViewModel {
     }
 
     private static func isUpcomingEvent(_ event: Event, now: Date = Date()) -> Bool {
-        guard event.status != .cancelled, event.status != .completed else {
-            return false
-        }
-
         guard let eventDate = dashboardDateFormatter.date(from: String(event.eventDate.prefix(10))) else {
             return false
         }


### PR DESCRIPTION
## Linked Issue
- Closes #253

## What
- Fix iOS dashboard decoding for top clients (total_events -> totalEvents compatibility).
- Make iOS upcoming events filter match Android behavior (event_date >= today).
- Harden iOS event decoding for unknown status/discount values.

## Why
- iOS showed empty upcoming events while Android displayed entries.
- PR previously included unrelated web commit and missing governance metadata.

## Scope
- [ ] Backend
- [ ] Web
- [x] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Linked issue has status:approved
- [ ] Exactly one type:* label on the PR
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (PRD 11_CURRENT_STATUS.md + relevant architecture doc)

## Risk and Rollback
- Risk: low, iOS-only dashboard data mapping/filtering.
- Rollback: revert commits 8a0e14b3 and cea8872e.