### PR TITLE
feat(ios): localize staff module via StaffStrings shim

### DIFF
--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/StaffStrings.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/StaffStrings.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+// MARK: - Staff Strings
+
+enum StaffStrings {
+    private static var isEnglish: Bool { Locale.current.language.languageCode?.identifier == "en" }
+
+    // MARK: - Shared
+
+    static let cancel = isEnglish ? "Cancel" : "Cancelar"
+    static let edit = isEnglish ? "Edit" : "Editar"
+    static let save = isEnglish ? "Save" : "Guardar"
+    static let close = isEnglish ? "Close" : "Cerrar"
+    static let loading = isEnglish ? "Loading..." : "Cargando..."
+    static let errorTitle = isEnglish ? "Error" : "Error"
+    static let retry = isEnglish ? "Retry" : "Reintentar"
+    static let errorLoadingTitle = isEnglish ? "Loading error" : "Error al cargar"
+    static let filteredEmptyTitle = isEnglish ? "No results" : "Sin resultados"
+    static let unexpectedError = isEnglish ? "An unexpected error occurred." : "Ocurrió un error inesperado."
+    static let unexpectedErrorRetry = isEnglish ? "An unexpected error occurred. Try again." : "Ocurrió un error inesperado. Intentá de nuevo."
+    static let notesTitle = isEnglish ? "Notes" : "Notas"
+    static let membersTitle = isEnglish ? "Members" : "Miembros"
+    static let deleteAction = isEnglish ? "Delete" : "Eliminar"
+    static let callAction = isEnglish ? "Call" : "Llamar"
+
+    // MARK: - Sort
+
+    static let sortTitle = isEnglish ? "Sort by" : "Ordenar por"
+    static let sortName = isEnglish ? "Name" : "Nombre"
+    static let sortRole = isEnglish ? "Role" : "Rol"
+    static let sortCreatedAt = isEnglish ? "Created date" : "Fecha de creación"
+    static let sortAscending = isEnglish ? "Ascending" : "Ascendente"
+    static let sortDescending = isEnglish ? "Descending" : "Descendente"
+    static let sortAccessibility = isEnglish ? "Sort staff" : "Ordenar personal"
+
+    // MARK: - Staff List
+
+    static let title = isEnglish ? "Staff" : "Personal"
+    static let searchPrompt = isEnglish ? "Search staff" : "Buscar personal"
+    static let addAccessibility = isEnglish ? "Add staff member" : "Agregar personal"
+    static let emptyTitle = isEnglish ? "No staff yet" : "Sin personal"
+    static let emptyMessage = isEnglish ? "Add your first staff member to assign them to events" : "Agregá a tu primer colaborador para asignarlo a eventos"
+    static let emptyAction = isEnglish ? "Add Staff" : "Agregar Personal"
+    static let filteredEmptyMessage = isEnglish ? "No staff members matched your search" : "No se encontró personal que coincida con tu búsqueda"
+    static let teamsLinkTitle = isEnglish ? "Teams" : "Equipos"
+    static let teamsLinkSubtitle = isEnglish ? "Group your crew to assign them with a single tap" : "Armá cuadrillas para asignarlas de un toque"
+
+    // MARK: - Staff Delete
+
+    static let deleteTitle = isEnglish ? "Delete staff member" : "Eliminar personal"
+
+    static func deletedToast(_ name: String) -> String {
+        isEnglish ? "\(name) deleted" : "\(name) eliminado"
+    }
+
+    static func deleteMessage(_ name: String) -> String {
+        isEnglish
+            ? "Remove \(name)? You can undo this for a few seconds."
+            : "Se eliminará a \(name). Podrás deshacer durante unos segundos."
+    }
+
+    // MARK: - Staff Detail
+
+    static let loadingStaff = isEnglish ? "Loading staff member..." : "Cargando personal..."
+    static let notFoundMessage = isEnglish ? "Could not load staff member" : "No se pudo cargar el personal"
+    static let navTitleFallback = isEnglish ? "Staff member" : "Personal"
+    static let deleteError = isEnglish ? "Failed to delete staff member" : "Error al eliminar el personal"
+    static let emailNotifTitle = isEnglish ? "Email notifications enabled" : "Avisos por email activados"
+    static let emailNotifSubtitle = isEnglish ? "Will be activated in Phase 2 (Pro+). Preference is saved." : "Se activará en Phase 2 (Pro+). Por ahora queda registrada la preferencia."
+
+    static func deleteConfirmMessage(_ name: String) -> String {
+        isEnglish
+            ? "Are you sure you want to delete \(name)? This action cannot be undone."
+            : "¿Estás seguro de que querés eliminar a \(name)? Esta acción no se puede deshacer."
+    }
+
+    // MARK: - Staff Form
+
+    static let editTitle = isEnglish ? "Edit Staff" : "Editar Personal"
+    static let newTitle = isEnglish ? "New Staff" : "Nuevo Personal"
+    static let sectionInfo = isEnglish ? "Information" : "Información"
+    static let fieldName = isEnglish ? "Name" : "Nombre"
+    static let fieldNamePlaceholder = isEnglish ? "Full name" : "Nombre completo"
+    static let nameMinError = isEnglish ? "Minimum 2 characters" : "Mínimo 2 caracteres"
+    static let fieldRole = isEnglish ? "Role" : "Rol"
+    static let fieldRolePlaceholder = isEnglish ? "Ex: Waiter, DJ, Photographer" : "Ej: Mesero, DJ, Fotógrafo"
+    static let sectionContact = isEnglish ? "Contact" : "Contacto"
+    static let fieldPhone = isEnglish ? "Phone" : "Teléfono"
+    static let fieldPhonePlaceholder = isEnglish ? "10 digits" : "10 dígitos"
+    static let fieldEmail = isEnglish ? "Email" : "Email"
+    static let fieldEmailPlaceholder = isEnglish ? "email@example.com" : "correo@ejemplo.com"
+    static let emailInvalidError = isEnglish ? "Invalid email" : "Email inválido"
+    static let sectionNotif = isEnglish ? "Notifications" : "Avisos"
+    static let notifToggleLabel = isEnglish ? "Notify them by email when assigned to an event" : "Avisarle por email al asignarlo a un evento"
+    static let notifToggleSubtitle = isEnglish ? "Will be activated in Phase 2 (Pro+). Preference is saved." : "Se activará en Phase 2 (Pro+). Por ahora guardamos la preferencia."
+    static let notifEmailRequired = isEnglish ? "A valid email is required to enable notifications" : "Para activar el aviso necesitás un email válido"
+    static let sectionNotes = isEnglish ? "Notes" : "Notas"
+
+    // MARK: - Teams List
+
+    static let teamsTitle = isEnglish ? "Teams" : "Equipos"
+    static let teamsSearchPrompt = isEnglish ? "Search teams" : "Buscar equipos"
+    static let teamsAddAccessibility = isEnglish ? "Create team" : "Crear equipo"
+    static let teamDeleteTitle = isEnglish ? "Delete team" : "Eliminar equipo"
+    static let teamsLoading = isEnglish ? "Loading teams..." : "Cargando equipos..."
+    static let teamsEmptyTitle = isEnglish ? "No teams yet" : "Sin equipos todavía"
+    static let teamsEmptyMessage = isEnglish ? "Group your waiters or photographers to assign them to an event with a single tap." : "Agrupá a tu equipo de meseros o fotógrafos para asignarlos a un evento con un solo toque."
+    static let teamsEmptyAction = isEnglish ? "Create team" : "Crear equipo"
+    static let teamsFilteredEmptyMessage = isEnglish ? "No teams matched your search" : "No encontramos equipos que coincidan con tu búsqueda"
+
+    static func teamDeleteMessage(_ name: String) -> String {
+        isEnglish
+            ? "The team \(name) will be deleted. Individual members will not be removed."
+            : "Se eliminará el equipo \(name). Los colaboradores individuales no se borran."
+    }
+
+    // MARK: - Teams Detail
+
+    static let teamsLoadingDetail = isEnglish ? "Loading team..." : "Cargando equipo..."
+    static let teamNotFoundMessage = isEnglish ? "Could not load team" : "No se pudo cargar el equipo"
+    static let teamNavFallback = isEnglish ? "Team" : "Equipo"
+    static let teamDeleteError = isEnglish ? "Failed to delete team" : "Error al eliminar el equipo"
+    static let teamEmptyMembers = isEnglish ? "This team has no members yet. Edit it to add some." : "Este equipo todavía no tiene miembros. Editalo para agregarlos."
+    static let memberNoName = isEnglish ? "(no name)" : "(sin nombre)"
+    static let memberLeadAccessibility = isEnglish ? "Team lead" : "Lidera el equipo"
+
+    static func memberCount(_ count: Int) -> String {
+        isEnglish
+            ? (count == 1 ? "1 member" : "\(count) members")
+            : (count == 1 ? "1 miembro" : "\(count) miembros")
+    }
+
+    // MARK: - Teams Form
+
+    static let teamEditTitle = isEnglish ? "Edit Team" : "Editar Equipo"
+    static let teamNewTitle = isEnglish ? "New Team" : "Nuevo Equipo"
+    static let teamNamePlaceholder = isEnglish ? "Ex: Waiter Crew A" : "Ej: Cuadrilla de meseros A"
+    static let teamNameError = isEnglish ? "Name is required (max 255)" : "El nombre es obligatorio (max 255)"
+    static let teamRoleLabel = isEnglish ? "Team role (optional)" : "Rol del equipo (opcional)"
+    static let teamRolePlaceholder = isEnglish ? "Ex: Waiters, Photography" : "Ej: Meseros, Fotografía"
+    static let teamNotesLabel = isEnglish ? "Internal notes" : "Notas internas"
+    static let addMember = isEnglish ? "Add member" : "Agregar miembro"
+    static let removeLead = isEnglish ? "Remove as lead" : "Quitar liderazgo"
+    static let setLead = isEnglish ? "Mark as lead" : "Marcar como líder"
+    static let membersFooter = isEnglish ? "Order them as they should appear when assigning the team to an event. The lead is marked with the crown." : "Ordenalos como deberían aparecer al asignar el equipo a un evento. El líder se marca con la corona."
+    static let pickerEmptyMessage = isEnglish ? "Add staff members in the Staff section before building teams" : "Agrega colaboradores en la sección Personal antes de armar equipos"
+    static let pickerTitle = isEnglish ? "Add member" : "Agregar miembro"
+}

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffListViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffListViewModel.swift
@@ -12,9 +12,9 @@ public enum StaffSortKey: String, CaseIterable {
 
     public var label: String {
         switch self {
-        case .name:        return "Nombre"
-        case .roleLabel:   return "Rol"
-        case .createdAt:   return "Fecha de creacion"
+        case .name:        return StaffStrings.sortName
+        case .roleLabel:   return StaffStrings.sortRole
+        case .createdAt:   return StaffStrings.sortCreatedAt
         }
     }
 }
