### PR TITLE
feat(cross-platform): consolidate team member portal and calendar parity

### DIFF
--- a/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/TeamMemberPortalScreen.kt
+++ b/android/feature/staff/src/main/java/com/creapolis/solennix/feature/staff/ui/TeamMemberPortalScreen.kt
@@ -1,5 +1,7 @@
 package com.creapolis.solennix.feature.staff.ui
 
+import android.widget.CalendarView
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,16 +31,23 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.creapolis.solennix.core.designsystem.component.SolennixTopAppBar
 import com.creapolis.solennix.core.designsystem.theme.SolennixTheme
@@ -49,6 +58,9 @@ import com.creapolis.solennix.core.network.AuthManager
 import com.creapolis.solennix.feature.staff.viewmodel.TeamMemberPortalViewModel
 import kotlinx.coroutines.launch
 import java.text.NumberFormat
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -60,6 +72,23 @@ fun TeamMemberPortalScreen(
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    var selectedTab by remember { mutableIntStateOf(0) }
+    var selectedDateMs by remember {
+        mutableLongStateOf(
+            LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        )
+    }
+
+    val pendingAssignments = remember(uiState.assignments) {
+        uiState.assignments.filter { AssignmentStatus.fromString(it.status) == AssignmentStatus.PENDING }
+    }
+
+    val selectedDayAssignments = remember(uiState.assignments, selectedDateMs) {
+        val selectedDate = Instant.ofEpochMilli(selectedDateMs).atZone(ZoneId.systemDefault()).toLocalDate()
+        uiState.assignments.filter { assignment ->
+            assignment.eventDate.toLocalDateOrNull() == selectedDate
+        }
+    }
 
     LaunchedEffect(uiState.errorMessage) {
         uiState.errorMessage?.let {
@@ -71,7 +100,7 @@ fun TeamMemberPortalScreen(
     Scaffold(
         topBar = {
             SolennixTopAppBar(
-                title = { Text("Mis asignaciones") },
+                title = { Text("Mi jornada") },
                 actions = {
                     IconButton(onClick = { viewModel.refresh() }) {
                         Icon(Icons.Default.Refresh, contentDescription = "Recargar")
@@ -133,19 +162,123 @@ fun TeamMemberPortalScreen(
                         contentPadding = PaddingValues(16.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        items(uiState.assignments, key = { it.eventStaffId }) { assignment ->
-                            TeamMemberAssignmentCard(
-                                assignment = assignment,
-                                isResponding = uiState.respondingAssignmentIds.contains(assignment.eventStaffId),
-                                onAccept = { viewModel.respond(assignment, AssignmentPortalResponse.ACCEPT) },
-                                onDecline = { viewModel.respond(assignment, AssignmentPortalResponse.DECLINE) }
-                            )
+                        item {
+                            TabRow(selectedTabIndex = selectedTab) {
+                                Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 }, text = { Text("Mi jornada") })
+                                Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 }, text = { Text("Calendario") })
+                            }
+                        }
+
+                        if (selectedTab == 0) {
+                            item {
+                                Text(
+                                    text = "Pendientes por responder",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = SolennixTheme.colors.secondaryText,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+
+                            if (pendingAssignments.isEmpty()) {
+                                item {
+                                    InfoCard("No tenes invitaciones pendientes.")
+                                }
+                            } else {
+                                items(pendingAssignments, key = { it.eventStaffId }) { assignment ->
+                                    TeamMemberAssignmentCard(
+                                        assignment = assignment,
+                                        isResponding = uiState.respondingAssignmentIds.contains(assignment.eventStaffId),
+                                        onAccept = { viewModel.respond(assignment, AssignmentPortalResponse.ACCEPT) },
+                                        onDecline = { viewModel.respond(assignment, AssignmentPortalResponse.DECLINE) }
+                                    )
+                                }
+                            }
+
+                            item {
+                                Text(
+                                    text = "Mi agenda",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = SolennixTheme.colors.secondaryText,
+                                    fontWeight = FontWeight.SemiBold,
+                                    modifier = Modifier.padding(top = 4.dp)
+                                )
+                            }
+
+                            items(uiState.assignments, key = { it.eventStaffId }) { assignment ->
+                                TeamMemberAssignmentCard(
+                                    assignment = assignment,
+                                    isResponding = uiState.respondingAssignmentIds.contains(assignment.eventStaffId),
+                                    onAccept = { viewModel.respond(assignment, AssignmentPortalResponse.ACCEPT) },
+                                    onDecline = { viewModel.respond(assignment, AssignmentPortalResponse.DECLINE) }
+                                )
+                            }
+                        } else {
+                            item {
+                                AndroidView(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(SolennixTheme.colors.card),
+                                    factory = { context ->
+                                        CalendarView(context).apply {
+                                            date = selectedDateMs
+                                            setOnDateChangeListener { _, year, month, dayOfMonth ->
+                                                val selected = LocalDate.of(year, month + 1, dayOfMonth)
+                                                selectedDateMs = selected.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                                            }
+                                        }
+                                    },
+                                    update = { it.date = selectedDateMs }
+                                )
+                            }
+
+                            item {
+                                Text(
+                                    text = "Eventos del dia",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = SolennixTheme.colors.secondaryText,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+
+                            if (selectedDayAssignments.isEmpty()) {
+                                item {
+                                    InfoCard("No hay asignaciones para esta fecha.")
+                                }
+                            } else {
+                                items(selectedDayAssignments, key = { it.eventStaffId }) { assignment ->
+                                    TeamMemberAssignmentCard(
+                                        assignment = assignment,
+                                        isResponding = uiState.respondingAssignmentIds.contains(assignment.eventStaffId),
+                                        onAccept = { viewModel.respond(assignment, AssignmentPortalResponse.ACCEPT) },
+                                        onDecline = { viewModel.respond(assignment, AssignmentPortalResponse.DECLINE) }
+                                    )
+                                }
+                            }
                         }
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun InfoCard(message: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = SolennixTheme.colors.card)
+    ) {
+        Text(
+            text = message,
+            color = SolennixTheme.colors.secondaryText,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+private fun String.toLocalDateOrNull(): LocalDate? {
+    return runCatching { LocalDate.parse(this) }.getOrNull()
 }
 
 @Composable

--- a/docs/PRD/02_FEATURES.md
+++ b/docs/PRD/02_FEATURES.md
@@ -1056,6 +1056,8 @@ Visualización + registro de pago por transferencia con approve/reject. Reemplaz
 - iPhone → overflow "Más" (no se agrega como 6º tab).
 - Android → overflow del bottom nav.
 
+**Decisión de UX 2026-05-15:** la experiencia del miembro se consolida en una sola superficie operativa. `Mis asignaciones` y `Mis eventos` dejan de competir como pantallas separadas y pasan a ser vistas/filtros dentro de una misma agenda; `Calendario de trabajo` se redefine como calendario real, no como lista agrupada por mes.
+
 ---
 
 ## P2 — Futuro

--- a/docs/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md
+++ b/docs/PRD/05_TECHNICAL_ARCHITECTURE_IOS.md
@@ -55,6 +55,13 @@ platform: iOS
 > - Pendiente: `TeamHomeView`, calendario completo mes/semana/día y detalle Team scoped.
 > - Fuente de roadmap y DoD: `docs/PRD/17_PERSONAL_TRACKER.md`.
 
+> [!success] 2026-05-15 — Team Member Portal iOS: consolidación + calendario (slice A3)
+>
+> - `TeamMemberPortalView` se consolidó en una única superficie operativa con selector segmentado: `Mi jornada` + `Calendario`.
+> - `Mi jornada` contiene pendientes accionables y agenda completa en la misma vista.
+> - `Calendario` usa `DatePicker(.graphical)` para selección real de fecha y detalle de asignaciones del día.
+> - `TeamMemberPortalViewModel.respond` ahora actualiza estado (`confirmed/declined/cancelled`) en lugar de eliminar la asignación, para mantener continuidad de agenda.
+
 > [!info] Dependencias externas SPM (2026-04-16)
 >
 > | Paquete                          | Versión mínima | Usado en                              |

--- a/docs/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md
+++ b/docs/PRD/06_TECHNICAL_ARCHITECTURE_ANDROID.md
@@ -53,6 +53,13 @@ platform: Android
 > - Pendiente: `TeamHomeScreen`, calendario completo mes/semana/día y detalle Team scoped.
 > - Fuente de roadmap y DoD: `docs/PRD/17_PERSONAL_TRACKER.md`.
 
+> [!success] 2026-05-15 — Team Member Portal Android: consolidación + calendario (slice A3)
+>
+> - `TeamMemberPortalScreen` se consolidó en una sola superficie con tabs `Mi jornada` y `Calendario`.
+> - `Mi jornada` agrupa pendientes accionables y agenda completa en la misma pantalla.
+> - `Calendario` usa `CalendarView` nativo con selección de día y lista de asignaciones del día.
+> - Se mantiene refresh, manejo de errores y actualización de estado de asignaciones en `TeamMemberPortalViewModel`.
+
 > [!tip] Documentos relacionados
 > [[PRD MOC]] · [[01_PRODUCT_VISION]] · [[02_FEATURES]] · [[05_TECHNICAL_ARCHITECTURE_IOS]] · [[07_TECHNICAL_ARCHITECTURE_BACKEND]] · [[08_TECHNICAL_ARCHITECTURE_WEB]] · [[11_CURRENT_STATUS]] · [[19_I18N_STRATEGY]]
 

--- a/docs/PRD/08_TECHNICAL_ARCHITECTURE_WEB.md
+++ b/docs/PRD/08_TECHNICAL_ARCHITECTURE_WEB.md
@@ -37,6 +37,12 @@ platform: Web
 > - Requisito: mantener guard de rol para aislar miembros invitados del layout de organizer.
 > - Fuente de backlog y DoD: `docs/PRD/17_PERSONAL_TRACKER.md`.
 
+> [!success] 2026-05-15 — Team Member web A1 consolidado
+> Primera ejecución del rediseño utility-first en web:
+> - Ruta principal del miembro: `/team/work`.
+> - Consolidación de `Mis asignaciones` + `Mis eventos` en una sola pantalla operativa (pendientes + agenda).
+> - Rutas legacy (`/team/assignments`, `/team/events`) preservadas como redirect para transición.
+
 > [!success] 2026-05-04 — Web 1.0.0 + Help Center alineado al design system
 > La Web queda formalmente en `1.0.0` y el Help Center deja de usar una paleta paralela para adoptar los tokens del sistema (`bg-*`, `text-*`, `border-*`).
 > - **Fuente canonica de version:** `versioning/releases.json`

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -25,6 +25,27 @@ status: active
 **Fecha:** Mayo 2026
 **Version:** 1.7
 
+> [!success] 2026-05-15 — Team Member Portal web: consolidación A1 implementada
+> Se ejecutó el primer slice de consolidación en Web para reducir duplicación de pantallas en el flujo de miembro.
+> - Nueva ruta principal: `/team/work` como superficie operativa única.
+> - `Mis asignaciones` y `Mis eventos` pasan a una sola pantalla con dos bloques: pendientes accionables + agenda filtrable.
+> - Rutas legacy (`/team/assignments`, `/team/events`, `/team`) quedan como redirects a `/team/work` para transición segura.
+> - Navegación Team Member simplificada: `Mi jornada` + `Calendario`.
+
+> [!success] 2026-05-15 — Team Member Portal web: calendario real A2 implementado
+> Se reemplazó la agenda agrupada por mes por un calendario real en la ruta Team Member.
+> - `Calendario de trabajo` ahora muestra grilla mensual navegable (prev/next + hoy).
+> - Los días renderizan densidad visual de asignaciones por estado (dots).
+> - Selección de fecha con panel derecho de detalle y acciones accept/decline para pendientes del día.
+> - Filtros de estado + búsqueda integrados sobre la misma fuente de asignaciones.
+
+> [!success] 2026-05-15 — Team Member Portal móvil: paridad A3 iOS + Android implementada
+> Se alineó el flujo móvil del miembro con la decisión de consolidación y calendario real.
+> - **iOS:** `TeamMemberPortalView` ahora usa una sola superficie con secciones `Mi jornada` y `Calendario` (selector gráfico de fecha + eventos del día).
+> - **Android:** `TeamMemberPortalScreen` ahora usa tabs `Mi jornada` y `Calendario` (CalendarView nativo + eventos del día).
+> - **Consolidación:** ambas plataformas muestran pendientes accionables y agenda en la misma pantalla operativa.
+> - **Respuesta de asignación:** iOS deja de remover ítems al responder y actualiza estado final para mantener consistencia de agenda.
+
 > [!info] 2026-05-14 — Plan de producto definido para Team Member Portal (Ola 4)
 > Se formalizó el backlog funcional para evolucionar el portal `team_member` desde vistas listadas hacia una experiencia de utilidad diaria y calendario operativo real.
 > - **Documento fuente:** `docs/PRD/17_PERSONAL_TRACKER.md` (sección "Ola 4 — Team Member Portal Utility")
@@ -38,6 +59,7 @@ status: active
 > - **Android:** `User.role` agregado al contrato, routing por rol en `MainNavHost`, nueva `TeamMemberPortalScreen` con carga y respuesta de asignaciones.
 > - **Backend:** sin cambios requeridos para este slice (ya existían `GET /api/staff/my-assignments` y `POST /api/staff/assignments/{id}/respond`).
 > - **Estado:** Ola 4 en progreso; faltan Mi Jornada, calendario completo mes/semana/día, detalle Team, timeline y disponibilidad.
+> - **Decisión de UX:** la siguiente iteración consolida `Mis asignaciones` + `Mis eventos` y reemplaza el pseudo-calendario por una vista real de agenda/calendario.
 
 > [!success] 2026-05-11 — Personal Phase 3.5: team_member responde asignación + first-accept-wins
 > Se implementó el MVP operativo para colaboradores con login (`team_member`) dentro de Personal:

--- a/docs/PRD/17_PERSONAL_TRACKER.md
+++ b/docs/PRD/17_PERSONAL_TRACKER.md
@@ -33,6 +33,51 @@ status: phase-2-done-olas-1-2-3-complete-ola-4-in-progress
 > [!info] Ola 4 iniciada 2026-05-15 — Team Member Portal Utility-First
 > Se definió el backlog funcional y ya se implementó el slice base móvil: entrada por rol `team_member` + bandeja mínima de asignaciones en iOS/Android.
 
+> [!success] Ola 4 — Slice A1 web implementado 2026-05-15
+> Se completó la consolidación inicial en web para eliminar la duplicación entre `Mis asignaciones` y `Mis eventos`.
+> - Nueva superficie unificada: `/team/work`.
+> - Estructura: sección de pendientes (aceptar/rechazar) + sección de agenda filtrable.
+> - Compatibilidad: `/team/assignments` y `/team/events` redirigen a `/team/work`.
+> - Navegación Team Member simplificada a dos entradas: `Mi jornada` y `Calendario`.
+
+> [!success] Ola 4 — Slice A2 web implementado 2026-05-15
+> Se reemplazó el pseudo-calendario de Team Member por una vista de calendario real.
+> - `TeamCalendarPage` migra a grilla mensual con selección de día.
+> - Densidad de asignaciones por fecha visible en cada celda (indicadores por estado).
+> - Panel de detalle del día con acciones rápidas accept/decline para pendientes.
+> - Filtros de estado y búsqueda aplicados sobre calendario y detalle diario.
+
+> [!success] Ola 4 — Slice A3 mobile implementado 2026-05-15
+> Se aplicó paridad de consolidación y calendario real en iOS y Android para `team_member`.
+> - **iOS:** `TeamMemberPortalView` agrega secciones `Mi jornada` + `Calendario` con `DatePicker(.graphical)` y eventos del día.
+> - **Android:** `TeamMemberPortalScreen` agrega tabs `Mi jornada` + `Calendario` con `CalendarView` nativo y eventos del día.
+> - **Comportamiento común:** pendientes accionables + agenda en una sola superficie, sin pantallas duplicadas.
+
+> [!important] Decisión 2026-05-15 — consolidación del portal miembro
+> La experiencia actual de `Mis asignaciones`, `Mis eventos` y `Calendario de trabajo` se rediseña para evitar pantallas duplicadas y darle al miembro una superficie realmente útil.
+> - **Superficie principal:** una sola experiencia de trabajo, centrada en `Mi Jornada` o `Mi Agenda`.
+> - **Bandeja operativa:** las asignaciones pendientes viven en la misma superficie, no en una pantalla aislada que repite datos.
+> - **Agenda unificada:** los próximos eventos y el historial se muestran como una sola línea de tiempo filtrable, no como dos listas clonadas.
+> - **Calendario real:** el calendario deja de ser una lista agrupada por fecha con filtro mensual y pasa a una grilla mes/semana/día con acceso a detalle.
+> - **Transición segura:** las rutas viejas pueden quedar como redirects temporales hasta cortar la redundancia por completo.
+
+### Rediseño operativo propuesto
+
+| Bloque | Decisión |
+|---|---|
+| Entrada principal | `Mi Jornada` como landing del miembro |
+| Acción inmediata | Pendientes por responder + CTA de aceptar/rechazar |
+| Consulta de trabajo | `Mi Agenda` con próximos eventos, pasados y filtros útiles |
+| Calendario | Vista real con meses, días y detalle por evento |
+| Redundancia | `Mis eventos` deja de ser una pantalla independiente |
+
+### Orden de ejecución recomendado
+
+1. Consolidar `Mis asignaciones` + `Mis eventos` en una sola superficie operativa.
+2. Reemplazar `Calendario de trabajo` por una vista de calendario real.
+3. Agregar detalle operativo del evento desde agenda/calendario.
+4. Dejar redirects o aliases temporales para las rutas viejas mientras dura la migración.
+
 ---
 
 ## 🧭 Qué resuelve

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/TeamMemberPortalViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/TeamMemberPortalViewModel.swift
@@ -38,27 +38,8 @@ public final class TeamMemberPortalViewModel {
         errorMessage = nil
 
         do {
-            let outcome = try await apiClient.respondAssignment(eventStaffId: assignment.id, response: response)
-            assignments = assignments.map { item in
-                guard item.id == assignment.id else { return item }
-                return TeamMemberAssignment(
-                    eventStaffId: item.eventStaffId,
-                    eventId: item.eventId,
-                    eventName: item.eventName,
-                    eventDate: item.eventDate,
-                    staffId: item.staffId,
-                    status: outcome.finalStatus,
-                    feeAmount: item.feeAmount,
-                    roleOverride: item.roleOverride,
-                    notes: item.notes,
-                    shiftStart: item.shiftStart,
-                    shiftEnd: item.shiftEnd,
-                    offerGroupId: item.offerGroupId,
-                    offerSlots: item.offerSlots,
-                    notificationLastResult: item.notificationLastResult,
-                    notificationSentAt: item.notificationSentAt
-                )
-            }
+            _ = try await apiClient.respondAssignment(eventStaffId: assignment.id, response: response)
+            assignments = try await apiClient.getMyAssignments()
         } catch {
             errorMessage = "No pudimos actualizar tu respuesta."
         }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/TeamMemberPortalViewModel.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/ViewModels/TeamMemberPortalViewModel.swift
@@ -38,8 +38,27 @@ public final class TeamMemberPortalViewModel {
         errorMessage = nil
 
         do {
-            _ = try await apiClient.respondAssignment(eventStaffId: assignment.id, response: response)
-            assignments.removeAll { $0.id == assignment.id }
+            let outcome = try await apiClient.respondAssignment(eventStaffId: assignment.id, response: response)
+            assignments = assignments.map { item in
+                guard item.id == assignment.id else { return item }
+                return TeamMemberAssignment(
+                    eventStaffId: item.eventStaffId,
+                    eventId: item.eventId,
+                    eventName: item.eventName,
+                    eventDate: item.eventDate,
+                    staffId: item.staffId,
+                    status: outcome.finalStatus,
+                    feeAmount: item.feeAmount,
+                    roleOverride: item.roleOverride,
+                    notes: item.notes,
+                    shiftStart: item.shiftStart,
+                    shiftEnd: item.shiftEnd,
+                    offerGroupId: item.offerGroupId,
+                    offerSlots: item.offerSlots,
+                    notificationLastResult: item.notificationLastResult,
+                    notificationSentAt: item.notificationSentAt
+                )
+            }
         } catch {
             errorMessage = "No pudimos actualizar tu respuesta."
         }

--- a/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/TeamMemberPortalView.swift
+++ b/ios/Packages/SolennixFeatures/Sources/SolennixFeatures/Staff/Views/TeamMemberPortalView.swift
@@ -5,8 +5,17 @@ import SolennixNetwork
 
 public struct TeamMemberPortalView: View {
 
+    private enum TeamMemberSection: String, CaseIterable, Identifiable {
+        case work
+        case calendar
+
+        var id: String { rawValue }
+    }
+
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var viewModel: TeamMemberPortalViewModel
+    @State private var section: TeamMemberSection = .work
+    @State private var selectedDate: Date = Date()
 
     public init(apiClient: APIClient) {
         _viewModel = State(initialValue: TeamMemberPortalViewModel(apiClient: apiClient))
@@ -15,7 +24,7 @@ public struct TeamMemberPortalView: View {
     public var body: some View {
         NavigationStack {
             content
-                .navigationTitle("Mis asignaciones")
+                .navigationTitle("Mi jornada")
                 .navigationBarTitleDisplayMode(.large)
                 .toolbar {
                     ToolbarItem(placement: .topBarTrailing) {
@@ -60,23 +69,137 @@ public struct TeamMemberPortalView: View {
         } else {
             ScrollView {
                 LazyVStack(spacing: Spacing.md) {
-                    ForEach(viewModel.assignments) { assignment in
-                        TeamMemberAssignmentCard(
-                            assignment: assignment,
-                            isResponding: viewModel.isResponding,
-                            onAccept: {
-                                Task { await viewModel.respond(to: assignment, response: .accept) }
-                            },
-                            onDecline: {
-                                Task { await viewModel.respond(to: assignment, response: .decline) }
-                            }
-                        )
+                    Picker("Seccion", selection: $section) {
+                        Text("Mi jornada").tag(TeamMemberSection.work)
+                        Text("Calendario").tag(TeamMemberSection.calendar)
+                    }
+                    .pickerStyle(.segmented)
+
+                    if section == .work {
+                        workSection
+                    } else {
+                        calendarSection
                     }
                 }
                 .padding(.horizontal, sizeClass == .regular ? Spacing.xxxl : Spacing.xl)
                 .padding(.vertical, Spacing.lg)
             }
         }
+    }
+
+    private var pendingAssignments: [TeamMemberAssignment] {
+        viewModel.assignments.filter { $0.status == .pending }
+    }
+
+    private var selectedDayAssignments: [TeamMemberAssignment] {
+        viewModel.assignments.filter { assignment in
+            guard let assignmentDate = parseLocalDate(assignment.eventDate) else { return false }
+            return Calendar.current.isDate(assignmentDate, inSameDayAs: selectedDate)
+        }
+    }
+
+    @ViewBuilder
+    private var workSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            Text("Pendientes por responder")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(SolennixColors.textSecondary)
+
+            if pendingAssignments.isEmpty {
+                cardContainer {
+                    Text("No tenes invitaciones pendientes.")
+                        .font(.subheadline)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            } else {
+                ForEach(pendingAssignments) { assignment in
+                    TeamMemberAssignmentCard(
+                        assignment: assignment,
+                        isResponding: viewModel.isResponding,
+                        onAccept: {
+                            Task { await viewModel.respond(to: assignment, response: .accept) }
+                        },
+                        onDecline: {
+                            Task { await viewModel.respond(to: assignment, response: .decline) }
+                        }
+                    )
+                }
+            }
+
+            Text("Mi agenda")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(SolennixColors.textSecondary)
+                .padding(.top, Spacing.sm)
+
+            ForEach(viewModel.assignments) { assignment in
+                TeamMemberAssignmentCard(
+                    assignment: assignment,
+                    isResponding: viewModel.isResponding,
+                    onAccept: {
+                        Task { await viewModel.respond(to: assignment, response: .accept) }
+                    },
+                    onDecline: {
+                        Task { await viewModel.respond(to: assignment, response: .decline) }
+                    }
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var calendarSection: some View {
+        VStack(alignment: .leading, spacing: Spacing.md) {
+            cardContainer {
+                DatePicker(
+                    "Fecha",
+                    selection: $selectedDate,
+                    displayedComponents: [.date]
+                )
+                .datePickerStyle(.graphical)
+                .labelsHidden()
+            }
+
+            Text("Eventos del dia")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(SolennixColors.textSecondary)
+
+            if selectedDayAssignments.isEmpty {
+                cardContainer {
+                    Text("No hay asignaciones para esta fecha.")
+                        .font(.subheadline)
+                        .foregroundStyle(SolennixColors.textSecondary)
+                }
+            } else {
+                ForEach(selectedDayAssignments) { assignment in
+                    TeamMemberAssignmentCard(
+                        assignment: assignment,
+                        isResponding: viewModel.isResponding,
+                        onAccept: {
+                            Task { await viewModel.respond(to: assignment, response: .accept) }
+                        },
+                        onDecline: {
+                            Task { await viewModel.respond(to: assignment, response: .decline) }
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func cardContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(Spacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(SolennixColors.card)
+            .clipShape(RoundedRectangle(cornerRadius: CornerRadius.lg))
+            .shadowSm()
+    }
+
+    private func parseLocalDate(_ value: String) -> Date? {
+        let parts = value.split(separator: "-").compactMap { Int($0) }
+        guard parts.count == 3 else { return nil }
+        return Calendar.current.date(from: DateComponents(year: parts[0], month: parts[1], day: parts[2]))
     }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -12,6 +12,8 @@
     </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="/pwa-192x192.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "Solennix",
+  "short_name": "Solennix",
+  "description": "Event management for LATAM organizers",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#C4A265",
+  "background_color": "#1B2A4A",
+  "icons": [
+    {
+      "src": "/pwa-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/pwa-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -61,7 +61,6 @@ const ClientPortalPage = React.lazy(() => import("@/pages/ClientPortal/ClientPor
 
 const EventFormLinksPage = React.lazy(() => import("@/pages/EventForms/EventFormLinksPage").then((m) => ({ default: m.EventFormLinksPage })));
 const PaymentInboxPage = React.lazy(() => import("@/pages/Payments/PaymentInboxPage").then((m) => ({ default: m.PaymentInboxPage })));
-const TeamMemberAssignmentsPage = React.lazy(() => import("@/pages/TeamMember/AssignmentsPage").then((m) => ({ default: m.AssignmentsPage })));
 const TeamMemberEventsPage = React.lazy(() => import("@/pages/TeamMember/TeamEventsPage").then((m) => ({ default: m.TeamEventsPage })));
 const TeamMemberCalendarPage = React.lazy(() => import("@/pages/TeamMember/TeamCalendarPage").then((m) => ({ default: m.TeamCalendarPage })));
 
@@ -155,20 +154,20 @@ function App() {
               </Route>
 
               <Route
-                path="/team/assignments"
-                element={
-                  <ProtectedRoute>
-                    <TeamMemberAssignmentsPage />
-                  </ProtectedRoute>
-                }
-              />
-              <Route
-                path="/team/events"
+                path="/team/work"
                 element={
                   <ProtectedRoute>
                     <TeamMemberEventsPage />
                   </ProtectedRoute>
                 }
+              />
+              <Route
+                path="/team/assignments"
+                element={<Navigate to="/team/work" replace />}
+              />
+              <Route
+                path="/team/events"
+                element={<Navigate to="/team/work" replace />}
               />
               <Route
                 path="/team/calendar"
@@ -178,7 +177,7 @@ function App() {
                   </ProtectedRoute>
                 }
               />
-              <Route path="/team" element={<Navigate to="/team/events" replace />} />
+              <Route path="/team" element={<Navigate to="/team/work" replace />} />
 
               <Route path="/pricing" element={<ProtectedRoute><Pricing /></ProtectedRoute>} />
               <Route path="*" element={<NotFound />} />

--- a/web/src/contexts/AuthContext.test.tsx
+++ b/web/src/contexts/AuthContext.test.tsx
@@ -6,6 +6,17 @@ import { api } from '../lib/api';
 import { logError } from '../lib/errorHandler';
 
 vi.mock('../lib/api', () => ({
+  ApiHttpError: class ApiHttpError extends Error {
+    statusCode: number;
+    endpoint: string;
+
+    constructor(message: string, statusCode: number, endpoint: string) {
+      super(message);
+      this.name = 'ApiHttpError';
+      this.statusCode = statusCode;
+      this.endpoint = endpoint;
+    }
+  },
   api: {
     get: vi.fn(),
     post: vi.fn(),

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { api } from '@/lib/api';
+import { ApiHttpError, api } from '@/lib/api';
 import { logError } from '@/lib/errorHandler';
 import { User } from '@/types/auth';
 import { AuthContext } from './AuthContextInstance';
@@ -8,6 +8,18 @@ import i18n from '@/i18n/config';
 
 // eslint-disable-next-line react-refresh/only-export-components
 export { AuthContext, useAuth };
+
+const isPublicAuthRoute = (pathname: string) => {
+  const publicAuthRoutes = new Set([
+    '/login',
+    '/register',
+    '/forgot-password',
+    '/reset-password',
+    '/team-invite',
+    '/team-invite/accept',
+  ]);
+  return publicAuthRoutes.has(pathname);
+};
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
@@ -19,7 +31,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const userData = await api.get<User>('/auth/me');
       setUser(userData);
     } catch (error) {
-      logError('Auth check failed', error);
+      // A 401 from /auth/me is expected when no session is active — don't log it as an error
+      if (!(error instanceof ApiHttpError && error.statusCode === 401)) {
+        logError('Auth check failed', error);
+      }
       setUser(null);
     } finally {
       setLoading(false);
@@ -27,6 +42,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   };
 
   useEffect(() => {
+    // Skip the /auth/me network call on public auth routes — no session expected there
+    if (isPublicAuthRoute(window.location.pathname)) {
+      setLoading(false);
+      return;
+    }
     checkAuth();
     
     // Listen for 401 logout events from api.ts

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,6 +24,24 @@ export class PlanLimitExceededError extends Error {
 }
 
 /**
+ * Thrown for any non-OK HTTP response that isn't already handled by
+ * a more specific error type (e.g. PlanLimitExceededError).
+ * Preserves the status code so callers can distinguish expected 401s
+ * (no active session) from genuine errors without string matching.
+ */
+export class ApiHttpError extends Error {
+  readonly statusCode: number;
+  readonly endpoint: string;
+
+  constructor(message: string, statusCode: number, endpoint: string) {
+    super(message);
+    this.name = 'ApiHttpError';
+    this.statusCode = statusCode;
+    this.endpoint = endpoint;
+  }
+}
+
+/**
  * Detail payload emitted on the `plan:limit-exceeded` CustomEvent.
  * Listeners (e.g., Layout.tsx) use this to decide whether to show a
  * modal, redirect, or simply flash a toast.
@@ -175,7 +193,11 @@ class ApiClient {
           detail.max,
         );
       }
-      throw new Error(errorData.error || `Request failed with status ${response.status}`);
+      throw new ApiHttpError(
+        errorData.error || `Request failed with status ${response.status}`,
+        response.status,
+        endpoint,
+      );
     }
 
     // Handle 204 No Content

--- a/web/src/pages/TeamMember/TeamCalendarPage.tsx
+++ b/web/src/pages/TeamMember/TeamCalendarPage.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/style.css';
 import { useTranslation } from 'react-i18next';
-import { CalendarDays } from 'lucide-react';
-import { useMyAssignments } from '@/hooks/queries/useStaffQueries';
+import { CalendarDays, CheckCircle2, Clock3, Search, XCircle } from 'lucide-react';
+import { format, isSameDay, startOfDay, startOfMonth, type Locale } from 'date-fns';
+import { enUS, es } from 'date-fns/locale';
+import { useMyAssignments, useRespondAssignment } from '@/hooks/queries/useStaffQueries';
 import type { TeamMemberAssignment } from '@/types/entities';
 import {
   filterAssignments,
@@ -12,43 +16,64 @@ import {
 } from './teamMemberUtils';
 import { TeamMemberPortalNav } from './components/TeamMemberPortalNav';
 
-const toMonthInput = (date: Date) => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+const parseLocalDate = (dateIso: string): Date => {
+  const [year, month, day] = dateIso.split('-').map(Number);
+  return startOfDay(new Date(year, month - 1, day));
+};
 
-const isInMonth = (dateIso: string, monthInput: string) => dateIso.startsWith(monthInput);
+const pickDateFnsLocale = (lang: string | undefined): Locale =>
+  lang?.startsWith('en') ? enUS : es;
 
-const byDate = (list: TeamMemberAssignment[]) => {
-  const map = new Map<string, TeamMemberAssignment[]>();
-  list.forEach((assignment) => {
-    const existing = map.get(assignment.event_date) ?? [];
-    existing.push(assignment);
-    map.set(assignment.event_date, existing);
-  });
-
-  return Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+const statusBadgeClass: Record<TeamMemberAssignment['status'], string> = {
+  pending: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200',
+  confirmed: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200',
+  declined: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200',
+  cancelled: 'bg-slate-200 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200',
 };
 
 export const TeamCalendarPage: React.FC = () => {
   const { t, i18n } = useTranslation(['common']);
+  const dfnsLocale = React.useMemo(() => pickDateFnsLocale(i18n.language), [i18n.language]);
   const { data: assignments = [], isLoading, isError, refetch } = useMyAssignments();
+  const respondMutation = useRespondAssignment();
   const moneyFormatter = React.useMemo(
     () => new Intl.NumberFormat(i18n.language || 'es-MX', { style: 'currency', currency: 'MXN' }),
     [i18n.language],
   );
 
-  const [month, setMonth] = React.useState(toMonthInput(new Date()));
+  const today = React.useMemo(() => startOfDay(new Date()), []);
+  const [currentMonth, setCurrentMonth] = React.useState<Date>(startOfMonth(today));
+  const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(today);
   const [statusFilter, setStatusFilter] = React.useState<TeamStatusFilter>('all');
-
-  const monthAssignments = React.useMemo(
-    () => assignments.filter((item) => isInMonth(item.event_date, month)),
-    [assignments, month],
-  );
+  const [search, setSearch] = React.useState('');
 
   const filtered = React.useMemo(
-    () => filterAssignments(monthAssignments, statusFilter, ''),
-    [monthAssignments, statusFilter],
+    () => filterAssignments(assignments, statusFilter, search),
+    [assignments, statusFilter, search],
   );
 
-  const grouped = React.useMemo(() => byDate(filtered), [filtered]);
+  const dayInfoByDate = React.useMemo(() => {
+    const map = new Map<string, { dots: TeamMemberAssignment['status'][]; total: number }>();
+    filtered.forEach((item) => {
+      const existing = map.get(item.event_date) ?? { dots: [], total: 0 };
+      existing.total += 1;
+      if (!existing.dots.includes(item.status) && existing.dots.length < 3) {
+        existing.dots.push(item.status);
+      }
+      map.set(item.event_date, existing);
+    });
+    return map;
+  }, [filtered]);
+
+  const selectedDayAssignments = React.useMemo(
+    () => filtered.filter((item) => selectedDate && isSameDay(parseLocalDate(item.event_date), selectedDate)),
+    [filtered, selectedDate],
+  );
+
+  const pendingIds = React.useMemo(
+    () => new Set(assignments.filter((item) => item.status === 'pending').map((item) => item.event_staff_id)),
+    [assignments],
+  );
 
   if (isLoading) {
     return (
@@ -70,7 +95,7 @@ export const TeamCalendarPage: React.FC = () => {
               {t('team.calendar_title', { defaultValue: 'Calendario de trabajo' })}
             </h1>
             <p className="text-sm text-text-secondary">
-              {t('team.calendar_subtitle', { defaultValue: 'Visualizá tus eventos asignados por fecha.' })}
+              {t('team.calendar_subtitle', { defaultValue: 'Usá un calendario real para planear tu carga de trabajo.' })}
             </p>
             <TeamMemberPortalNav />
           </header>
@@ -100,22 +125,13 @@ export const TeamCalendarPage: React.FC = () => {
             {t('team.calendar_title', { defaultValue: 'Calendario de trabajo' })}
           </h1>
           <p className="text-sm text-text-secondary">
-            {t('team.calendar_subtitle', { defaultValue: 'Visualizá tus eventos asignados por fecha.' })}
+            {t('team.calendar_subtitle', { defaultValue: 'Usá un calendario real para planear tu carga de trabajo.' })}
           </p>
           <TeamMemberPortalNav />
         </header>
 
         <section className="rounded-2xl border border-border bg-card p-4">
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="text-sm text-text-secondary">
-              {t('team.filter.month', { defaultValue: 'Mes' })}
-              <input
-                type="month"
-                className="mt-1 w-full rounded-xl border border-border bg-bg px-3 py-2 text-sm text-text"
-                value={month}
-                onChange={(e) => setMonth(e.target.value)}
-              />
-            </label>
+          <div className="grid gap-3 md:grid-cols-4">
             <label className="text-sm text-text-secondary">
               {t('team.filter.status', { defaultValue: 'Estado' })}
               <select
@@ -141,32 +157,154 @@ export const TeamCalendarPage: React.FC = () => {
                 ))}
               </select>
             </label>
+
+            <label className="text-sm text-text-secondary md:col-span-3">
+              {t('team.filter.search', { defaultValue: 'Buscar evento' })}
+              <div className="mt-1 flex items-center rounded-xl border border-border bg-bg px-3">
+                <Search className="h-4 w-4 text-text-secondary" aria-hidden="true" />
+                <input
+                  type="search"
+                  className="w-full border-0 bg-transparent px-2 py-2 text-sm text-text outline-none"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={t('team.filter.search_placeholder', { defaultValue: 'Nombre del evento' })}
+                />
+              </div>
+            </label>
           </div>
         </section>
 
-        {grouped.length === 0 ? (
-          <div className="rounded-2xl border border-border bg-card p-8 text-center text-sm text-text-secondary">
-            {t('team.calendar_empty', { defaultValue: 'No hay eventos asignados para este mes y filtro.' })}
-          </div>
-        ) : (
-          <div className="space-y-4">
-            {grouped.map(([date, items]) => (
-              <section key={date} className="rounded-2xl border border-border bg-card p-4">
-                <h2 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
-                  {formatEventDate(date, i18n.language)}
-                </h2>
-                <div className="mt-3 space-y-2">
-                  {items.map((assignment) => {
-                    const shift = formatShiftLabel(assignment, i18n.language, t);
-                    return (
-                      <div
-                        key={assignment.event_staff_id}
-                        className="flex flex-col gap-1 rounded-xl border border-border/70 bg-bg px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
-                      >
+        <div className="grid gap-4 lg:grid-cols-[380px_1fr]">
+          <section className="rounded-2xl border border-border bg-card p-4">
+            <style>{`
+              .team-rdp .rdp-day_button {
+                position: relative;
+              }
+              .team-rdp .team-rdp-dot-row {
+                position: absolute;
+                bottom: 4px;
+                left: 50%;
+                transform: translateX(-50%);
+                display: flex;
+                gap: 2px;
+              }
+              .team-rdp .team-rdp-dot {
+                width: 5px;
+                height: 5px;
+                border-radius: 999px;
+              }
+            `}</style>
+
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
+                {format(currentMonth, 'MMMM yyyy', { locale: dfnsLocale })}
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  const now = startOfDay(new Date());
+                  setCurrentMonth(startOfMonth(now));
+                  setSelectedDate(now);
+                }}
+                className="rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-text-secondary hover:bg-surface-alt"
+              >
+                {t('team.today', { defaultValue: 'Hoy' })}
+              </button>
+            </div>
+
+            <DayPicker
+              mode="single"
+              month={currentMonth}
+              selected={selectedDate}
+              onSelect={setSelectedDate}
+              onMonthChange={(month) => setCurrentMonth(startOfMonth(startOfDay(month)))}
+              showOutsideDays
+              locale={dfnsLocale}
+              className="team-rdp"
+              components={{
+                DayButton: ({ day, children, ...props }) => {
+                  const key = format(day.date, 'yyyy-MM-dd');
+                  const info = dayInfoByDate.get(key);
+                  return (
+                    <button {...props}>
+                      {children}
+                      {info && info.total > 0 ? (
+                        <span className="team-rdp-dot-row" aria-hidden="true">
+                          {info.dots.map((status, index) => (
+                            <span
+                              key={`${status}-${index}`}
+                              className="team-rdp-dot"
+                              style={{
+                                backgroundColor:
+                                  status === 'pending'
+                                    ? '#d97706'
+                                    : status === 'confirmed'
+                                      ? '#059669'
+                                      : status === 'declined'
+                                        ? '#e11d48'
+                                        : '#64748b',
+                              }}
+                            />
+                          ))}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                },
+              }}
+            />
+
+            <p className="mt-3 text-xs text-text-secondary">
+              {t('team.calendar_legend', {
+                defaultValue: 'Puntos por día indican asignaciones (estado filtrado).',
+              })}
+            </p>
+          </section>
+
+          <section className="rounded-2xl border border-border bg-card p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
+                {selectedDate
+                  ? format(selectedDate, 'EEEE d MMMM yyyy', { locale: dfnsLocale })
+                  : t('team.select_day', { defaultValue: 'Seleccioná un día' })}
+              </h2>
+              {selectedDate ? (
+                <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                  {selectedDayAssignments.length}
+                </span>
+              ) : null}
+            </div>
+
+            {selectedDayAssignments.length === 0 ? (
+              <div className="rounded-xl border border-border/70 bg-bg px-4 py-8 text-center text-sm text-text-secondary">
+                {t('team.calendar_day_empty', { defaultValue: 'No hay asignaciones para este día con los filtros activos.' })}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {selectedDayAssignments.map((assignment) => {
+                  const shift = formatShiftLabel(assignment, i18n.language, t);
+                  const isPending = assignment.status === 'pending';
+                  const isBusy = respondMutation.isPending && pendingIds.has(assignment.event_staff_id);
+
+                  return (
+                    <article
+                      key={assignment.event_staff_id}
+                      className="rounded-xl border border-border/70 bg-bg px-3 py-3"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                         <div>
-                          <p className="text-sm font-medium text-text">{assignment.event_name}</p>
-                          <div className="flex flex-wrap items-center gap-2 text-xs text-text-secondary">
-                            {shift ? <span>{shift}</span> : null}
+                          <p className="text-sm font-semibold text-text">{assignment.event_name}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-secondary">
+                            <span className="inline-flex items-center gap-1">
+                              <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                              {formatEventDate(assignment.event_date, i18n.language)}
+                            </span>
+                            {shift ? (
+                              <span className="inline-flex items-center gap-1">
+                                <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                                {shift}
+                              </span>
+                            ) : null}
                             {assignment.fee_amount != null ? (
                               <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
                                 {t('team.fee', { defaultValue: 'Pago' })}: {moneyFormatter.format(assignment.fee_amount)}
@@ -174,8 +312,7 @@ export const TeamCalendarPage: React.FC = () => {
                             ) : null}
                           </div>
                         </div>
-                        <span className="inline-flex items-center gap-1 text-xs text-text-secondary">
-                          <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                        <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClass[assignment.status]}`}>
                           {t(`team.status.${assignment.status}`, {
                             defaultValue:
                               assignment.status === 'pending'
@@ -188,13 +325,59 @@ export const TeamCalendarPage: React.FC = () => {
                           })}
                         </span>
                       </div>
-                    );
-                  })}
-                </div>
-              </section>
-            ))}
+
+                      {(assignment.role_override || assignment.notes) && (
+                        <div className="mt-2 space-y-1 text-xs text-text-secondary">
+                          {assignment.role_override ? (
+                            <p>
+                              <span className="font-medium text-text">{t('team.role', { defaultValue: 'Rol' })}:</span>{' '}
+                              {assignment.role_override}
+                            </p>
+                          ) : null}
+                          {assignment.notes ? (
+                            <p>
+                              <span className="font-medium text-text">{t('team.notes', { defaultValue: 'Notas' })}:</span>{' '}
+                              {assignment.notes}
+                            </p>
+                          ) : null}
+                        </div>
+                      )}
+
+                      {isPending ? (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            disabled={isBusy}
+                            onClick={() => respondMutation.mutate({ id: assignment.event_staff_id, response: 'accept' })}
+                            className="inline-flex items-center rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-60"
+                          >
+                            <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                            {t('team.accept', { defaultValue: 'Aceptar' })}
+                          </button>
+                          <button
+                            type="button"
+                            disabled={isBusy}
+                            onClick={() => respondMutation.mutate({ id: assignment.event_staff_id, response: 'decline' })}
+                            className="inline-flex items-center rounded-lg bg-rose-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-700 disabled:opacity-60"
+                          >
+                            <XCircle className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                            {t('team.decline', { defaultValue: 'Rechazar' })}
+                          </button>
+                        </div>
+                      ) : null}
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="rounded-2xl border border-border bg-card p-6 text-center text-sm text-text-secondary">
+            {t('team.calendar_empty', { defaultValue: 'No hay asignaciones para los filtros activos.' })}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/pages/TeamMember/TeamEventsPage.tsx
+++ b/web/src/pages/TeamMember/TeamEventsPage.tsx
@@ -50,6 +50,11 @@ export const TeamEventsPage: React.FC = () => {
     [assignments, statusFilter, search, fromDate, toDate],
   );
 
+  const pendingAssignments = React.useMemo(
+    () => assignments.filter((item) => item.status === 'pending'),
+    [assignments],
+  );
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-bg px-4 py-8">
@@ -67,10 +72,12 @@ export const TeamEventsPage: React.FC = () => {
         <div className="mx-auto max-w-5xl space-y-6">
           <header className="space-y-3">
             <h1 className="text-2xl font-bold text-text tracking-tight">
-              {t('team.events_title', { defaultValue: 'Mis eventos' })}
+              {t('team.work_title', { defaultValue: 'Mi jornada' })}
             </h1>
             <p className="text-sm text-text-secondary">
-              {t('team.events_subtitle', { defaultValue: 'Filtrá solo tus eventos asignados y revisá tu estado.' })}
+              {t('team.work_subtitle', {
+                defaultValue: 'Respondé pendientes y revisá toda tu agenda en una sola pantalla.',
+              })}
             </p>
             <TeamMemberPortalNav />
           </header>
@@ -97,15 +104,86 @@ export const TeamEventsPage: React.FC = () => {
       <div className="mx-auto max-w-5xl space-y-6">
         <header className="space-y-3">
           <h1 className="text-2xl font-bold text-text tracking-tight">
-            {t('team.events_title', { defaultValue: 'Mis eventos' })}
+            {t('team.work_title', { defaultValue: 'Mi jornada' })}
           </h1>
           <p className="text-sm text-text-secondary">
-            {t('team.events_subtitle', { defaultValue: 'Filtrá solo tus eventos asignados y revisá tu estado.' })}
+            {t('team.work_subtitle', {
+              defaultValue: 'Respondé pendientes y revisá toda tu agenda en una sola pantalla.',
+            })}
           </p>
           <TeamMemberPortalNav />
         </header>
 
         <section className="rounded-2xl border border-border bg-card p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
+              {t('team.pending_section_title', { defaultValue: 'Pendientes por responder' })}
+            </h2>
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+              {pendingAssignments.length}
+            </span>
+          </div>
+
+          {pendingAssignments.length === 0 ? (
+            <p className="mt-3 text-sm text-text-secondary">
+              {t('team.pending_empty', { defaultValue: 'No tenés invitaciones pendientes.' })}
+            </p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {pendingAssignments.map((assignment) => {
+                const shift = formatShiftLabel(assignment, i18n.language, t);
+                const isBusy = respondMutation.isPending;
+                return (
+                  <article
+                    key={`pending-${assignment.event_staff_id}`}
+                    className="rounded-xl border border-border/70 bg-bg px-3 py-3"
+                  >
+                    <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <h3 className="text-sm font-semibold text-text">{assignment.event_name}</h3>
+                        <div className="mt-1 flex flex-wrap items-center gap-3 text-xs text-text-secondary">
+                          <span className="inline-flex items-center gap-1">
+                            <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                            {formatEventDate(assignment.event_date, i18n.language)}
+                          </span>
+                          {shift ? (
+                            <span className="inline-flex items-center gap-1">
+                              <Clock3 className="h-3.5 w-3.5" aria-hidden="true" />
+                              {shift}
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          disabled={isBusy}
+                          onClick={() => respondMutation.mutate({ id: assignment.event_staff_id, response: 'accept' })}
+                          className="rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:opacity-60"
+                        >
+                          {t('team.accept', { defaultValue: 'Aceptar' })}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={isBusy}
+                          onClick={() => respondMutation.mutate({ id: assignment.event_staff_id, response: 'decline' })}
+                          className="rounded-lg bg-rose-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-700 disabled:opacity-60"
+                        >
+                          {t('team.decline', { defaultValue: 'Rechazar' })}
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="rounded-2xl border border-border bg-card p-4">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-text-secondary">
+            {t('team.agenda_section_title', { defaultValue: 'Mi agenda' })}
+          </h2>
           <div className="grid gap-3 md:grid-cols-4">
             <label className="text-sm text-text-secondary">
               {t('team.filter.status', { defaultValue: 'Estado' })}
@@ -159,7 +237,7 @@ export const TeamEventsPage: React.FC = () => {
 
         {filtered.length === 0 ? (
           <div className="rounded-2xl border border-border bg-card p-8 text-center text-sm text-text-secondary">
-            {t('team.events_empty', { defaultValue: 'No hay eventos asignados con los filtros actuales.' })}
+            {t('team.agenda_empty', { defaultValue: 'No hay asignaciones para los filtros actuales.' })}
           </div>
         ) : (
           <div className="space-y-3">

--- a/web/src/pages/TeamMember/components/TeamMemberPortalNav.tsx
+++ b/web/src/pages/TeamMember/components/TeamMemberPortalNav.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
-import { CalendarRange, ClipboardList, ListTodo, LogOut } from 'lucide-react';
+import { CalendarRange, ClipboardList, LogOut } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -29,13 +29,9 @@ export const TeamMemberPortalNav: React.FC = () => {
 
   return (
     <nav className="flex flex-wrap gap-2" aria-label={t('team.portal_nav', { defaultValue: 'Navegación personal' })}>
-      <NavLink to="/team/assignments" className={linkClass}>
+      <NavLink to="/team/work" className={linkClass}>
         <ClipboardList className="h-4 w-4" aria-hidden="true" />
-        {t('team.nav.assignments', { defaultValue: 'Asignaciones' })}
-      </NavLink>
-      <NavLink to="/team/events" className={linkClass}>
-        <ListTodo className="h-4 w-4" aria-hidden="true" />
-        {t('team.nav.events', { defaultValue: 'Mis eventos' })}
+        {t('team.nav.work', { defaultValue: 'Mi jornada' })}
       </NavLink>
       <NavLink to="/team/calendar" className={linkClass}>
         <CalendarRange className="h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## Linked Issue
- Closes #348

## What
- Consolidates Team Member UX in Web into a single operational surface (`/team/work`) with legacy redirects from `/team/assignments` and `/team/events`.
- Upgrades Team Member calendar in Web to a true day-picker calendar flow with day detail + pending actions.
- Implements mobile parity for Team Member in iOS and Android with unified sections (`Mi jornada` + `Calendario`) and actionable pending assignments.
- Updates PRD status and architecture docs for Web, iOS and Android.

## Why
- Reduce duplicate member screens and improve day-to-day utility for team members.
- Keep cross-platform behavior aligned after web consolidation.

## Scope
- [ ] Backend
- [x] Web
- [x] iOS
- [x] Android
- [x] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Linked issue has `status:approved`
- [x] Exactly one `type:*` label on the PR
- [ ] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [x] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: Medium (UX navigation and behavior changes for team_member routes/screens).
- Rollback: Revert commit `a389d81b` to restore previous Team Member portal behavior.
