### PR TITLE
feat(backend): enforce HTTPS redirect middleware in production

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -171,7 +171,7 @@ func main() {
 	pdfHandler := handlers.NewPDFHandler(eventRepo, clientRepo, paymentRepo, userRepo, cfg.UploadDir)
 
 	// Create router
-	r := router.New(authHandler, crudHandler, subHandler, searchHandler, eventPaymentHandler, uploadHandler, adminHandler, dashboardHandler, auditHandler, unavailHandler, deviceHandler, liveActivityHandler, eventFormHandler, eventPublicLinkHandler, paymentSubmissionHandler, reviewHandler, staffHandler, staffTeamHandler, pdfHandler, authService, userRepo, auditRepo, pool, cfg.CORSAllowedOrigins, cfg.UploadDir)
+	r := router.New(authHandler, crudHandler, subHandler, searchHandler, eventPaymentHandler, uploadHandler, adminHandler, dashboardHandler, auditHandler, unavailHandler, deviceHandler, liveActivityHandler, eventFormHandler, eventPublicLinkHandler, paymentSubmissionHandler, reviewHandler, staffHandler, staffTeamHandler, pdfHandler, authService, userRepo, auditRepo, pool, cfg.CORSAllowedOrigins, cfg.UploadDir, cfg.Environment, cfg.TrustProxy)
 
 	// Background job: expire gifted plans that have passed their expiry date.
 	// Runs once at startup then every hour.

--- a/backend/internal/middleware/https_redirect.go
+++ b/backend/internal/middleware/https_redirect.go
@@ -1,0 +1,48 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+// RedirectToHTTPS enforces HTTPS only in production. It trusts forwarded
+// headers only when trustProxy is enabled to avoid spoofing.
+func RedirectToHTTPS(environment string, trustProxy bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.EqualFold(environment, "production") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			isHTTPS := r.TLS != nil
+			if trustProxy {
+				isHTTPS = isHTTPS || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+			}
+
+			if isHTTPS {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			host := r.Host
+			if trustProxy {
+				if forwardedHost := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); forwardedHost != "" {
+					host = forwardedHost
+				}
+			}
+
+			target := "https://" + host + r.URL.Path
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+
+			status := http.StatusMovedPermanently
+			if r.Method != http.MethodGet && r.Method != http.MethodHead {
+				status = http.StatusPermanentRedirect
+			}
+
+			http.Redirect(w, r, target, status)
+		})
+	}
+}

--- a/backend/internal/middleware/https_redirect_test.go
+++ b/backend/internal/middleware/https_redirect_test.go
@@ -1,0 +1,129 @@
+package middleware
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRedirectToHTTPS(t *testing.T) {
+	t.Run("GivenDevelopmentEnvironment_WhenHTTPRequest_ThenNoRedirect", func(t *testing.T) {
+		handler := RedirectToHTTPS("development", true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "http://example.com/api/health", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("GivenProductionWhenPlainHTTPGet_ThenRedirect301ToHTTPS", func(t *testing.T) {
+		handler := RedirectToHTTPS("production", false)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "http://api.example.com/api/clients?q=test", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusMovedPermanently {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusMovedPermanently)
+		}
+		if got := rr.Header().Get("Location"); got != "https://api.example.com/api/clients?q=test" {
+			t.Fatalf("Location = %q, want %q", got, "https://api.example.com/api/clients?q=test")
+		}
+	})
+
+	t.Run("GivenProductionWhenPlainHTTPPost_ThenRedirect308ToHTTPS", func(t *testing.T) {
+		handler := RedirectToHTTPS("production", false)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "http://api.example.com/api/auth/login", nil)
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusPermanentRedirect {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusPermanentRedirect)
+		}
+	})
+
+	t.Run("GivenProductionWhenTLSRequest_ThenNoRedirect", func(t *testing.T) {
+		handler := RedirectToHTTPS("production", false)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "https://api.example.com/health", nil)
+		req.TLS = &tls.ConnectionState{}
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("GivenProductionAndTrustedProxyWhenForwardedHTTP_ThenRedirectUsingForwardedHost", func(t *testing.T) {
+		handler := RedirectToHTTPS("production", true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "http://internal.local/api/clients", nil)
+		req.Header.Set("X-Forwarded-Proto", "http")
+		req.Header.Set("X-Forwarded-Host", "api.solennix.com")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusMovedPermanently {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusMovedPermanently)
+		}
+		if got := rr.Header().Get("Location"); got != "https://api.solennix.com/api/clients" {
+			t.Fatalf("Location = %q, want %q", got, "https://api.solennix.com/api/clients")
+		}
+	})
+
+	t.Run("GivenProductionAndTrustedProxyWhenForwardedHTTPS_ThenNoRedirect", func(t *testing.T) {
+		handler := RedirectToHTTPS("production", true)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "http://internal.local/api/clients", nil)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("GivenProductionAndUntrustedProxyWhenForwardedHostSet_ThenDoNotTrustForwardedHost", func(t *testing.T) {
+		handler := RedirectToHTTPS("production", false)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "http://internal.local/api/clients", nil)
+		req.Header.Set("X-Forwarded-Host", "api.solennix.com")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusMovedPermanently {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusMovedPermanently)
+		}
+		if got := rr.Header().Get("Location"); got != "https://internal.local/api/clients" {
+			t.Fatalf("Location = %q, want %q", got, "https://internal.local/api/clients")
+		}
+	})
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -23,7 +23,7 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 	staffHandler *handlers.StaffHandler,
 	staffTeamHandler *handlers.StaffTeamHandler,
 	pdfHandler *handlers.PDFHandler,