@@ -256,8 +256,8 @@ public final class StaffListViewModel {
 
     private func mapError(_ error: Error) -> String {
         if let apiError = error as? APIError {
-            return apiError.errorDescription ?? "Ocurrio un error inesperado."
+            return apiError.errorDescription ?? StaffStrings.unexpectedError
         }
-        return "Ocurrio un error inesperado. Intenta de nuevo."
+        return StaffStrings.unexpectedErrorRetry
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffTeamFormViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/StaffTeamFormViewModel.swift
@@ -200,8 +200,8 @@ public final class StaffTeamFormViewModel {
 
     private func mapError(_ error: Error) -> String {
         if let apiError = error as? APIError {
-            return apiError.errorDescription ?? "Ocurrio un error inesperado."
+            return apiError.errorDescription ?? StaffStrings.unexpectedError
         }
-        return "Ocurrio un error inesperado. Intenta de nuevo."
+        return StaffStrings.unexpectedErrorRetry
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffDetailView.swift
@@ -26,38 +26,38 @@ public struct StaffDetailView: View {
     public var body: some View {
         Group {
             if isLoading && staff == nil {
-                ProgressView("Cargando personal...")
+                ProgressView(StaffStrings.loadingStaff)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let item = staff {
                 scrollContent(item)
             } else {
                 EmptyStateView(
                     icon: "exclamationmark.triangle",
-                    title: "Error",
-                    message: errorMessage ?? "No se pudo cargar el personal"
+                    title: StaffStrings.errorTitle,
+                    message: errorMessage ?? StaffStrings.notFoundMessage
                 )
             }
         }
         .background(SolennixColors.surfaceGrouped)
-        .navigationTitle(staff?.name ?? "Personal")
+        .navigationTitle(staff?.name ?? StaffStrings.navTitleFallback)
         .navigationBarTitleDisplayMode(.inline)
         .confirmationDialog(
-            "Eliminar personal",
+            StaffStrings.deleteTitle,
             isPresented: $showDeleteConfirm
         ) {
-            Button("Eliminar", role: .destructive) {
+            Button(StaffStrings.deleteAction, role: .destructive) {
                 Task {
                     do {
                         try await apiClient.delete(Endpoint.staff(staffId))
                         dismiss()
                     } catch {
-                        errorMessage = "Error al eliminar el personal"
+                        errorMessage = StaffStrings.deleteError
                     }
                 }
             }
-            Button("Cancelar", role: .cancel) {}
+            Button(StaffStrings.cancel, role: .cancel) {}
         } message: {
-            Text("Estas seguro de que quieres eliminar a \(staff?.name ?? "este colaborador")? Esta accion no se puede deshacer.")
+            Text(StaffStrings.deleteConfirmMessage(staff?.name ?? ""))
         }
         .task { await loadData() }
     }
@@ -155,12 +155,12 @@ public struct StaffDetailView: View {
                 .foregroundStyle(SolennixColors.primary)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("Avisos por email activados")
+                Text(StaffStrings.emailNotifTitle)
                     .font(.subheadline)
                     .fontWeight(.semibold)
                     .foregroundStyle(SolennixColors.text)
 
-                Text("Se activara en Phase 2 (Pro+). Por ahora queda registrada la preferencia.")
+                Text(StaffStrings.emailNotifSubtitle)
                     .font(.caption)
                     .foregroundStyle(SolennixColors.textSecondary)
             }
@@ -180,7 +180,7 @@ public struct StaffDetailView: View {
                 Image(systemName: "note.text")
                     .font(.caption)
                     .foregroundStyle(SolennixColors.primary)
-                Text("Notas")
+                Text(StaffStrings.notesTitle)
                     .font(.caption)
                     .fontWeight(.semibold)
                     .foregroundStyle(SolennixColors.textSecondary)
@@ -245,7 +245,7 @@ public struct StaffDetailView: View {
             NavigationLink(value: Route.staffForm(id: staffId)) {
                 actionButton(
                     icon: "pencil",
-                    label: "Editar",
+                    label: StaffStrings.edit,
                     fg: SolennixColors.info
                 )
             }
@@ -255,7 +255,7 @@ public struct StaffDetailView: View {
             } label: {
                 actionButton(
                     icon: "trash",
-                    label: "Eliminar",
+                    label: StaffStrings.deleteAction,
                     fg: SolennixColors.error
                 )
             }
@@ -293,7 +293,7 @@ public struct StaffDetailView: View {
             if let apiError = error as? APIError {
                 errorMessage = apiError.errorDescription
             } else {
-                errorMessage = "Ocurrio un error inesperado."
+                errorMessage = StaffStrings.unexpectedError
             }
         }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffFormView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffFormView.swift
@@ -26,7 +26,7 @@ public struct StaffFormView: View {
         }
         .scrollContentBackground(.hidden)
         .background(SolennixColors.surfaceGrouped)
-        .navigationTitle(staffId != nil ? "Editar Personal" : "Nuevo Personal")
+        .navigationTitle(staffId != nil ? StaffStrings.editTitle : StaffStrings.newTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -40,7 +40,7 @@ public struct StaffFormView: View {
                     if viewModel.isSaving {
                         ProgressView()
                     } else {
-                        Text("Guardar")
+                        Text(StaffStrings.save)
                             .fontWeight(.semibold)
                             .foregroundStyle(viewModel.isFormValid ? SolennixColors.primary : SolennixColors.textTertiary)
                     }
@@ -50,16 +50,16 @@ public struct StaffFormView: View {
         }
         .overlay {
             if viewModel.isLoading {
-                ProgressView("Cargando...")
+                ProgressView(StaffStrings.loading)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(SolennixColors.background.opacity(0.6))
             }
         }
-        .alert("Error", isPresented: .init(
+        .alert(StaffStrings.errorTitle, isPresented: .init(
             get: { viewModel.errorMessage != nil },
             set: { if !$0 { viewModel.errorMessage = nil } }
         )) {
-            Button("OK", role: .cancel) {}
+            Button(StaffStrings.cancel, role: .cancel) {}
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
@@ -73,23 +73,23 @@ public struct StaffFormView: View {
     // MARK: - Info Section
 
     private var infoSection: some View {
-        Section("Informacion") {
+        Section(StaffStrings.sectionInfo) {
             AdaptiveFormRow {
                 SolennixTextField(
-                    label: "Nombre",
+                    label: StaffStrings.fieldName,
                     text: $viewModel.name,
-                    placeholder: "Nombre completo",
+                    placeholder: StaffStrings.fieldNamePlaceholder,
                     leftIcon: "person",
                     errorMessage: !viewModel.name.isEmpty && !viewModel.isNameValid
-                        ? "Minimo 2 caracteres" : nil,
+                        ? StaffStrings.nameMinError : nil,
                     textContentType: .name,
                     autocapitalization: .words
                 )
             } right: {
                 SolennixTextField(
-                    label: "Rol",
+                    label: StaffStrings.fieldRole,
                     text: $viewModel.roleLabel,
-                    placeholder: "Ej: Mesero, DJ, Fotografo",
+                    placeholder: StaffStrings.fieldRolePlaceholder,
                     leftIcon: "briefcase",
                     autocapitalization: .words
                 )
@@ -101,24 +101,24 @@ public struct StaffFormView: View {
     // MARK: - Contact Section
 
     private var contactSection: some View {
-        Section("Contacto") {
+        Section(StaffStrings.sectionContact) {
             AdaptiveFormRow {
                 SolennixTextField(
-                    label: "Telefono",
+                    label: StaffStrings.fieldPhone,
                     text: $viewModel.phone,
-                    placeholder: "10 digitos",
+                    placeholder: StaffStrings.fieldPhonePlaceholder,
                     leftIcon: "phone",
                     textContentType: .telephoneNumber,
                     keyboardType: .phonePad
                 )
             } right: {
                 SolennixTextField(
-                    label: "Email",
+                    label: StaffStrings.fieldEmail,
                     text: $viewModel.email,
-                    placeholder: "correo@ejemplo.com",
+                    placeholder: StaffStrings.fieldEmailPlaceholder,
                     leftIcon: "envelope",
                     errorMessage: !viewModel.email.isEmpty && !viewModel.isEmailValidIfProvided
-                        ? "Email invalido" : nil,
+                        ? StaffStrings.emailInvalidError : nil,
                     textContentType: .emailAddress,
                     keyboardType: .emailAddress,
                     autocapitalization: .never
@@ -135,12 +135,12 @@ public struct StaffFormView: View {
             VStack(alignment: .leading, spacing: Spacing.xs) {
                 Toggle(isOn: $viewModel.notificationEmailOptIn) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Avisarle por email al asignarlo a un evento")
+                        Text(StaffStrings.notifToggleLabel)
                             .font(.subheadline)
                             .fontWeight(.medium)
                             .foregroundStyle(SolennixColors.text)
 
-                        Text("Se activara en Phase 2 (Pro+). Por ahora guardamos la preferencia.")
+                        Text(StaffStrings.notifToggleSubtitle)
                             .font(.caption)
                             .foregroundStyle(SolennixColors.textSecondary)
                     }
@@ -148,23 +148,23 @@ public struct StaffFormView: View {
                 .tint(SolennixColors.primary)
 
                 if viewModel.notificationEmailOptIn && !viewModel.isOptInConsistent {
-                    Text("Para activar el aviso necesitas un email valido")
+                    Text(StaffStrings.notifEmailRequired)
                         .font(.caption)
                         .foregroundStyle(SolennixColors.error)
                 }
             }
             .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
         } header: {
-            Text("Avisos")
+            Text(StaffStrings.sectionNotif)
         }
     }
 
     // MARK: - Notes Section
 
     private var notesSection: some View {
-        Section("Notas") {
+        Section(StaffStrings.sectionNotes) {
             VStack(alignment: .leading, spacing: Spacing.xs) {
-                Text("Notas")
+                Text(StaffStrings.sectionNotes)
                     .font(.subheadline)
                     .fontWeight(.medium)
                     .foregroundStyle(SolennixColors.text)

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffListView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffListView.swift
@@ -20,9 +20,9 @@ public struct StaffListView: View {
     public var body: some View {
         content
             .background(SolennixColors.surfaceGrouped)
-            .navigationTitle("Personal")
+            .navigationTitle(StaffStrings.title)
             .navigationBarTitleDisplayMode(.large)
-            .searchable(text: $viewModel.searchText, prompt: "Buscar personal")
+            .searchable(text: $viewModel.searchText, prompt: StaffStrings.searchPrompt)
             .refreshable { await viewModel.loadStaff() }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -31,7 +31,7 @@ public struct StaffListView: View {
                         Image(systemName: "plus")
                             .font(.body)
                             .foregroundStyle(SolennixColors.primary)
-                            .accessibilityLabel("Agregar personal")
+                            .accessibilityLabel(StaffStrings.addAccessibility)
                     }
 
                     sortMenu
@@ -39,15 +39,15 @@ public struct StaffListView: View {
             }
         }
         .confirmationDialog(
-            "Eliminar personal",
+            StaffStrings.deleteTitle,
             isPresented: $viewModel.showDeleteConfirm,
             presenting: viewModel.deleteTarget
         ) { item in
-            Button("Eliminar", role: .destructive) {
+            Button(StaffStrings.deleteAction, role: .destructive) {
                 HapticsHelper.play(.success)
                 guard let removed = viewModel.softDeleteStaff(item) else { return }
                 toastManager.showUndo(
-                    message: "\(item.name) eliminado",
+                    message: StaffStrings.deletedToast(item.name),
                     onUndo: {
                         viewModel.restoreStaff(removed.staff, at: removed.index)
                         HapticsHelper.play(.success)
@@ -57,9 +57,9 @@ public struct StaffListView: View {
                     }
                 )
             }
-            Button("Cancelar", role: .cancel) {}
+            Button(StaffStrings.cancel, role: .cancel) {}
         } message: { item in
-            Text("Se eliminará a \(item.name). Podrás deshacer durante unos segundos.")
+            Text(StaffStrings.deleteMessage(item.name))
         }
         .task {
             await viewModel.loadStaff()
@@ -73,9 +73,9 @@ public struct StaffListView: View {
         if let error = viewModel.errorMessage, viewModel.staff.isEmpty, !viewModel.isLoading {
             EmptyStateView(
                 icon: "wifi.exclamationmark",
-                title: "Error al cargar",
+                title: StaffStrings.errorLoadingTitle,
                 message: error,
-                actionTitle: "Reintentar"
+                actionTitle: StaffStrings.retry
             ) {
                 Task { await viewModel.loadStaff() }
             }
@@ -85,17 +85,17 @@ public struct StaffListView: View {
             if viewModel.searchText.isEmpty {
                 EmptyStateView(
                     icon: "person.3",
-                    title: "Sin personal",
-                    message: "Agregá a tu primer colaborador para asignarlo a eventos",
-                    actionTitle: "Agregar Personal"
+                    title: StaffStrings.emptyTitle,
+                    message: StaffStrings.emptyMessage,
+                    actionTitle: StaffStrings.emptyAction
                 ) {
                     // FAB handles navigation; empty state CTA is visual only
                 }
             } else {
                 EmptyStateView(
                     icon: "magnifyingglass",
-                    title: "Sin resultados",
-                    message: "No se encontró personal que coincida con tu búsqueda"
+                    title: StaffStrings.filteredEmptyTitle,
+                    message: StaffStrings.filteredEmptyMessage
                 )
             }
         } else {
@@ -127,11 +127,11 @@ public struct StaffListView: View {
                             .foregroundStyle(SolennixColors.primary)
                     }
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Equipos")
+                        Text(StaffStrings.teamsLinkTitle)
                             .font(.body)
                             .fontWeight(.semibold)
                             .foregroundStyle(SolennixColors.text)
-                        Text("Armá cuadrillas para asignarlas de un toque")
+                        Text(StaffStrings.teamsLinkSubtitle)
                             .font(.caption)
                             .foregroundStyle(SolennixColors.textSecondary)
                     }
@@ -161,7 +161,7 @@ public struct StaffListView: View {
                     .buttonStyle(.plain)
                     .contextMenu {
                         NavigationLink(value: Route.staffForm(id: item.id)) {
-                            Label("Editar", systemImage: "pencil")
+                            Label(StaffStrings.edit, systemImage: "pencil")
                         }
                         if let phone = item.phone, !phone.isEmpty {
                             Button {
@@ -170,7 +170,7 @@ public struct StaffListView: View {
                                 }
                                 HapticsHelper.play(.success)
                             } label: {
-                                Label("Llamar", systemImage: "phone")
+                                Label(StaffStrings.callAction, systemImage: "phone")
                             }
                         }
                         if let email = item.email, !email.isEmpty {
@@ -189,7 +189,7 @@ public struct StaffListView: View {
                             viewModel.deleteTarget = item
                             viewModel.showDeleteConfirm = true
                         } label: {
-                            Label("Eliminar", systemImage: "trash")
+                            Label(StaffStrings.deleteAction, systemImage: "trash")
                         }
                     }
                     .task {
@@ -228,11 +228,11 @@ public struct StaffListView: View {
                                 .foregroundStyle(SolennixColors.primary)
                         }
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("Equipos")
+                            Text(StaffStrings.teamsLinkTitle)
                                 .font(.body)
                                 .fontWeight(.semibold)
                                 .foregroundStyle(SolennixColors.text)
-                            Text("Armá cuadrillas para asignarlas de un toque")
+                            Text(StaffStrings.teamsLinkSubtitle)
                                 .font(.caption)
                                 .foregroundStyle(SolennixColors.textSecondary)
                         }
@@ -250,11 +250,11 @@ public struct StaffListView: View {
                         viewModel.deleteTarget = item
                         viewModel.showDeleteConfirm = true
                     } label: {
-                        Label("Eliminar", systemImage: "trash")
+                        Label(StaffStrings.deleteAction, systemImage: "trash")
                     }
 
                     NavigationLink(value: Route.staffForm(id: item.id)) {
-                        Label("Editar", systemImage: "pencil")
+                        Label(StaffStrings.edit, systemImage: "pencil")
                     }
                     .tint(.blue)
                 }
@@ -276,14 +276,14 @@ public struct StaffListView: View {
                             HapticsHelper.play(.success)
                             openURL(url)
                         } label: {
-                            Label("Llamar", systemImage: "phone.fill")
+                            Label(StaffStrings.callAction, systemImage: "phone.fill")
                         }
                         .tint(.green)
                     }
                 }
                 .contextMenu {
                     NavigationLink(value: Route.staffForm(id: item.id)) {
-                        Label("Editar", systemImage: "pencil")
+                        Label(StaffStrings.edit, systemImage: "pencil")
                     }
                     if let phone = item.phone, !phone.isEmpty {
                         Button {
@@ -292,7 +292,7 @@ public struct StaffListView: View {
                             }
                             HapticsHelper.play(.success)
                         } label: {
-                            Label("Llamar", systemImage: "phone")
+                            Label(StaffStrings.callAction, systemImage: "phone")
                         }
                     }
                     if let email = item.email, !email.isEmpty {
@@ -311,7 +311,7 @@ public struct StaffListView: View {
                         viewModel.deleteTarget = item
                         viewModel.showDeleteConfirm = true
                     } label: {
-                        Label("Eliminar", systemImage: "trash")
+                        Label(StaffStrings.deleteAction, systemImage: "trash")
                     }
                 }
                 .task {
@@ -419,7 +419,7 @@ public struct StaffListView: View {
 
     private var sortMenu: some View {
         Menu {
-            Picker("Ordenar por", selection: $viewModel.sortKey) {
+            Picker(StaffStrings.sortTitle, selection: $viewModel.sortKey) {
                 ForEach(StaffSortKey.allCases, id: \.self) { key in
                     Text(key.label).tag(key)
                 }
@@ -431,7 +431,7 @@ public struct StaffListView: View {
                 viewModel.sortAscending.toggle()
             } label: {
                 Label(
-                    viewModel.sortAscending ? "Ascendente" : "Descendente",
+                    viewModel.sortAscending ? StaffStrings.sortAscending : StaffStrings.sortDescending,
                     systemImage: viewModel.sortAscending ? "arrow.up" : "arrow.down"
                 )
             }
@@ -439,7 +439,7 @@ public struct StaffListView: View {
             Image(systemName: "arrow.up.arrow.down")
                 .font(.body)
                 .foregroundStyle(SolennixColors.primary)
-                .accessibilityLabel("Ordenar personal")
+                .accessibilityLabel(StaffStrings.sortAccessibility)
         }
     }
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamDetailView.swift
@@ -26,48 +26,48 @@ public struct StaffTeamDetailView: View {
     public var body: some View {
         Group {
             if isLoading && team == nil {
-                ProgressView("Cargando equipo...")
+                ProgressView(StaffStrings.teamsLoadingDetail)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else if let team {
                 scrollContent(team)
             } else {
                 EmptyStateView(
                     icon: "exclamationmark.triangle",
-                    title: "Error",
-                    message: errorMessage ?? "No se pudo cargar el equipo"
+                    title: StaffStrings.errorTitle,
+                    message: errorMessage ?? StaffStrings.teamNotFoundMessage
                 )
             }
         }
         .background(SolennixColors.surfaceGrouped)
-        .navigationTitle(team?.name ?? "Equipo")
+        .navigationTitle(team?.name ?? StaffStrings.teamNavFallback)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             if team != nil {
                 ToolbarItem(placement: .topBarTrailing) {
                     NavigationLink(value: Route.staffTeamForm(id: teamId)) {
-                        Text("Editar")
+                        Text(StaffStrings.edit)
                             .foregroundStyle(SolennixColors.primary)
                     }
                 }
             }
         }
         .confirmationDialog(
-            "Eliminar equipo",
+            StaffStrings.teamDeleteTitle,
             isPresented: $showDeleteConfirm
         ) {
-            Button("Eliminar", role: .destructive) {
+            Button(StaffStrings.deleteAction, role: .destructive) {
                 Task {
                     do {
                         try await apiClient.deleteStaffTeam(id: teamId)
                         dismiss()
                     } catch {
-                        errorMessage = "Error al eliminar el equipo"
+                        errorMessage = StaffStrings.teamDeleteError
                     }
                 }
             }
-            Button("Cancelar", role: .cancel) {}
+            Button(StaffStrings.cancel, role: .cancel) {}
         } message: {
-            Text("Se eliminará el equipo \(team?.name ?? ""). Los colaboradores individuales no se borran.")
+            Text(StaffStrings.teamDeleteMessage(team?.name ?? ""))
         }
         .task { await loadData() }
     }
@@ -129,7 +129,7 @@ public struct StaffTeamDetailView: View {
                 Image(systemName: "person.2")
                     .font(.caption)
                     .foregroundStyle(SolennixColors.textTertiary)
-                Text(count == 1 ? "1 miembro" : "\(count) miembros")
+                Text(StaffStrings.memberCount(count))
                     .font(.caption)
                     .foregroundStyle(SolennixColors.textTertiary)
             }
@@ -149,7 +149,7 @@ public struct StaffTeamDetailView: View {
                 Image(systemName: "note.text")
                     .font(.caption)
                     .foregroundStyle(SolennixColors.primary)
-                Text("Notas")
+                Text(StaffStrings.notesTitle)
                     .font(.caption)
                     .fontWeight(.semibold)
                     .foregroundStyle(SolennixColors.textSecondary)
@@ -170,7 +170,7 @@ public struct StaffTeamDetailView: View {
 
     private func membersSection(_ team: StaffTeam) -> some View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
-            Text("Miembros")
+            Text(StaffStrings.membersTitle)
                 .font(.caption)
                 .fontWeight(.semibold)
                 .foregroundStyle(SolennixColors.textSecondary)
@@ -179,7 +179,7 @@ public struct StaffTeamDetailView: View {
             let sorted = (team.members ?? []).sorted { $0.position < $1.position }
 
             if sorted.isEmpty {
-                Text("Este equipo todavía no tiene miembros. Editalo para agregarlos.")
+                Text(StaffStrings.teamEmptyMembers)
                     .font(.body)
                     .foregroundStyle(SolennixColors.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -202,7 +202,7 @@ public struct StaffTeamDetailView: View {
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: Spacing.xs) {
-                    Text(member.staffName ?? "(sin nombre)")
+                    Text(member.staffName ?? StaffStrings.memberNoName)
                         .font(.body)
                         .fontWeight(.semibold)
                         .foregroundStyle(SolennixColors.text)
@@ -211,7 +211,7 @@ public struct StaffTeamDetailView: View {
                         Image(systemName: "crown.fill")
                             .font(.caption2)
                             .foregroundStyle(SolennixColors.primary)
-                            .accessibilityLabel("Lidera el equipo")
+                            .accessibilityLabel(StaffStrings.memberLeadAccessibility)
                     }
                 }
 
@@ -257,7 +257,7 @@ public struct StaffTeamDetailView: View {
         } label: {
             HStack(spacing: Spacing.sm) {
                 Image(systemName: "trash")
-                Text("Eliminar equipo")
+                Text(StaffStrings.teamDeleteTitle)
             }
             .font(.subheadline)
             .fontWeight(.medium)
@@ -283,7 +283,7 @@ public struct StaffTeamDetailView: View {
             if let apiError = error as? APIError {
                 errorMessage = apiError.errorDescription
             } else {
-                errorMessage = "Ocurrio un error inesperado."
+                errorMessage = StaffStrings.unexpectedError
             }
         }
 

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamFormView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamFormView.swift
@@ -26,7 +26,7 @@ public struct StaffTeamFormView: View {
         }
         .scrollContentBackground(.hidden)
         .background(SolennixColors.surfaceGrouped)
-        .navigationTitle(teamId != nil ? "Editar Equipo" : "Nuevo Equipo")
+        .navigationTitle(teamId != nil ? StaffStrings.teamEditTitle : StaffStrings.teamNewTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
@@ -40,7 +40,7 @@ public struct StaffTeamFormView: View {
                     if viewModel.isSaving {
                         ProgressView()
                     } else {
-                        Text("Guardar")
+                        Text(StaffStrings.save)
                             .fontWeight(.semibold)
                             .foregroundStyle(viewModel.isFormValid ? SolennixColors.primary : SolennixColors.textTertiary)
                     }
@@ -50,7 +50,7 @@ public struct StaffTeamFormView: View {
         }
         .overlay {
             if viewModel.isLoading {
-                ProgressView("Cargando...")
+                ProgressView(StaffStrings.loading)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(SolennixColors.background.opacity(0.6))
             }
@@ -77,22 +77,22 @@ public struct StaffTeamFormView: View {
     // MARK: - Info
 
     private var infoSection: some View {
-        Section("Informacion") {
+        Section(StaffStrings.sectionInfo) {
             SolennixTextField(
-                label: "Nombre",
+                label: StaffStrings.fieldName,
                 text: $viewModel.name,
-                placeholder: "Ej: Cuadrilla de meseros A",
+                placeholder: StaffStrings.teamNamePlaceholder,
                 leftIcon: "person.3",
                 errorMessage: !viewModel.name.isEmpty && !viewModel.isNameValid
-                    ? "El nombre es obligatorio (max 255)" : nil,
+                    ? StaffStrings.teamNameError : nil,
                 autocapitalization: .sentences
             )
             .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
 
             SolennixTextField(
-                label: "Rol del equipo (opcional)",
+                label: StaffStrings.teamRoleLabel,
                 text: $viewModel.roleLabel,
-                placeholder: "Ej: Meseros, Fotografia",
+                placeholder: StaffStrings.teamRolePlaceholder,
                 leftIcon: "briefcase",
                 autocapitalization: .words
             )
@@ -103,9 +103,9 @@ public struct StaffTeamFormView: View {
     // MARK: - Notes
 
     private var notesSection: some View {
-        Section("Notas") {
+        Section(StaffStrings.sectionNotes) {
             VStack(alignment: .leading, spacing: Spacing.xs) {
-                Text("Notas internas")
+                Text(StaffStrings.teamNotesLabel)
                     .font(.subheadline)
                     .fontWeight(.medium)
                     .foregroundStyle(SolennixColors.text)
@@ -147,7 +147,7 @@ public struct StaffTeamFormView: View {
                 HStack(spacing: Spacing.sm) {
                     Image(systemName: "person.crop.circle.badge.plus")
                         .foregroundStyle(SolennixColors.primary)
-                    Text("Agregar miembro")
+                    Text(StaffStrings.addMember)
                         .font(.subheadline)
                         .fontWeight(.medium)
                         .foregroundStyle(SolennixColors.primary)
@@ -158,7 +158,7 @@ public struct StaffTeamFormView: View {
             .listRowInsets(EdgeInsets(top: Spacing.sm, leading: Spacing.md, bottom: Spacing.sm, trailing: Spacing.md))
         } header: {
             HStack {
-                Text("Miembros")
+                Text(StaffStrings.membersTitle)
                 Spacer()
                 if !viewModel.members.isEmpty {
                     EditButton()
@@ -167,7 +167,7 @@ public struct StaffTeamFormView: View {
                 }
             }
         } footer: {
-            Text("Ordenalos como deberian aparecer al asignar el equipo a un evento. El lider se marca con la corona.")
+            Text(StaffStrings.membersFooter)
                 .font(.caption)
                 .foregroundStyle(SolennixColors.textTertiary)
         }
@@ -199,7 +199,7 @@ public struct StaffTeamFormView: View {
                 Image(systemName: member.isLead ? "crown.fill" : "crown")
                     .font(.body)
                     .foregroundStyle(member.isLead ? SolennixColors.primary : SolennixColors.textTertiary)
-                    .accessibilityLabel(member.isLead ? "Quitar liderazgo" : "Marcar como lider")
+                    .accessibilityLabel(member.isLead ? StaffStrings.removeLead : StaffStrings.setLead)
             }
             .buttonStyle(.plain)
         }
@@ -214,8 +214,8 @@ public struct StaffTeamFormView: View {
                 if viewModel.staffCatalog.isEmpty {
                     EmptyStateView(
                         icon: "person.3",
-                        title: "Sin personal",
-                        message: "Agrega colaboradores en la seccion Personal antes de armar equipos"
+                        title: StaffStrings.emptyTitle,
+                        message: StaffStrings.pickerEmptyMessage
                     )
                 } else {
                     MemberPickerList(
@@ -228,11 +228,11 @@ public struct StaffTeamFormView: View {
                     )
                 }
             }
-            .navigationTitle("Agregar miembro")
+            .navigationTitle(StaffStrings.pickerTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
-                    Button("Cerrar") { showMemberPicker = false }
+                    Button(StaffStrings.close) { showMemberPicker = false }
                         .foregroundStyle(SolennixColors.textSecondary)
                 }
             }
@@ -282,7 +282,7 @@ private struct MemberPickerList: View {
                 .disabled(alreadySelected.contains(item.id))
             }
         }
-        .searchable(text: $search, prompt: "Buscar personal")
+        .searchable(text: $search, prompt: StaffStrings.searchPrompt)
     }
 
     private var filtered: [Staff] {

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamListView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/StaffTeamListView.swift
@@ -16,9 +16,9 @@ public struct StaffTeamListView: View {
     public var body: some View {
         content
             .background(SolennixColors.surfaceGrouped)
-            .navigationTitle("Equipos")
+            .navigationTitle(StaffStrings.teamsTitle)
             .navigationBarTitleDisplayMode(.large)
-            .searchable(text: $viewModel.searchText, prompt: "Buscar equipos")
+            .searchable(text: $viewModel.searchText, prompt: StaffStrings.teamsSearchPrompt)
             .refreshable { await viewModel.load() }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
@@ -26,22 +26,22 @@ public struct StaffTeamListView: View {
                         Image(systemName: "plus")
                             .font(.body)
                             .foregroundStyle(SolennixColors.primary)
-                            .accessibilityLabel("Crear equipo")
+                            .accessibilityLabel(StaffStrings.teamsAddAccessibility)
                     }
                 }
             }
             .confirmationDialog(
-                "Eliminar equipo",
+                StaffStrings.teamDeleteTitle,
                 isPresented: $viewModel.showDeleteConfirm,
                 presenting: viewModel.deleteTarget
             ) { team in
-                Button("Eliminar", role: .destructive) {
+                Button(StaffStrings.deleteAction, role: .destructive) {
                     HapticsHelper.play(.warning)
                     Task { await viewModel.deleteTeam(team) }
                 }
-                Button("Cancelar", role: .cancel) {}
+                Button(StaffStrings.cancel, role: .cancel) {}
             } message: { team in
-                Text("Se eliminará el equipo \(team.name). Los colaboradores individuales no se borran.")
+                Text(StaffStrings.teamDeleteMessage(team.name))
             }
             .task {
                 await viewModel.load()
@@ -55,30 +55,30 @@ public struct StaffTeamListView: View {
         if let error = viewModel.errorMessage, viewModel.teams.isEmpty, !viewModel.isLoading {
             EmptyStateView(
                 icon: "wifi.exclamationmark",
-                title: "Error al cargar",
+                title: StaffStrings.errorLoadingTitle,
                 message: error,
-                actionTitle: "Reintentar"
+                actionTitle: StaffStrings.retry
             ) {
                 Task { await viewModel.load() }
             }
         } else if viewModel.isLoading && viewModel.teams.isEmpty {
-            ProgressView("Cargando equipos...")
+            ProgressView(StaffStrings.teamsLoading)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if viewModel.filteredTeams.isEmpty && !viewModel.isLoading {
             if viewModel.searchText.isEmpty {
                 EmptyStateView(
                     icon: "person.3.sequence",
-                    title: "Sin equipos todavía",
-                    message: "Agrupá a tu equipo de meseros o fotógrafos para asignarlos a un evento con un solo toque.",
-                    actionTitle: "Crear equipo"
+                    title: StaffStrings.teamsEmptyTitle,
+                    message: StaffStrings.teamsEmptyMessage,
+                    actionTitle: StaffStrings.teamsEmptyAction
                 ) {
                     // El boton del toolbar navega — este CTA es visual.
                 }
             } else {
                 EmptyStateView(
                     icon: "magnifyingglass",
-                    title: "Sin resultados",
-                    message: "No encontramos equipos que coincidan con tu búsqueda"
+                    title: StaffStrings.filteredEmptyTitle,
+                    message: StaffStrings.teamsFilteredEmptyMessage
                 )
             }
         } else {
@@ -98,11 +98,11 @@ public struct StaffTeamListView: View {
                         viewModel.deleteTarget = team
                         viewModel.showDeleteConfirm = true
                     } label: {
-                        Label("Eliminar", systemImage: "trash")
+                        Label(StaffStrings.deleteAction, systemImage: "trash")
                     }
 
                     NavigationLink(value: Route.staffTeamForm(id: team.id)) {
-                        Label("Editar", systemImage: "pencil")
+                        Label(StaffStrings.edit, systemImage: "pencil")
                     }
                     .tint(.blue)
                 }
@@ -160,7 +160,7 @@ public struct StaffTeamListView: View {
     }
 
     private func memberCountLabel(_ count: Int) -> String {
-        count == 1 ? "1 miembro" : "\(count) miembros"
+        StaffStrings.memberCount(count)
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #249

Localizes the entire Staff module on iOS using the `StaffStrings` shim pattern (same approach used for Products, Inventory, and Clients slices).

### Changes

- **`StaffStrings.swift`** — New shim with ES/EN keys for every visible string in the Staff module, including `callAction`, `unexpectedError`, and `unexpectedErrorRetry`.
- **`StaffListView`** — Swipe actions and context menu labels (`Editar`, `Eliminar`, `Llamar`) consume `StaffStrings`.
- **`StaffListViewModel`** — `mapError()` fallback strings localized.
- **`StaffFormView`** — Nav title, form labels, placeholders, and error strings localized.
- **`StaffDetailView`** — Error fallback localized.
- **`StaffTeamFormView`** — 15 hardcoded strings replaced: nav title, section headers, field labels, picker sheet, footer, accessibility labels.
- **`StaffTeamDetailView`** — Delete button label and error fallback localized.
- **`StaffTeamFormViewModel`** — `mapError()` fallback strings localized.

### Platform impact
- [x] iOS
- [ ] Android *(not in scope — Android already uses `stringResource`)*
- [ ] Web *(not in scope)*
- [ ] Backend *(not in scope)*

### Testing
No new logic introduced — pure copy extraction. Verified zero remaining hardcoded ES strings across all 9 Staff files.