### PR TITLE
fix(web): silence expected 401 on auth/me and skip check on public routes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,8 @@
     </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/pwa-192x192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "Solennix",
+  "short_name": "Solennix",
+  "description": "Event management for LATAM organizers",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#C4A265",
+  "background_color": "#1B2A4A",
+  "icons": [
+    {
+      "src": "/pwa-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/pwa-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -6,6 +6,17 @@ import { api } from '../lib/api';
 import { logError } from '../lib/errorHandler';
 
 vi.mock('../lib/api', () => ({
+  ApiHttpError: class ApiHttpError extends Error {
+    statusCode: number;
+    endpoint: string;
+
+    constructor(message: string, statusCode: number, endpoint: string) {
+      super(message);
+      this.name = 'ApiHttpError';
+      this.statusCode = statusCode;
+      this.endpoint = endpoint;
+    }
+  },
   api: {
     get: vi.fn(),
     post: vi.fn(),

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { api } from '@/lib/api';
+import { ApiHttpError, api } from '@/lib/api';
 import { logError } from '@/lib/errorHandler';
 import { User } from '@/types/auth';
 import { AuthContext } from './AuthContextInstance';
@@ -8,6 +8,18 @@ import i18n from '@/i18n/config';
 
 // eslint-disable-next-line react-refresh/only-export-components
 export { AuthContext, useAuth };
+
+const isPublicAuthRoute = (pathname: string) => {
+  const publicAuthRoutes = new Set([
+    '/login',
+    '/register',
+    '/forgot-password',
+    '/reset-password',
+    '/team-invite',
+    '/team-invite/accept',
+  ]);
+  return publicAuthRoutes.has(pathname);
+};
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
@@ -19,7 +31,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const userData = await api.get<User>('/auth/me');
       setUser(userData);
     } catch (error) {
-      logError('Auth check failed', error);
+      // A 401 from /auth/me is expected when no session is active — don't log it as an error
+      if (!(error instanceof ApiHttpError && error.statusCode === 401)) {
+        logError('Auth check failed', error);
+      }
       setUser(null);
     } finally {
       setLoading(false);
@@ -27,6 +42,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   useEffect(() => {
+    // Skip the /auth/me network call on public auth routes — no session expected there
+    if (isPublicAuthRoute(window.location.pathname)) {
+      setLoading(false);
+      return;
+    }
     checkAuth();
     
     // Listen for 401 logout events from api.ts

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,6 +24,24 @@ export class PlanLimitExceededError extends Error {
 }
 
 /**
+ * Thrown for any non-OK HTTP response that isn't already handled by
+ * a more specific error type (e.g. PlanLimitExceededError).
+ * Preserves the status code so callers can distinguish expected 401s
+ * (no active session) from genuine errors without string matching.
+ */
+export class ApiHttpError extends Error {
+  readonly statusCode: number;
+  readonly endpoint: string;
+
+  constructor(message: string, statusCode: number, endpoint: string) {
+    super(message);
+    this.name = 'ApiHttpError';
+    this.statusCode = statusCode;
+    this.endpoint = endpoint;
+  }
+}
+
+/**
  * Detail payload emitted on the `plan:limit-exceeded` CustomEvent.
  * Listeners (e.g., Layout.tsx) use this to decide whether to show a
  * modal, redirect, or simply flash a toast.
@@ -175,7 +193,11 @@ class ApiClient {
           detail.max,
         );
       }
-      throw new Error(errorData.error || `Request failed with status ${response.status}`);
+      throw new ApiHttpError(
+        errorData.error || `Request failed with status ${response.status}`,
+        response.status,
+        endpoint,
+      );
     }
 
     // Handle 204 No Content


### PR DESCRIPTION
## Summary

Fixes the console noise visible in production on every unauthenticated page load.

### Problem
- `GET /api/auth/me 401` was being logged as `[Auth check failed] Error: Authentication required` — a 401 on `/auth/me` is **expected** (no active session), not an error
- `/auth/me` was being called on public routes (/login, /register, etc.) where no session ever exists
- PWA web app manifest was missing, causing browser icon warnings

### Changes
- `web/src/lib/api.ts`: Add `ApiHttpError` class with `statusCode: number` and `endpoint: string` — all HTTP errors now throw this instead of generic `Error`
- `web/src/contexts/AuthContext.tsx`: Catch `ApiHttpError`, only call `logError` when it is NOT an expected 401; add `isPublicAuthRoute()` to skip `/auth/me` entirely on auth pages
- `web/public/manifest.webmanifest`: New PWA manifest (name, icons, theme colors)
- `web/index.html`: Link manifest and apple-touch-icon

Closes #346