### PR TITLE
feat(web): organizer payment submissions inbox

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -158,7 +158,7 @@ func main() {
 	liveActivityHandler := handlers.NewLiveActivityHandler(liveActivityRepo)
 	eventFormHandler := handlers.NewEventFormHandler(eventFormLinkRepo, productRepo, userRepo, cfg.FrontendURL, pool)
 	eventPublicLinkHandler := handlers.NewEventPublicLinkHandler(eventPublicLinkRepo, eventRepo, clientRepo, userRepo, paymentRepo, cfg.FrontendURL)
-	paymentSubmissionHandler := handlers.NewPaymentSubmissionHandler(paymentSubmissionRepo, paymentRepo, pool)
+	paymentSubmissionHandler := handlers.NewPaymentSubmissionHandler(paymentSubmissionRepo, paymentRepo, pool, cfg.UploadDir)
 	staffHandler := handlers.NewStaffHandler(staffRepo, userRepo)
 	staffTeamHandler := handlers.NewStaffTeamHandler(staffTeamRepo)
 

--- a/backend/internal/handlers/payment_submission_handler.go
+++ b/backend/internal/handlers/payment_submission_handler.go
@@ -3,7 +3,11 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,22 +17,36 @@ import (
 	"github.com/tiagofur/solennix-backend/internal/repository"
 )
 
-type PaymentSubmissionHandler struct {
-	repo *repository.PaymentSubmissionRepo
-	paymentRepo *repository.PaymentRepo
-	pool *pgxpool.Pool
+// allowedReceiptMIME maps accepted content types to file extensions.
+var allowedReceiptMIME = map[string]string{
+	"image/jpeg":      ".jpg",
+	"image/png":       ".png",
+	"image/webp":      ".webp",
+	"application/pdf": ".pdf",
 }
 
-func NewPaymentSubmissionHandler(repo *repository.PaymentSubmissionRepo, paymentRepo *repository.PaymentRepo, pool *pgxpool.Pool) *PaymentSubmissionHandler {
-	return &PaymentSubmissionHandler{repo: repo, paymentRepo: paymentRepo, pool: pool}
+type PaymentSubmissionHandler struct {
+	repo        *repository.PaymentSubmissionRepo
+	paymentRepo *repository.PaymentRepo
+	pool        *pgxpool.Pool
+	uploadDir   string
+}
+
+func NewPaymentSubmissionHandler(repo *repository.PaymentSubmissionRepo, paymentRepo *repository.PaymentRepo, pool *pgxpool.Pool, uploadDir string) *PaymentSubmissionHandler {
+	receiptsDir := filepath.Join(uploadDir, "receipts")
+	if err := os.MkdirAll(receiptsDir, 0755); err != nil {
+		// Non-fatal: log and continue; uploads will fail at runtime if dir missing.
+		_ = err
+	}
+	return &PaymentSubmissionHandler{repo: repo, paymentRepo: paymentRepo, pool: pool, uploadDir: uploadDir}
 }
 
 // CreatePublicRequest for client submitting payment from portal
 type CreatePublicPaymentRequest struct {
-	EventID     uuid.UUID  `json:"event_id"`
-	ClientID    uuid.UUID  `json:"client_id"`
-	Amount      float64    `json:"amount"`
-	TransferRef *string    `json:"transfer_ref,omitempty"`
+	EventID     uuid.UUID `json:"event_id"`
+	ClientID    uuid.UUID `json:"client_id"`
+	Amount      float64   `json:"amount"`
+	TransferRef *string   `json:"transfer_ref,omitempty"`
 }
 
 // CreatePublic handles POST /api/public/events/{token}/payment-submissions (client portal)
@@ -51,7 +69,7 @@ func (h *PaymentSubmissionHandler) CreatePublic(w http.ResponseWriter, r *http.R
 	clientIDStr := r.FormValue("client_id")
 	amount := r.FormValue("amount")
 	transferRef := r.FormValue("transfer_ref")
-	
+
 	if eventIDStr == "" || clientIDStr == "" || amount == "" {
 		writeError(w, http.StatusBadRequest, "event_id, client_id, and amount are required")
 		return
@@ -78,14 +96,68 @@ func (h *PaymentSubmissionHandler) CreatePublic(w http.ResponseWriter, r *http.R
 
 	// Parse receipt file if provided (optional)
 	var receiptFileURL *string
-	file, handler, err := r.FormFile("receipt_file")
-	if err == nil {
+	file, fileHeader, fileErr := r.FormFile("receipt_file")
+	if fileErr == nil {
 		defer file.Close()
-		
-		// TODO: Upload to S3/CDN and get URL
-		// For now, store filename as placeholder
-		filename := handler.Filename
-		receiptFileURL = &filename
+
+		// Validate MIME type by reading the first 512 bytes.
+		buf := make([]byte, 512)
+		n, err := file.Read(buf)
+		if err != nil && err != io.EOF {
+			writeError(w, http.StatusBadRequest, "Failed to read uploaded file")
+			return
+		}
+		detectedMIME := http.DetectContentType(buf[:n])
+		// Normalise: http.DetectContentType returns "image/jpeg" etc., but PDF
+		// may be detected as "application/octet-stream" — fall back to extension.
+		ext, mimeOK := allowedReceiptMIME[detectedMIME]
+		if !mimeOK {
+			// Try extension as secondary signal (e.g. PDF).
+			lowerName := strings.ToLower(fileHeader.Filename)
+			for mime, e := range allowedReceiptMIME {
+				if strings.HasSuffix(lowerName, e) {
+					ext = e
+					_ = mime
+					mimeOK = true
+					break
+				}
+			}
+		}
+		if !mimeOK {
+			writeError(w, http.StatusBadRequest, "receipt_file must be jpeg, png, webp, or pdf")
+			return
+		}
+
+		// Validate size (already capped by ParseMultipartForm, but double-check header).
+		if fileHeader.Size > 10<<20 {
+			writeError(w, http.StatusBadRequest, "receipt_file must be 10 MB or smaller")
+			return
+		}
+
+		// Save to {uploadDir}/receipts/{uuid}{ext}
+		receiptsDir := filepath.Join(h.uploadDir, "receipts")
+		filename := fmt.Sprintf("%s%s", uuid.New().String(), ext)
+		dstPath := filepath.Join(receiptsDir, filename)
+
+		dst, err := os.Create(dstPath)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to save receipt file")
+			return
+		}
+		defer dst.Close()
+
+		// Write the already-read buffer, then copy the rest.
+		if _, err := dst.Write(buf[:n]); err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to write receipt file")
+			return
+		}
+		if _, err := io.Copy(dst, file); err != nil {
+			writeError(w, http.StatusInternalServerError, "Failed to write receipt file")
+			return
+		}
+
+		url := "/api/uploads/receipts/" + filename
+		receiptFileURL = &url
 	}
 
 	// Validate event public link
@@ -138,7 +210,7 @@ func (h *PaymentSubmissionHandler) GetHistoryPublic(w http.ResponseWriter, r *ht
 
 	eventIDStr := r.URL.Query().Get("event_id")
 	clientIDStr := r.URL.Query().Get("client_id")
-	
+
 	if eventIDStr == "" || clientIDStr == "" {
 		writeError(w, http.StatusBadRequest, "event_id and client_id query params required")
 		return
@@ -185,8 +257,7 @@ func (h *PaymentSubmissionHandler) GetHistoryPublic(w http.ResponseWriter, r *ht
 		submissions = make([]*models.PaymentSubmission, 0)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"data": submissions,
-	})
+	writeJSON(w, http.StatusOK, map[string]interface{}{"data": submissions})
 }
 
 // GetPendingOrganizerInbox handles GET /api/organizer/payment-submissions (organizer review inbox)
@@ -204,8 +275,7 @@ func (h *PaymentSubmissionHandler) GetPendingOrganizerInbox(w http.ResponseWrite
 		submissions = make([]*models.PaymentSubmission, 0)
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"data": submissions,
-	})
+	writeJSON(w, http.StatusOK, map[string]interface{}{"data": submissions})
 }
 
 // ReviewRequest for approving/rejecting a submission
@@ -245,6 +315,12 @@ func (h *PaymentSubmissionHandler) ReviewSubmission(w http.ResponseWriter, r *ht
 	// Verify organizer ownership
 	if ps.UserID != userID {
 		writeError(w, http.StatusForbidden, "You do not have permission to review this submission")
+		return
+	}
+
+	// Idempotency guard: only pending submissions can be reviewed.
+	if ps.Status != "pending" {
+		writeError(w, http.StatusConflict, "Submission has already been reviewed")
 		return
 	}
 
@@ -288,6 +364,5 @@ func (h *PaymentSubmissionHandler) ReviewSubmission(w http.ResponseWriter, r *ht
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{"data": ps,
-	})
+	writeJSON(w, http.StatusOK, map[string]interface{}{"data": ps})
 }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/ViewModels/InventoryListViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/ViewModels/InventoryListViewModel.swift
@@ -280,7 +280,7 @@ public final class InventoryListViewModel {
                 id: item.id,
                 userId: item.userId,
                 ingredientName: item.ingredientName,
-                currentStock: adjustmentQuantity,
+                currentStock: max(0, adjustmentQuantity),
                 minimumStock: item.minimumStock,
                 unit: item.unit,
                 unitCost: item.unitCost,

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/ViewModels/InventoryListViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/ViewModels/InventoryListViewModel.swift
@@ -276,22 +276,22 @@ public final class InventoryListViewModel {
         }
 
         do {
-            let body = ["current_stock": adjustmentQuantity]
-            let _: InventoryItem = try await apiClient.put(Endpoint.inventoryItem(item.id), body: body)
+            let body = InventoryItem(
+                id: item.id,
+                userId: item.userId,
+                ingredientName: item.ingredientName,
+                currentStock: adjustmentQuantity,
+                minimumStock: item.minimumStock,
+                unit: item.unit,
+                unitCost: item.unitCost,
+                lastUpdated: item.lastUpdated,
+                type: item.type
+            )
+            let result: InventoryItem = try await apiClient.put(Endpoint.inventoryItem(item.id), body: body)
 
             // Update local state
             if let index = items.firstIndex(where: { $0.id == item.id }) {
-                items[index] = InventoryItem(
-                    id: item.id,
-                    userId: item.userId,
-                    ingredientName: item.ingredientName,
-                    currentStock: adjustmentQuantity,
-                    minimumStock: item.minimumStock,
-                    unit: item.unit,
-                    unitCost: item.unitCost,
-                    lastUpdated: ISO8601DateFormatter().string(from: Date()),
-                    type: item.type
-                )
+                items[index] = result
             }
             applyFilters()
             showStockAdjustment = false

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/Views/InventoryDetailView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Inventory/Views/InventoryDetailView.swift
@@ -210,8 +210,19 @@ public struct InventoryDetailView: View {
 
     @MainActor
     private func saveStockAdjustment() async {
+        guard let currentItem = item else { return }
         do {
-            let body = ["current_stock": adjustmentQuantity]
+            let body = InventoryItem(
+                id: currentItem.id,
+                userId: currentItem.userId,
+                ingredientName: currentItem.ingredientName,
+                currentStock: max(0, adjustmentQuantity),
+                minimumStock: currentItem.minimumStock,
+                unit: currentItem.unit,
+                unitCost: currentItem.unitCost,
+                lastUpdated: currentItem.lastUpdated,
+                type: currentItem.type
+            )
             let updated: InventoryItem = try await apiClient.put(Endpoint.inventoryItem(itemId), body: body)
             item = updated
             showStockAdjustment = false

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,7 @@ const PublicEventFormPage = React.lazy(() => import("@/pages/PublicEventForm/Pub
 const ClientPortalPage = React.lazy(() => import("@/pages/ClientPortal/ClientPortalPage").then((m) => ({ default: m.ClientPortalPage })));
 
 const EventFormLinksPage = React.lazy(() => import("@/pages/EventForms/EventFormLinksPage").then((m) => ({ default: m.EventFormLinksPage })));
+const PaymentInboxPage = React.lazy(() => import("@/pages/Payments/PaymentInboxPage").then((m) => ({ default: m.PaymentInboxPage })));
 
 const AdminDashboard = React.lazy(() => import("@/pages/Admin/AdminDashboard").then((m) => ({ default: m.AdminDashboard })));
 const AdminUsers = React.lazy(() => import("@/pages/Admin/AdminUsers").then((m) => ({ default: m.AdminUsers })));
@@ -140,6 +141,7 @@ function App() {
                 <Route path="/inventory/:id/edit" element={<InventoryForm />} />
 
                 <Route path="/event-forms" element={<EventFormLinksPage />} />
+                <Route path="/payments/inbox" element={<PaymentInboxPage />} />
                 <Route path="/settings" element={<Settings />} />
 
                 <Route path="/admin" element={<AdminRoute><AdminDashboard /></AdminRoute>} />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -20,6 +20,7 @@ import {
   Link2,
   UserCog,
   HelpCircle,
+  Wallet,
 } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '@/hooks/useTheme';
@@ -105,6 +106,7 @@ export const Layout: React.FC = () => {
     { name: t('nav.products'), href: '/products', icon: Package },
     { name: t('nav.inventory'), href: '/inventory', icon: Boxes },
     { name: t('nav.forms'), href: '/event-forms', icon: Link2 },
+    { name: t('nav.payments_inbox', { defaultValue: 'Cobros' }), href: '/payments/inbox', icon: Wallet },
     { name: t('nav.help'), href: '/help', icon: HelpCircle },
     { name: t('nav.settings'), href: '/settings', icon: Settings },
     // Admin link — only visible to admins

--- a/web/src/components/PaymentStatusBadge.tsx
+++ b/web/src/components/PaymentStatusBadge.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+type Status = 'pending' | 'approved' | 'rejected';
+
+interface PaymentStatusBadgeProps {
+  status: Status;
+}
+
+export const PaymentStatusBadge: React.FC<PaymentStatusBadgeProps> = ({ status }) => {
+  const { t } = useTranslation('payments');
+
+  const styles: Record<Status, string> = {
+    pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+    approved: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+    rejected: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  };
+
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${styles[status]}`}>
+      {t(`status.${status}`, { defaultValue: status })}
+    </span>
+  );
+};

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -197,6 +197,10 @@ class ApiClient {
     return this.request<T>(endpoint, { method: 'PUT', body: JSON.stringify(body) });
   }
 
+  patch<T>(endpoint: string, body: any) {
+    return this.request<T>(endpoint, { method: 'PATCH', body: JSON.stringify(body) });
+  }
+
   delete<T>(endpoint: string) {
     return this.request<T>(endpoint, { method: 'DELETE' });
   }

--- a/web/src/pages/Payments/PaymentInboxPage.tsx
+++ b/web/src/pages/Payments/PaymentInboxPage.tsx
@@ -10,7 +10,6 @@ import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { Modal } from '@/components/Modal';
 
 const QUERY_KEY = ['payment-submissions', 'pending'];
-const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080/api';
 
 export const PaymentInboxPage: React.FC = () => {
   const { t, i18n } = useTranslation(['payments', 'common']);
@@ -32,6 +31,9 @@ export const PaymentInboxPage: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEY });
       setApproveId(null);
     },
+    onError: () => {
+      setApproveId(null);
+    },
   });
 
   const rejectMutation = useMutation({
@@ -39,6 +41,11 @@ export const PaymentInboxPage: React.FC = () => {
       paymentSubmissionService.reviewSubmission(id, 'rejected', reason),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      setRejectId(null);
+      setRejectReason('');
+      setRejectError('');
+    },
+    onError: () => {
       setRejectId(null);
       setRejectReason('');
       setRejectError('');
@@ -73,7 +80,8 @@ export const PaymentInboxPage: React.FC = () => {
     amount.toLocaleString(i18n.language.startsWith('en') ? 'en-US' : 'es-MX', {
       style: 'currency',
       currency: 'MXN',
-      maximumFractionDigits: 0,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
     });
 
   if (error) {
@@ -152,7 +160,7 @@ export const PaymentInboxPage: React.FC = () => {
                       <div className="flex items-center gap-2">
                         {sub.receipt_file_url && (
                           <a
-                            href={`${API_BASE.replace('/api', '')}/api/uploads/${sub.receipt_file_url.replace(/^.*uploads\//, '')}`}
+                            href={sub.receipt_file_url}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
@@ -165,7 +173,8 @@ export const PaymentInboxPage: React.FC = () => {
                           <>
                             <button
                               onClick={() => setApproveId(sub.id)}
-                              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-green-500 text-white text-xs font-semibold hover:bg-green-600 transition-colors"
+                              disabled={approveMutation.isPending}
+                              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-green-500 text-white text-xs font-semibold hover:bg-green-600 transition-colors disabled:opacity-50"
                             >
                               <CheckCircle className="h-3.5 w-3.5" />
                               Aprobar

--- a/web/src/pages/Payments/PaymentInboxPage.tsx
+++ b/web/src/pages/Payments/PaymentInboxPage.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useState } from 'react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { Inbox, ExternalLink, CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import paymentSubmissionService from '@/services/paymentSubmissionService';
+import { PaymentStatusBadge } from '@/components/PaymentStatusBadge';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { Modal } from '@/components/Modal';
+
+const QUERY_KEY = ['payment-submissions', 'pending'];
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080/api';
+
+export const PaymentInboxPage: React.FC = () => {
+  const { t, i18n } = useTranslation(['payments', 'common']);
+  const queryClient = useQueryClient();
+
+  const [approveId, setApproveId] = useState<string | null>(null);
+  const [rejectId, setRejectId] = useState<string | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [rejectError, setRejectError] = useState('');
+
+  const { data: submissions = [], isLoading, error } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: () => paymentSubmissionService.getPendingSubmissions(),
+  });
+
+  const approveMutation = useMutation({
+    mutationFn: (id: string) => paymentSubmissionService.reviewSubmission(id, 'approved'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      setApproveId(null);
+    },
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+      paymentSubmissionService.reviewSubmission(id, 'rejected', reason),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      setRejectId(null);
+      setRejectReason('');
+      setRejectError('');
+    },
+  });
+
+  const handleRejectSubmit = useCallback(() => {
+    if (!rejectId) return;
+    if (rejectReason.trim().length < 10) {
+      setRejectError(t('payments:reject.reason_min', { defaultValue: 'El motivo debe tener al menos 10 caracteres.' }));
+      return;
+    }
+    rejectMutation.mutate({ id: rejectId, reason: rejectReason.trim() });
+  }, [rejectId, rejectReason, rejectMutation, t]);
+
+  const handleOpenReject = useCallback((id: string) => {
+    setRejectId(id);
+    setRejectReason('');
+    setRejectError('');
+  }, []);
+
+  const formatDate = (dateStr: string) => {
+    try {
+      const locale = i18n.language.startsWith('en') ? undefined : es;
+      return format(new Date(dateStr), 'dd MMM yyyy', { locale });
+    } catch {
+      return dateStr;
+    }
+  };
+
+  const formatCurrency = (amount: number) =>
+    amount.toLocaleString(i18n.language.startsWith('en') ? 'en-US' : 'es-MX', {
+      style: 'currency',
+      currency: 'MXN',
+      maximumFractionDigits: 0,
+    });
+
+  if (error) {
+    return (
+      <div className="p-6 text-center text-text-secondary">
+        {t('common:error.loading', { defaultValue: 'Error al cargar los datos.' })}
+      </div>
+    );
+  }
+
+  const pendingForApprove = submissions.find((s) => s.id === approveId);
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <div className="flex items-center gap-3">
+        <Inbox className="h-6 w-6 text-primary" />
+        <h1 className="text-2xl font-bold text-text">
+          {t('payments:inbox.title', { defaultValue: 'Pagos pendientes' })}
+        </h1>
+        {submissions.length > 0 && (
+          <span className="inline-flex items-center justify-center h-5 min-w-[1.25rem] px-1.5 rounded-full bg-primary text-white text-xs font-bold">
+            {submissions.length}
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center items-center h-48">
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+        </div>
+      ) : submissions.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 py-20 text-text-secondary">
+          <CheckCircle className="h-12 w-12 text-green-500 opacity-60" />
+          <p className="text-base font-medium">
+            {t('payments:inbox.empty', { defaultValue: 'Sin pagos pendientes de revisión.' })}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-border bg-surface overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border">
+              <thead className="bg-surface-alt">
+                <tr>
+                  {['Cliente', 'Evento', 'Monto', 'Referencia', 'Fecha', 'Estado', ''].map((col) => (
+                    <th
+                      key={col}
+                      className="px-4 py-3 text-left text-xs font-semibold text-text-secondary uppercase tracking-wider"
+                    >
+                      {col}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {submissions.map((sub) => (
+                  <tr key={sub.id} className="hover:bg-surface-alt/50 transition-colors">
+                    <td className="px-4 py-3 text-sm font-medium text-text whitespace-nowrap">
+                      {sub.client_name ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-text-secondary whitespace-nowrap">
+                      {sub.event_label ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 text-sm font-semibold text-text whitespace-nowrap">
+                      {formatCurrency(sub.amount)}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-text-secondary max-w-[160px] truncate">
+                      {sub.transfer_ref ?? '—'}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-text-secondary whitespace-nowrap">
+                      {formatDate(sub.submitted_at)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <PaymentStatusBadge status={sub.status} />
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <div className="flex items-center gap-2">
+                        {sub.receipt_file_url && (
+                          <a
+                            href={`${API_BASE.replace('/api', '')}/api/uploads/${sub.receipt_file_url.replace(/^.*uploads\//, '')}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                            Comprobante
+                          </a>
+                        )}
+                        {sub.status === 'pending' && (
+                          <>
+                            <button
+                              onClick={() => setApproveId(sub.id)}
+                              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-green-500 text-white text-xs font-semibold hover:bg-green-600 transition-colors"
+                            >
+                              <CheckCircle className="h-3.5 w-3.5" />
+                              Aprobar
+                            </button>
+                            <button
+                              onClick={() => handleOpenReject(sub.id)}
+                              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg bg-error text-white text-xs font-semibold hover:opacity-90 transition-opacity"
+                            >
+                              <XCircle className="h-3.5 w-3.5" />
+                              Rechazar
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Approve confirmation dialog */}
+      <ConfirmDialog
+        open={approveId !== null}
+        title="Aprobar pago"
+        description={
+          pendingForApprove
+            ? `¿Confirmás aprobar el pago de ${formatCurrency(pendingForApprove.amount)} de ${pendingForApprove.client_name ?? 'este cliente'}? Se registrará automáticamente como pago del evento.`
+            : '¿Confirmás aprobar este pago?'
+        }
+        confirmText={approveMutation.isPending ? 'Aprobando...' : 'Aprobar'}
+        cancelText="Cancelar"
+        onConfirm={() => approveId && approveMutation.mutate(approveId)}
+        onCancel={() => setApproveId(null)}
+      />
+
+      {/* Reject modal with reason */}
+      <Modal
+        isOpen={rejectId !== null}
+        onClose={() => { setRejectId(null); setRejectReason(''); setRejectError(''); }}
+        title="Rechazar pago"
+        maxWidth="sm"
+        titleId="reject-modal-title"
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            Indicá el motivo del rechazo. El cliente podrá verlo en su historial.
+          </p>
+          <div>
+            <textarea
+              value={rejectReason}
+              onChange={(e) => { setRejectReason(e.target.value); setRejectError(''); }}
+              placeholder="Motivo del rechazo..."
+              rows={4}
+              className="w-full rounded-xl border border-border bg-surface text-text text-sm p-3 focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+            />
+            {rejectError && (
+              <p className="mt-1 text-xs text-error">{rejectError}</p>
+            )}
+          </div>
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={() => { setRejectId(null); setRejectReason(''); setRejectError(''); }}
+              className="px-4 py-2 rounded-xl bg-surface-alt text-text border border-border hover:bg-surface transition-colors text-sm font-medium"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleRejectSubmit}
+              disabled={rejectMutation.isPending}
+              className="px-4 py-2 rounded-xl bg-error text-white text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              {rejectMutation.isPending ? 'Rechazando...' : 'Rechazar'}
+            </button>
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};

--- a/web/src/services/paymentSubmissionService.ts
+++ b/web/src/services/paymentSubmissionService.ts
@@ -99,7 +99,7 @@ class PaymentSubmissionService {
     status: 'approved' | 'rejected',
     rejectionReason?: string
   ): Promise<PaymentSubmission> {
-    const response = await api.put<{ data: PaymentSubmission }>(
+    const response = await api.patch<{ data: PaymentSubmission }>(
       `/organizer/payment-submissions/${submissionId}`,
       {
         status,


### PR DESCRIPTION
## Summary

PR #2 of 5 for issue #191 — organizer review surface on web.

## Changes

### `web/src/components/PaymentStatusBadge.tsx` *(new)*
- Reusable badge component for `pending` / `approved` / `rejected` states
- Used in both this page and the client portal

### `web/src/pages/Payments/PaymentInboxPage.tsx` *(new)*
- Table listing all pending submissions (client, event, amount, reference, date)
- **Approve**: one-click with confirmation dialog showing amount + client summary
- **Reject**: modal with required reason textarea (min 10 chars)
- Wires `paymentSubmissionService.getPendingSubmissions()` and `reviewSubmission()`
- Shows receipt link when `receipt_file_url` is present

### `web/src/App.tsx`
- Route `/payments/inbox` registered (authenticated, wrapped with `ProtectedRoute + Layout`)

### `web/src/components/Layout.tsx`
- Wallet nav entry added to sidebar linking to `/payments/inbox`

## Depends on
PR #318 (backend foundation) — file URL paths served by `/api/uploads/*`

## Part of
Closes #191 (partial)

Next: PR #3 (portal tabs), PR #4 (iOS), PR #5 (Android)