### PR TITLE
chore(web): migrate TypeScript 5 → 6

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -61,7 +61,7 @@
         "postcss": "^8.5.14",
         "react-is": "^19.2.5",
         "tailwindcss": "^4.2.0",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.59.2",
         "vite": "^8.0.10",
         "vite-plugin-pwa": "^1.3.0",
@@ -5168,7 +5168,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6460,7 +6460,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -10426,6 +10426,7 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -11895,10 +11896,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/web/package.json
+++ b/web/package.json
@@ -71,7 +71,7 @@
     "postcss": "^8.5.14",
     "react-is": "^19.2.5",
     "tailwindcss": "^4.2.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^8.0.10",
     "vite-plugin-pwa": "^1.3.0",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -22,7 +22,6 @@
     "noFallthroughCasesInSwitch": false,
     "noUncheckedSideEffectImports": false,
     "forceConsistentCasingInFileNames": false,
-    "baseUrl": "./",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
- Bump typescript from ~5.9.3 to ~6.0.3
- Remove deprecated baseUrl from tsconfig.json (paths aliases unaffected)
- Regenerate package-lock.json

Closes #297

## Linked Issue
- Closes #

## What
- 

## Why
- 

## Scope
- [ ] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [ ] Issue linked
- [ ] Linked issue has `status:approved`
- [ ] Exactly one `type:*` label on the PR
- [ ] Tests added/updated
- [ ] CI green
- [ ] Cross-platform parity reviewed
- [ ] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk:
- Rollback:
