### PR TITLE
fix(backend): harden budget PDF layout

### DIFF
--- a/backend/internal/handlers/pdf_handler_test.go
+++ b/backend/internal/handlers/pdf_handler_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuickQuotePDFRequestToPDFData_PercentDiscountAndTax(t *testing.T) {
+	userID := uuid.MustParse("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	email := "cliente@ejemplo.com"
+	req := quickQuotePDFRequest{
+		Client: &quickQuotePDFClient{
+			Name:  "María Fernanda de los Ángeles García Hernández",
+			Phone: "+52 55 5555 5555",
+			Email: &email,
+		},
+		Products: []quickQuotePDFProduct{
+			{
+				ProductID: "product-1",
+				Name:      "Paquete premium con montaje completo y coordinación extendida",
+				Quantity:  2,
+				UnitPrice: 1500,
+				Discount:  100,
+			},
+		},
+		Extras: []quickQuotePDFExtra{
+			{
+				Description:    "Decoración floral integral",
+				Cost:           500,
+				Price:          1000,
+				ExcludeUtility: false,
+			},
+			{
+				Description:    "Permiso del venue",
+				Cost:           300,
+				Price:          300,
+				ExcludeUtility: true,
+			},
+		},
+		NumPeople:       120,
+		Discount:        10,
+		DiscountType:    "percent",
+		RequiresInvoice: true,
+		TaxRate:         16,
+	}
+
+	event, products, extras, client := req.toPDFData(userID)
+
+	assert.NotNil(t, client)
+	assert.Equal(t, req.Client.Name, client.Name)
+	assert.Equal(t, req.Client.Phone, client.Phone)
+	assert.Equal(t, req.Client.Email, client.Email)
+	assert.Equal(t, userID, client.UserID)
+
+	assert.Len(t, products, 1)
+	assert.Len(t, extras, 2)
+	assert.Equal(t, req.Products[0].Name, *products[0].ProductName)
+	assert.Equal(t, 2800.0, products[0].TotalPrice)
+
+	assert.Equal(t, "percent", event.DiscountType)
+	assert.Equal(t, 10.0, event.Discount)
+	assert.Equal(t, 120, event.NumPeople)
+	assert.Equal(t, 595.2, event.TaxAmount)
+	assert.Equal(t, 4315.2, event.TotalAmount)
+	assert.Equal(t, client, event.Client)
+}
+
+func TestQuickQuotePDFRequestToPDFData_SkipsInvalidItemsAndClampsFixedDiscount(t *testing.T) {
+	userID := uuid.MustParse("12345678-1234-1234-1234-1234567890ab")
+	req := quickQuotePDFRequest{
+		Products: []quickQuotePDFProduct{
+			{Name: "", Quantity: 0, UnitPrice: 1000, Discount: 0},
+			{Name: "Servicio base", Quantity: 1, UnitPrice: 500, Discount: 0},
+		},
+		Extras: []quickQuotePDFExtra{
+			{Description: "   ", Cost: 10, Price: 50},
+			{Description: "Logística externa", Cost: 100, Price: 200, ExcludeUtility: false},
+		},
+		NumPeople:       20,
+		Discount:        5000,
+		DiscountType:    "fixed",
+		RequiresInvoice: false,
+		TaxRate:         16,
+	}
+
+	event, products, extras, client := req.toPDFData(userID)
+
+	assert.Nil(t, client)
+	assert.Len(t, products, 1)
+	assert.Len(t, extras, 1)
+	assert.Equal(t, "fixed", event.DiscountType)
+	assert.Equal(t, 0.0, event.TaxAmount)
+	assert.Equal(t, 0.0, event.TotalAmount)
+	assert.Equal(t, "quoted", event.Status)
+	assert.Equal(t, userID, event.UserID)
+}

--- a/backend/internal/pdf/budget.go
+++ b/backend/internal/pdf/budget.go
@@ -98,24 +98,28 @@ func GenerateBudget(data BudgetData) ([]byte, error) {
 		discount := p.Discount
 		lineTotal := (unitPrice - discount) * qty
 
-		y = doc.EnsureSpace(y, 8)
-		drawTableRow(doc, y, []string{
+		cells := []string{
 			name,
 			fmt.Sprintf("%.0f", qty),
 			FormatCurrency(unitPrice),
 			FormatCurrency(lineTotal),
-		}, colWidths)
+		}
+		rowHeight := estimateTableRowHeight(doc, cells, colWidths)
+		y = ensureBudgetTableSpace(doc, y, rowHeight, headers, colWidths)
+		y = drawTableRow(doc, y, cells, colWidths)
 		rowCount++
 	}
 
 	for _, e := range data.Extras {
-		y = doc.EnsureSpace(y, 8)
-		drawTableRow(doc, y, []string{
+		cells := []string{
 			e.Description,
 			"1",
 			FormatCurrency(e.Price),
 			FormatCurrency(e.Price),
-		}, colWidths)
+		}
+		rowHeight := estimateTableRowHeight(doc, cells, colWidths)
+		y = ensureBudgetTableSpace(doc, y, rowHeight, headers, colWidths)
+		y = drawTableRow(doc, y, cells, colWidths)
 		rowCount++
 	}
 
@@ -130,6 +134,11 @@ func GenerateBudget(data BudgetData) ([]byte, error) {
 
 	// ── Financial Summary ──
 	fs := ComputeFinancialSummary(data.Event, 0)
+	summaryHeight := doc.EstimateFinancialSummaryHeight(fs) + 12
+	if y+summaryHeight > PageHeight-12 {
+		doc.AddPage()
+		y = doc.DrawHeader("Presupuesto")
+	}
 	y = doc.DrawFinancialSummary(y, fs)
 
 	// ── Deposit Info ──
@@ -167,34 +176,77 @@ func drawTableHeader(doc *PDFDoc, y float64, headers []string, colWidths []float
 	return y
 }
 
+func estimateTableRowHeight(doc *PDFDoc, cells []string, colWidths []float64) float64 {
+	const (
+		cellPadding = 2.0
+		lineHeight  = 3.8
+		minHeight   = 6.5
+	)
+	maxLines := 1
+	for i, cell := range cells {
+		availableWidth := colWidths[i] - (cellPadding * 2)
+		if availableWidth < 6 {
+			availableWidth = 6
+		}
+		lineCount := len(doc.SplitText(cell, availableWidth))
+		if lineCount > maxLines {
+			maxLines = lineCount
+		}
+	}
+	height := float64(maxLines)*lineHeight + 2
+	if height < minHeight {
+		return minHeight
+	}
+	return height
+}
+
+func ensureBudgetTableSpace(doc *PDFDoc, y, rowHeight float64, headers []string, colWidths []float64) float64 {
+	if y+rowHeight <= PageHeight-MarginBottom {
+		return y
+	}
+
+	doc.AddPage()
+	y = doc.DrawHeader("Presupuesto")
+	y = doc.DrawSectionHeader(y, "Productos y Servicios")
+	return drawTableHeader(doc, y, headers, colWidths)
+}
+
 // drawTableRow draws a single table row.
-func drawTableRow(doc *PDFDoc, y float64, cells []string, colWidths []float64) {
+func drawTableRow(doc *PDFDoc, y float64, cells []string, colWidths []float64) float64 {
+	const (
+		cellPadding = 2.0
+		lineHeight  = 3.8
+	)
 	doc.SetFont(FontDejaVuSans, "", 8)
 	doc.SetTextColorDefault()
+	rowHeight := estimateTableRowHeight(doc, cells, colWidths)
 
 	x := MarginLeft
 	for i, cell := range cells {
-		// Right-align numeric columns (index 1, 2, 3)
-		align := "L"
-		if i > 0 {
-			align = "R"
+		alignRight := i > 0
+		availableWidth := colWidths[i] - (cellPadding * 2)
+		if availableWidth < 6 {
+			availableWidth = 6
 		}
-
-		cellX := x
-		if align == "R" {
-			w := doc.GetStringWidth(cell)
-			cellX = x + colWidths[i] - w - 2
-		} else {
-			cellX = x + 2
+		lines := doc.SplitText(cell, availableWidth)
+		for lineIndex, line := range lines {
+			lineY := y + 3 + float64(lineIndex)*lineHeight
+			cellX := x + cellPadding
+			if alignRight {
+				w := doc.GetStringWidth(line)
+				cellX = x + colWidths[i] - w - cellPadding
+			}
+			doc.Text(cellX, lineY, line)
 		}
-		doc.Text(cellX, y+1, cell)
 		x += colWidths[i]
 	}
 
 	// Subtle row separator
 	doc.SetDrawColor(230, 230, 230)
 	doc.SetLineWidth(0.1)
-	doc.Line(MarginLeft, y+3.5, MarginLeft+ContentWidth, y+3.5)
+	doc.Line(MarginLeft, y+rowHeight-1, MarginLeft+ContentWidth, y+rowHeight-1)
+
+	return y + rowHeight
 }
 
 // buildProductsList returns a human-readable list of products for contracts.

--- a/backend/internal/pdf/builder.go
+++ b/backend/internal/pdf/builder.go
@@ -81,6 +81,15 @@ func (d *PDFDoc) MultiCell(w, h float64, txtStr, border, alignStr string, fill b
 	d.Fpdf.MultiCell(w, h, sanitizePDFText(txtStr), border, alignStr, fill)
 }
 
+// SplitText sanitizes the string before splitting it into wrapped lines.
+func (d *PDFDoc) SplitText(text string, width float64) []string {
+	lines := d.Fpdf.SplitText(sanitizePDFText(text), width)
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}
+
 // GetStringWidth sanitizes the string before measuring it.
 func (d *PDFDoc) GetStringWidth(s string) float64 {
 	return d.Fpdf.GetStringWidth(sanitizePDFText(s))
@@ -294,8 +303,16 @@ func (d *PDFDoc) DrawSectionHeader(y float64, title string) float64 {
 // Each column takes half the content width.
 func (d *PDFDoc) DrawInfoGrid(y float64, leftItems, rightItems [][2]string) float64 {
 	d.SetFont(FontDejaVuSans, "", 9)
-	colWidth := ContentWidth / 2
-	lineHeight := 5.0
+	const (
+		columnGap    = 8.0
+		lineHeight   = 4.5
+		labelPadding = 2.0
+	)
+	colWidth := (ContentWidth - columnGap) / 2
+	leftX := MarginLeft
+	rightX := MarginLeft + colWidth + columnGap
+	leftLabelWidth := infoGridLabelWidth(d, leftItems, colWidth)
+	rightLabelWidth := infoGridLabelWidth(d, rightItems, colWidth)
 
 	maxRows := len(leftItems)
 	if len(rightItems) > maxRows {
@@ -303,29 +320,61 @@ func (d *PDFDoc) DrawInfoGrid(y float64, leftItems, rightItems [][2]string) floa
 	}
 
 	for i := 0; i < maxRows; i++ {
-		// Left column
-		if i < len(leftItems) {
-			label, value := leftItems[i][0], leftItems[i][1]
-			d.SetTextColorSecondary()
-			d.Text(MarginLeft, y, label+":")
-			d.SetTextColorDefault()
-			d.Text(MarginLeft+30, y, value)
+		leftRowHeight := drawInfoGridColumn(d, leftX, y, colWidth, leftLabelWidth, lineHeight, labelPadding, leftItems, i)
+		rightRowHeight := drawInfoGridColumn(d, rightX, y, colWidth, rightLabelWidth, lineHeight, labelPadding, rightItems, i)
+		if rightRowHeight > leftRowHeight {
+			leftRowHeight = rightRowHeight
 		}
-
-		// Right column
-		if i < len(rightItems) {
-			label, value := rightItems[i][0], rightItems[i][1]
-			rightX := MarginLeft + colWidth
-			d.SetTextColorSecondary()
-			d.Text(rightX, y, label+":")
-			d.SetTextColorDefault()
-			d.Text(rightX+30, y, value)
-		}
-
-		y += lineHeight
+		y += leftRowHeight
 	}
 
 	return y
+}
+
+func infoGridLabelWidth(d *PDFDoc, items [][2]string, colWidth float64) float64 {
+	maxWidth := 0.0
+	for _, item := range items {
+		width := d.GetStringWidth(item[0] + ":")
+		if width > maxWidth {
+			maxWidth = width
+		}
+	}
+	minWidth := 18.0
+	maxAllowedWidth := colWidth * 0.34
+	if maxAllowedWidth < minWidth {
+		maxAllowedWidth = minWidth
+	}
+	if maxWidth < minWidth {
+		return minWidth
+	}
+	if maxWidth > maxAllowedWidth {
+		return maxAllowedWidth
+	}
+	return maxWidth
+}
+
+func drawInfoGridColumn(d *PDFDoc, x, y, colWidth, labelWidth, lineHeight, labelPadding float64, items [][2]string, index int) float64 {
+	if index >= len(items) {
+		return lineHeight
+	}
+
+	label, value := items[index][0], items[index][1]
+	valueWidth := colWidth - labelWidth - labelPadding
+	if valueWidth < 10 {
+		valueWidth = 10
+	}
+	valueLines := d.SplitText(value, valueWidth)
+	rowHeight := float64(len(valueLines)) * lineHeight
+
+	d.SetTextColorSecondary()
+	d.Text(x, y, label+":")
+	d.SetTextColorDefault()
+	for lineIndex, line := range valueLines {
+		lineY := y + float64(lineIndex)*lineHeight
+		d.Text(x+labelWidth+labelPadding, lineY, line)
+	}
+
+	return rowHeight
 }
 
 // DrawSeparator draws a thin horizontal line.

--- a/backend/internal/pdf/financial.go
+++ b/backend/internal/pdf/financial.go
@@ -82,6 +82,24 @@ func PaymentMethodLabel(method string) string {
 	return method
 }
 
+// EstimateFinancialSummaryHeight returns the vertical space required for the
+// summary block plus the optional deposit note.
+func (d *PDFDoc) EstimateFinancialSummaryHeight(fs FinancialSummary) float64 {
+	height := 7.0 + 6.0
+	if fs.HasDiscount {
+		height += 6.0
+	}
+	if fs.ShowTax {
+		height += 6.0
+	}
+	height += 10.0
+	if fs.HasDeposit {
+		text := fmt.Sprintf("Se requiere un anticipo del %.0f%% (%s) para confirmar la reserva.", fs.DepositPercent, FormatCurrency(fs.DepositAmount))
+		height += float64(len(d.SplitText(text, ContentWidth)))*4.0 + 3.0
+	}
+	return height
+}
+
 // DrawFinancialSummary renders the financial summary block (subtotal, discount, IVA, total).
 // Returns the Y position after the summary.
 func (d *PDFDoc) DrawFinancialSummary(y float64, fs FinancialSummary) float64 {

--- a/backend/internal/pdf/financial_test.go
+++ b/backend/internal/pdf/financial_test.go
@@ -1,6 +1,7 @@
 package pdf
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -71,6 +72,11 @@ func samplePayments() []models.Payment {
 		{Amount: 15000, PaymentDate: "2026-05-01", PaymentMethod: "transfer", Notes: strPtr("Anticipo")},
 		{Amount: 7500, PaymentDate: "2026-05-15", PaymentMethod: "cash", Notes: strPtr("Segundo pago")},
 	}
+}
+
+func countPDFPages(pdfBytes []byte) int {
+	pagePattern := regexp.MustCompile(`/Type /Page\b`)
+	return len(pagePattern.FindAll(pdfBytes, -1))
 }
 
 // ---------------------------------------------------------------------------
@@ -231,6 +237,50 @@ func TestGenerateBudget_WithDiscount(t *testing.T) {
 	pdfBytes, err := GenerateBudget(data)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, pdfBytes)
+}
+
+func TestDrawInfoGrid_LongValuesIncreaseHeight(t *testing.T) {
+	doc, err := NewPDFDoc("", "", true, nil)
+	assert.NoError(t, err)
+	doc.AddPage()
+
+	startY := 40.0
+	leftItems := [][2]string{{
+		"Cliente",
+		"María Fernanda de los Ángeles García Hernández con nombre extremadamente largo",
+	}, {
+		"Email",
+		"maria.fernanda.de.los.angeles.garcia.hernandez.eventos@cliente-muy-largo-ejemplo.com",
+	}}
+	rightItems := [][2]string{{
+		"Horario",
+		"Montaje 08:00 - Evento 14:00 - Desmontaje 02:00 con observaciones adicionales y acceso restringido",
+	}}
+
+	endY := doc.DrawInfoGrid(startY, leftItems, rightItems)
+
+	assert.Greater(t, endY, startY+12.0)
+	assert.Less(t, endY, 90.0)
+}
+
+func TestDrawTableRow_LongDescriptionWraps(t *testing.T) {
+	doc, err := NewPDFDoc("", "", true, nil)
+	assert.NoError(t, err)
+	doc.AddPage()
+
+	colWidths := []float64{ContentWidth * 0.40, ContentWidth * 0.15, ContentWidth * 0.22, ContentWidth * 0.23}
+	cells := []string{
+		"Paquete premium con montaje completo, barra de postres, personal adicional y ajustes especiales para venue con acceso limitado",
+		"12",
+		"$25,000.00",
+		"$300,000.00",
+	}
+
+	startY := 55.0
+	endY := drawTableRow(doc, startY, cells, colWidths)
+
+	assert.Greater(t, endY, startY+6.5)
+	assert.Greater(t, estimateTableRowHeight(doc, cells, colWidths), 6.5)
 }
 
 // ---------------------------------------------------------------------------
@@ -474,4 +524,57 @@ func TestGenerateBudget_NoDeposit(t *testing.T) {
 	pdfBytes, err := GenerateBudget(data)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, pdfBytes)
+}
+
+func TestGenerateBudget_LongCatalogSpillsToSecondPage(t *testing.T) {
+	event := sampleEvent()
+	event.Discount = 1500
+	event.DiscountType = "fixed"
+	event.TaxAmount = 7200
+	event.TotalAmount = 52200
+
+	products := make([]models.EventProduct, 0, 48)
+	for range 48 {
+		name := "Paquete premium con montaje completo, barra de postres, personal adicional y ajustes especiales para venue con acceso restringido " + strings.Repeat("detalle ", 4)
+		products = append(products, models.EventProduct{
+			Quantity:    1,
+			UnitPrice:   2500,
+			Discount:    100,
+			ProductName: &name,
+		})
+	}
+
+	extras := []models.EventExtra{
+		{Description: "Decoracion floral integral con traslado nocturno y montaje fuera de horario", Cost: 1200, Price: 2500},
+		{Description: "Coordinacion extendida para venue con acceso restringido y ventanas de montaje", Cost: 800, Price: 1800},
+	}
+
+	data := BudgetData{
+		Event:    event,
+		Client:   sampleClient(),
+		Profile:  sampleProfile(),
+		Products: products,
+		Extras:   extras,
+	}
+
+	pdfBytes, err := GenerateBudget(data)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, pdfBytes)
+	assert.GreaterOrEqual(t, countPDFPages(pdfBytes), 2)
+	assert.True(t, strings.HasPrefix(string(pdfBytes[:5]), "%PDF-"))
+}
+
+func TestEnsureBudgetTableSpace_RedrawsHeaderAfterPageBreak(t *testing.T) {
+	doc, err := NewPDFDoc("", "", true, nil)
+	assert.NoError(t, err)
+	doc.AddPage()
+
+	headers := []string{"Descripción", "Cant.", "Precio Unit.", "Total"}
+	colWidths := []float64{ContentWidth * 0.40, ContentWidth * 0.15, ContentWidth * 0.22, ContentWidth * 0.23}
+	startY := PageHeight - MarginBottom - 2
+
+	nextY := ensureBudgetTableSpace(doc, startY, 12, headers, colWidths)
+
+	assert.Greater(t, nextY, MarginTop+10)
+	assert.Less(t, nextY, PageHeight/2)
 }

--- a/docs/PRD/07_TECHNICAL_ARCHITECTURE_BACKEND.md
+++ b/docs/PRD/07_TECHNICAL_ARCHITECTURE_BACKEND.md
@@ -10,7 +10,7 @@ aliases:
   - Arquitectura Backend
   - Backend Architecture
 date: 2026-03-20
-updated: 2026-05-17
+updated: 2026-05-18
 status: active
 platform: Backend
 ---
@@ -21,7 +21,7 @@ platform: Backend
 > [[PRD MOC]] | [[01_PRODUCT_VISION]] | [[02_FEATURES]] | [[05_TECHNICAL_ARCHITECTURE_IOS]] | [[06_TECHNICAL_ARCHITECTURE_ANDROID]] | [[08_TECHNICAL_ARCHITECTURE_WEB]] | [[11_CURRENT_STATUS]] | [[04_MONETIZATION]]
 
 **Version:** 1.0
-**Fecha:** 2026-03-20 · **Última actualización:** 2026-05-11
+**Fecha:** 2026-03-20 · **Última actualización:** 2026-05-18
 **Plataforma:** Go REST API + PostgreSQL
 
 > [!success] Producción (2026-04-16)
@@ -63,6 +63,13 @@ platform: Backend
 > - `UnavailableDate` agrega rango horario opcional (`start_time`, `end_time`) vía migración 053.
 > - Nuevos flujos de edición para bloqueos (`PUT /api/unavailable-dates/{id}`) y validación de solapes por fecha/horario.
 > - `GET /api/staff/availability` ahora contempla bloqueos del miembro invitado para marcar no disponibilidad en asignación del organizer.
+
+> [!success] 2026-05-18 — Budget PDF layout hardening en backend compartido
+>
+> - `internal/pdf/builder.go`: `DrawInfoGrid` dejó offsets fijos y ahora mide ancho de labels, envuelve valores largos y devuelve altura real consumida por fila.
+> - `internal/pdf/budget.go`: las filas del catálogo usan altura dinámica (`estimateTableRowHeight` + `drawTableRow`) para soportar descripciones multilinea sin invadir columnas vecinas.
+> - `internal/pdf/financial.go`: el presupuesto reserva el espacio del bloque financiero completo antes de dibujarlo para evitar overlap con catálogo/footer; el anticipo sigue renderizado vía `MultiCell` con altura estimada.
+> - `POST /api/quick-quotes/pdf` reutiliza exactamente el mismo `GenerateBudget`, por lo que la mejora cubre presupuesto normal y cotización rápida en Web, iOS y Android.
 
 > [!success] 2026-05-17 — Client Portal backend: contrato explícito tier/capabilities (issue #325)
 >

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -8,7 +8,7 @@ aliases:
   - Estado Actual
   - Current Status
 date: 2026-03-20
-updated: 2026-05-17
+updated: 2026-05-18
 status: active
 ---
 
@@ -24,6 +24,14 @@ status: active
 
 **Fecha:** Mayo 2026
 **Version:** 1.7
+
+> [!success] 2026-05-18 — Presupuesto PDF cliente robustecido en backend compartido
+> Se corrigió el layout del presupuesto PDF para evitar texto encimado y bloques mal posicionados en documentos enviados al cliente.
+> - **Backend PDF:** `DrawInfoGrid` ahora mide labels/values, hace wrap y avanza `y` según altura real por fila en vez de offsets fijos.
+> - **Tabla de presupuesto:** las filas del catálogo calculan altura dinámica para descripciones largas y paginan con `EnsureSpace` usando esa altura real.
+> - **Bloque financiero:** subtotal, descuento, IVA, total y anticipo se reservan como bloque antes de dibujarse para no pisarse con la tabla ni el footer.
+> - **Cobertura:** nuevas regresiones en `internal/pdf/financial_test.go` y `internal/handlers/pdf_handler_test.go` cubren textos largos, catálogo extenso y quick quote (`/quick-quotes/pdf`) que reutiliza el mismo generador.
+> - **Validación:** `go test ./internal/pdf` y `go test ./internal/handlers -run 'TestQuickQuotePDFRequestToPDFData'`.
 
 > [!success] 2026-05-17 — Backend: rate limiting autenticado por `user_id` configurable (issue #180)
 > Se completó el hardening de rate limiting para tráfico autenticado detrás de NAT/proxy.


### PR DESCRIPTION
## Linked Issue
- Closes #360

## What
- harden the shared backend budget PDF layout to wrap long info-grid values and multiline catalog rows
- redraw the budget header and table header after catalog page breaks
- add regression tests for long catalogs and quick quote payload mapping, plus update PRD backend docs

## Why
- long client fields, schedules, and item descriptions were causing overlapping or mispositioned content in the client-facing budget PDF
- quick quote export reuses the same backend generator, so the fix needs to hold for both flows

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [x] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Linked issue has `status:approved`
- [x] Exactly one `type:*` label on the PR
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [x] Docs updated (PRD `11_CURRENT_STATUS.md` + relevant architecture doc)

## Risk and Rollback
- Risk: PDF pagination/layout is shared behavior, so regressions could affect budget exports broadly if an edge case was missed.
- Rollback: revert commit `420660c2` to restore the previous budget PDF renderer.