### PR TITLE
fix(backend): resolve UserRateLimit shared stop-func race

### DIFF
--- a/backend/internal/middleware/user_ratelimit.go
+++ b/backend/internal/middleware/user_ratelimit.go
@@ -32,17 +32,23 @@ func UserRateLimit(resolver PlanResolver, window time.Duration) func(http.Handle
 
 	// Register cleanup stop function
 	stopThis := func() { close(done) }
+	stopFuncsMu.Lock()
 	allStopFuncs = append(allStopFuncs, stopThis)
+	stopFuncsSnapshot := append([]func(){}, allStopFuncs...)
 	RateLimitStopFunc = func() {
-		for _, fn := range allStopFuncs {
+		for _, fn := range stopFuncsSnapshot {
 			fn()
 		}
+		stopFuncsMu.Lock()
 		allStopFuncs = nil
+		stopFuncsMu.Unlock()
 	}
+	stopFuncsMu.Unlock()
 
 	// Background cleanup of stale entries
+	cleanupInterval := RateLimitCleanupInterval
 	go func() {
-		ticker := time.NewTicker(RateLimitCleanupInterval)
+		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/backend/internal/middleware/user_ratelimit.go
+++ b/backend/internal/middleware/user_ratelimit.go
@@ -34,15 +34,6 @@ func UserRateLimit(resolver PlanResolver, window time.Duration) func(http.Handle
 	stopThis := func() { close(done) }
 	stopFuncsMu.Lock()
 	allStopFuncs = append(allStopFuncs, stopThis)
-	stopFuncsSnapshot := append([]func(){}, allStopFuncs...)
-	RateLimitStopFunc = func() {
-		for _, fn := range stopFuncsSnapshot {
-			fn()
-		}
-		stopFuncsMu.Lock()
-		allStopFuncs = nil
-		stopFuncsMu.Unlock()
-	}
 	stopFuncsMu.Unlock()
 
 	// Background cleanup of stale entries

--- a/backend/internal/middleware/user_ratelimit_test.go
+++ b/backend/internal/middleware/user_ratelimit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"strings"
 	"testing"
 	"time"
@@ -267,6 +268,40 @@ func TestUserRateLimit_DifferentUsersIndependent(t *testing.T) {
 	handler.ServeHTTP(rr, authenticatedRequest(user2))
 	if rr.Code != http.StatusOK {
 		t.Errorf("Expected user2 to be OK, got %d", rr.Code)
+	}
+
+	if RateLimitStopFunc != nil {
+		RateLimitStopFunc()
+	}
+}
+
+func TestUserRateLimit_ConcurrentInitializationRegistersAllStopFuncs(t *testing.T) {
+	originalInterval := RateLimitCleanupInterval
+	RateLimitCleanupInterval = 10 * time.Millisecond
+	defer func() { RateLimitCleanupInterval = originalInterval }()
+
+	stopFuncsMu.Lock()
+	allStopFuncs = nil
+	stopFuncsMu.Unlock()
+
+	resolver := &mockPlanResolver{plan: "basic"}
+	const workers = 32
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			_ = UserRateLimit(resolver, 100*time.Millisecond)
+		}()
+	}
+	wg.Wait()
+
+	stopFuncsMu.Lock()
+	got := len(allStopFuncs)
+	stopFuncsMu.Unlock()
+	if got != workers {
+		t.Fatalf("registered stop funcs = %d, want %d", got, workers)
 	}
 
 	if RateLimitStopFunc != nil {

--- a/backend/internal/middleware/user_ratelimit_test.go
+++ b/backend/internal/middleware/user_ratelimit_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -280,9 +280,9 @@ func TestUserRateLimit_ConcurrentInitializationRegistersAllStopFuncs(t *testing.
 	RateLimitCleanupInterval = 10 * time.Millisecond
 	defer func() { RateLimitCleanupInterval = originalInterval }()
 
-	stopFuncsMu.Lock()
-	allStopFuncs = nil
-	stopFuncsMu.Unlock()
+	if RateLimitStopFunc != nil {
+		RateLimitStopFunc()
+	}
 
 	resolver := &mockPlanResolver{plan: "basic"}
 	const workers = 32


### PR DESCRIPTION
## Linked Issue
- Closes #376
- Closes #378

## What
- Added mutex protection around shared stop-function registration in UserRateLimit.
- Preserved shared package-level RateLimitStopFunc implementation in ratelimit.go (no reassignment in UserRateLimit).
- Captured cleanup interval locally before spawning the cleanup goroutine.
- Added concurrency regression test for parallel middleware initialization.

## Why
- Issue #376 reported a race condition on shared stop function state in user rate limiting.
- Running go test -race on UserRateLimit tests exposed concurrent access to shared globals.
- Issue #378 requested removing duplicate global stop closure ownership; this PR centralizes ownership in ratelimit.go.

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Validation
- go test ./internal/middleware -run UserRateLimit
- go test -race ./internal/middleware -run UserRateLimit
- go test ./internal/middleware

## Risk and Rollback
- Risk: Low. Change is scoped to synchronization and test coverage in middleware internals.
- Rollback: Revert this PR commit.