-	authService *services.AuthService, userRepo *repository.UserRepo, auditRepo mw.AuditLogger, pool *pgxpool.Pool, corsOrigins []string, uploadDir string) http.Handler {
+	authService *services.AuthService, userRepo *repository.UserRepo, auditRepo mw.AuditLogger, pool *pgxpool.Pool, corsOrigins []string, uploadDir string, environment string, trustProxy bool) http.Handler {
 
 	r := chi.NewRouter()
 
@@ -31,6 +31,7 @@ func New(authHandler *handlers.AuthHandler, crudHandler *handlers.CRUDHandler, s
 	r.Use(mw.Recovery)  // Panic recovery — outermost so it catches the repanic from Sentry
 	r.Use(mw.Sentry)    // Per-request Sentry hub; captures panics then repanics (no-op if Sentry DSN unset)
 	r.Use(mw.RequestID) // X-Request-ID for tracing
+	r.Use(mw.RedirectToHTTPS(environment, trustProxy))
 	r.Use(mw.Localization())
 	r.Use(mw.CORS(corsOrigins))
 	r.Use(mw.SecurityHeaders) // Security headers (X-Frame-Options, CSP, HSTS, etc.)

--- a/backend/internal/router/router_api_integration_test.go
+++ b/backend/internal/router/router_api_integration_test.go
@@ -36,7 +36,7 @@ func TestAPIIntegrationCoreFlows(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir(), "development", false)
 
 	registerBody := map[string]interface{}{
 		"email":    "router.integration@test.dev",
@@ -184,7 +184,7 @@ func TestAPIContractMatrixAuthenticatedValidationErrors(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir(), "development", false)
 
 	status, body := performJSONRequest(t, h, http.MethodPost, "/api/auth/register", "", map[string]interface{}{
 		"email":    "router.contracts@test.dev",
@@ -307,7 +307,7 @@ func TestAPIContractMatrixSuccessShapes(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir(), "development", false)
 
 	status, body := performJSONRequest(t, h, http.MethodPost, "/api/auth/register", "", map[string]interface{}{
 		"email":    "router.success.contracts@test.dev",
@@ -614,7 +614,7 @@ func TestGoldenContractsV1(t *testing.T) {
 		repository.NewUnavailableDateRepo(pool),
 	)
 	unavailHandler := handlers.NewUnavailableDateHandler(repository.NewUnavailableDateRepo(pool))
-	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir())
+	h := New(authHandler, crudHandler, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, unavailHandler, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, userRepo, &noopAuditLogger{}, nil, []string{"http://localhost:5173"}, t.TempDir(), "development", false)
 
 	responses := map[string]observedResponse{}
 

--- a/backend/internal/router/router_test.go
+++ b/backend/internal/router/router_test.go
@@ -25,7 +25,7 @@ func (n *noopAuditLogger) Create(_ context.Context, _ *models.AuditLog) error { 
 
 func TestNewRouter(t *testing.T) {
 	authService := services.NewAuthService("test-secret", 1)
-	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
+	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir(), "development", false)
 
 	t.Run("GivenHealthEndpoint_WhenRequest_ThenReturnsOK", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
@@ -64,7 +64,7 @@ func TestNewRouter(t *testing.T) {
 		testFilePath := filepath.Join(tempDir, "test.png")
 		_ = os.WriteFile(testFilePath, []byte("fake image data"), 0644)
 
-		h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(tempDir, nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, tempDir)
+		h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(tempDir, nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, tempDir, "development", false)
 
 		req := httptest.NewRequest(http.MethodGet, "/api/uploads/test.png", nil)
 		rr := httptest.NewRecorder()
@@ -78,7 +78,7 @@ func TestNewRouter(t *testing.T) {
 }
 func TestProtectedRoutesRequireValidBearerToken(t *testing.T) {
 	authService := services.NewAuthService("test-secret", 1)
-	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
+	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir(), "development", false)
 
 	protectedRequests := []struct {
 		name   string
@@ -135,7 +135,7 @@ func TestProtectedRoutesRequireValidBearerToken(t *testing.T) {
 
 func TestRouterErrorContractMatrix(t *testing.T) {
 	authService := services.NewAuthService("test-secret", 1)
-	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir())
+	h := New(&handlers.AuthHandler{}, &handlers.CRUDHandler{}, &handlers.SubscriptionHandler{}, &handlers.SearchHandler{}, &handlers.EventPaymentHandler{}, handlers.NewUploadHandler(t.TempDir(), nil), &handlers.AdminHandler{}, &handlers.DashboardHandler{}, &handlers.AuditHandler{}, &handlers.UnavailableDateHandler{}, nil, nil, nil, nil, nil, nil, nil, nil, nil, authService, &repository.UserRepo{}, &noopAuditLogger{}, nil, []string{"http://allowed.com"}, t.TempDir(), "development", false)
 
 	cases := []struct {
 		name       string


### PR DESCRIPTION
## Linked Issue
- Closes #377

## What
- Added RedirectToHTTPS middleware to enforce HTTPS only in production.
- Wired middleware in the global router stack after RequestID.
- Passed environment and trust proxy flags from server bootstrap into router construction.
- Added unit tests for 301/308 behavior, trusted proxy forwarding, and development/TLS bypass.

## Why
- HSTS headers alone do not actively redirect plaintext HTTP requests.
- This closes the transport hardening gap tracked in issue #377.

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Checklist
- [x] Issue linked
- [x] Linked issue approved
- [x] Exactly one type label on the PR
- [x] Tests added/updated
- [ ] CI green
- [x] Cross-platform parity reviewed
- [ ] Docs updated (not required for this isolated backend middleware change)

## Risk and Rollback
- Risk: In production, plaintext requests are redirected; misconfigured proxies could cause unexpected redirect behavior if trust-proxy settings are incorrect.
- Rollback: Revert this PR to disable middleware and restore previous routing behavior.
