### PR TITLE
fix(backend): enforce search query guardrails

### DIFF
--- a/backend/internal/handlers/search_handler.go
+++ b/backend/internal/handlers/search_handler.go
@@ -3,10 +3,16 @@ package handlers
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/tiagofur/solennix-backend/internal/middleware"
 	"github.com/tiagofur/solennix-backend/internal/models"
+)
+
+const (
+	maxSearchQueryLength    = 100
+	maxSearchResultsPerType = 6
 )
 
 type SearchHandler struct {
@@ -34,10 +40,15 @@ func NewSearchHandler(
 func (h *SearchHandler) SearchAll(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID := middleware.GetUserID(ctx)
-	query := r.URL.Query().Get("q")
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
 
 	if query == "" {
 		writeError(w, http.StatusBadRequest, "Query parameter 'q' is required")
+		return
+	}
+
+	if len(query) > maxSearchQueryLength {
+		writeError(w, http.StatusBadRequest, "Query parameter 'q' exceeds maximum length of 100 characters")
 		return
 	}
 
@@ -123,18 +134,18 @@ func (h *SearchHandler) SearchAll(w http.ResponseWriter, r *http.Request) {
 
 	wg.Wait()
 
-	// Limit results to 6 per category (as per current frontend behavior)
-	if len(result.clients) > 6 {
-		result.clients = result.clients[:6]
+	// Limit results per category to bound response size and DB amplification.
+	if len(result.clients) > maxSearchResultsPerType {
+		result.clients = result.clients[:maxSearchResultsPerType]
 	}
-	if len(result.products) > 6 {
-		result.products = result.products[:6]
+	if len(result.products) > maxSearchResultsPerType {
+		result.products = result.products[:maxSearchResultsPerType]
 	}
-	if len(result.inventory) > 6 {
-		result.inventory = result.inventory[:6]
+	if len(result.inventory) > maxSearchResultsPerType {
+		result.inventory = result.inventory[:maxSearchResultsPerType]
 	}
-	if len(result.events) > 6 {
-		result.events = result.events[:6]
+	if len(result.events) > maxSearchResultsPerType {
+		result.events = result.events[:maxSearchResultsPerType]
 	}
 
 	// Return results even if some searches failed

--- a/backend/internal/handlers/search_handler_test.go
+++ b/backend/internal/handlers/search_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -76,6 +77,59 @@ func TestSearchHandler(t *testing.T) {
 		if rr.Code != http.StatusBadRequest {
 			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
 		}
+	})
+
+	t.Run("SearchAll_WhitespaceOnlyQuery", func(t *testing.T) {
+		mockClients := new(MockClientRepo)
+		mockProducts := new(MockProductRepo)
+		mockInventory := new(MockInventoryRepo)
+		mockEvents := new(MockFullEventRepo)
+
+		h := NewSearchHandler(mockClients, mockProducts, mockInventory, mockEvents)
+		req := httptest.NewRequest(http.MethodGet, "/api/search?q=%20%20%20", nil)
+		req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, uuid.New()))
+		rr := httptest.NewRecorder()
+
+		h.SearchAll(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+		if !strings.Contains(rr.Body.String(), "Query parameter 'q' is required") {
+			t.Fatalf("body = %q, expected required query error", rr.Body.String())
+		}
+
+		mockClients.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+		mockProducts.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+		mockInventory.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+		mockEvents.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("SearchAll_QueryTooLong", func(t *testing.T) {
+		mockClients := new(MockClientRepo)
+		mockProducts := new(MockProductRepo)
+		mockInventory := new(MockInventoryRepo)
+		mockEvents := new(MockFullEventRepo)
+
+		h := NewSearchHandler(mockClients, mockProducts, mockInventory, mockEvents)
+		longQuery := strings.Repeat("a", maxSearchQueryLength+1)
+		req := httptest.NewRequest(http.MethodGet, "/api/search?q="+url.QueryEscape(longQuery), nil)
+		req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, uuid.New()))
+		rr := httptest.NewRecorder()
+
+		h.SearchAll(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+		}
+		if !strings.Contains(rr.Body.String(), "exceeds maximum length") {
+			t.Fatalf("body = %q, expected length validation error", rr.Body.String())
+		}
+
+		mockClients.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+		mockProducts.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+		mockInventory.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
+		mockEvents.AssertNotCalled(t, "Search", mock.Anything, mock.Anything, mock.Anything)
 	})
 }
 


### PR DESCRIPTION
## Linked Issue
- Closes #383

## What
- Trimmed global search query input before validation and dispatch.
- Rejected empty-after-trim and oversized search queries before hitting repositories.
- Centralized search query/result guardrail constants in the handler.
- Added handler tests covering whitespace-only and oversized queries and verified repos are not called.

## Why
- Issue #383 reported that oversized search queries could trigger expensive backend work.
- Search validation should fail fast before any repository fan-out.

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Validation
- go test ./internal/handlers -run SearchHandler

## Risk and Rollback
- Risk: Low. This only tightens request validation and keeps the existing per-category result cap behavior explicit.
- Rollback: Revert this PR commit.
