### PR TITLE
fix(backend): bind presigned upload completion to signed token

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -155,6 +155,7 @@ func main() {
 
 	uploadHandler := handlers.NewUploadHandler(cfg.UploadDir, userRepo)
 	uploadHandler.SetStorageProvider(storageProvider)
+	uploadHandler.SetPresignSigningKey(cfg.JWTSecret)
 	adminHandler := handlers.NewAdminHandler(adminRepo)
 	auditHandler := handlers.NewAuditHandler(auditRepo)
 	dashboardHandler := handlers.NewDashboardHandler(dashboardRepo)

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1444,8 +1444,11 @@ components:
       type: object
       required:
         - object_key
+        - upload_token
       properties:
         object_key:
+          type: string
+        upload_token:
           type: string
     SearchResponse:
       type: object

--- a/backend/internal/handlers/upload_handler.go
+++ b/backend/internal/handlers/upload_handler.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/tiagofur/solennix-backend/internal/middleware"
 	"github.com/tiagofur/solennix-backend/internal/storage"
@@ -16,9 +20,10 @@ import (
 
 // UploadHandler handles image uploads, organizing files by user ID.
 type UploadHandler struct {
-	uploadDir string
-	userRepo  UserRepository
-	storage   storage.Provider // optional, falls back to legacy disk write
+	uploadDir         string
+	userRepo          UserRepository
+	storage           storage.Provider // optional, falls back to legacy disk write
+	presignSigningKey []byte
 }
 
 type presignImageRequest struct {
@@ -27,7 +32,16 @@ type presignImageRequest struct {
 }
 
 type completePresignedUploadRequest struct {
+	ObjectKey   string `json:"object_key"`
+	UploadToken string `json:"upload_token"`
+}
+
+const presignedUploadTokenTTL = 15 * time.Minute
+
+type presignedUploadTokenPayload struct {
+	UserID    string `json:"user_id"`
 	ObjectKey string `json:"object_key"`
+	ExpiresAt int64  `json:"expires_at"`
 }
 
 func NewUploadHandler(uploadDir string, userRepo UserRepository) *UploadHandler {
@@ -45,6 +59,63 @@ func NewUploadHandler(uploadDir string, userRepo UserRepository) *UploadHandler 
 // SetStorageProvider configures the file storage backend.
 func (h *UploadHandler) SetStorageProvider(p storage.Provider) {
 	h.storage = p
+}
+
+// SetPresignSigningKey configures the HMAC key used to bind presigned uploads
+// to a server-issued completion token.
+func (h *UploadHandler) SetPresignSigningKey(key string) {
+	h.presignSigningKey = []byte(strings.TrimSpace(key))
+}
+
+func (h *UploadHandler) issuePresignedUploadToken(userID, objectKey string, expiresAt time.Time) (string, error) {
+	if len(h.presignSigningKey) == 0 {
+		return "", fmt.Errorf("presign signing key is not configured")
+	}
+	payloadJSON, err := json.Marshal(presignedUploadTokenPayload{
+		UserID:    userID,
+		ObjectKey: objectKey,
+		ExpiresAt: expiresAt.Unix(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("marshal upload token payload: %w", err)
+	}
+	mac := hmac.New(sha256.New, h.presignSigningKey)
+	mac.Write(payloadJSON)
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	return encodedPayload + "." + signature, nil
+}
+
+func (h *UploadHandler) verifyPresignedUploadToken(userID, objectKey, token string, now time.Time) error {
+	if len(h.presignSigningKey) == 0 {
+		return fmt.Errorf("presign signing key is not configured")
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid upload token")
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return fmt.Errorf("invalid upload token")
+	}
+	mac := hmac.New(sha256.New, h.presignSigningKey)
+	mac.Write(payloadBytes)
+	expected := mac.Sum(nil)
+	provided, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil || !hmac.Equal(provided, expected) {
+		return fmt.Errorf("invalid upload token")
+	}
+	var payload presignedUploadTokenPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return fmt.Errorf("invalid upload token")
+	}
+	if payload.UserID != userID || payload.ObjectKey != objectKey {
+		return fmt.Errorf("upload token does not match object key")
+	}
+	if now.After(time.Unix(payload.ExpiresAt, 0)) {
+		return fmt.Errorf("upload token expired")
+	}
+	return nil
 }
 
 // maxUploadsForPlan returns the maximum number of uploads allowed per user based on plan.
@@ -194,12 +265,19 @@ func (h *UploadHandler) PresignImage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "Failed to create presigned upload")
 		return
 	}
+	uploadToken, err := h.issuePresignedUploadToken(userID.String(), result.ObjectKey, time.Now().Add(presignedUploadTokenTTL))
+	if err != nil {
+		slog.Error("Failed to sign presigned upload token", "error", err)
+		writeError(w, http.StatusInternalServerError, "Failed to create presigned upload")
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"upload_url":         result.UploadURL,
 		"method":             result.Method,
 		"headers":            result.Headers,
 		"object_key":         result.ObjectKey,
+		"upload_token":       uploadToken,
 		"expires_in_seconds": result.ExpiresInSeconds,
 		"content_type":       result.ContentType,
 	})
@@ -219,10 +297,19 @@ func (h *UploadHandler) CompletePresignedUpload(w http.ResponseWriter, r *http.R
 		writeError(w, http.StatusBadRequest, "object_key is required")
 		return
 	}
+	if strings.TrimSpace(req.UploadToken) == "" {
+		writeError(w, http.StatusBadRequest, "upload_token is required")
+		return
+	}
 
 	presignProvider, ok := h.storage.(storage.PresignCapableProvider)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "Presigned uploads are available only with S3 storage provider")
+		return
+	}
+
+	if err := h.verifyPresignedUploadToken(userID.String(), req.ObjectKey, req.UploadToken, time.Now()); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 

--- a/backend/internal/handlers/upload_handler.go
+++ b/backend/internal/handlers/upload_handler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -38,6 +39,8 @@ type completePresignedUploadRequest struct {
 
 const presignedUploadTokenTTL = 15 * time.Minute
 
+var errPresignSigningKeyNotConfigured = errors.New("presign signing key is not configured")
+
 type presignedUploadTokenPayload struct {
 	UserID    string `json:"user_id"`
 	ObjectKey string `json:"object_key"`
@@ -69,7 +72,7 @@ func (h *UploadHandler) SetPresignSigningKey(key string) {
 
 func (h *UploadHandler) issuePresignedUploadToken(userID, objectKey string, expiresAt time.Time) (string, error) {
 	if len(h.presignSigningKey) == 0 {
-		return "", fmt.Errorf("presign signing key is not configured")
+		return "", errPresignSigningKeyNotConfigured
 	}
 	payloadJSON, err := json.Marshal(presignedUploadTokenPayload{
 		UserID:    userID,
@@ -88,7 +91,7 @@ func (h *UploadHandler) issuePresignedUploadToken(userID, objectKey string, expi
 
 func (h *UploadHandler) verifyPresignedUploadToken(userID, objectKey, token string, now time.Time) error {
 	if len(h.presignSigningKey) == 0 {
-		return fmt.Errorf("presign signing key is not configured")
+		return errPresignSigningKeyNotConfigured
 	}
 	parts := strings.Split(token, ".")
 	if len(parts) != 2 {
@@ -265,7 +268,11 @@ func (h *UploadHandler) PresignImage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "Failed to create presigned upload")
 		return
 	}
-	uploadToken, err := h.issuePresignedUploadToken(userID.String(), result.ObjectKey, time.Now().Add(presignedUploadTokenTTL))
+	expiresIn := time.Duration(result.ExpiresInSeconds) * time.Second
+	if expiresIn <= 0 {
+		expiresIn = presignedUploadTokenTTL
+	}
+	uploadToken, err := h.issuePresignedUploadToken(userID.String(), result.ObjectKey, time.Now().Add(expiresIn))
 	if err != nil {
 		slog.Error("Failed to sign presigned upload token", "error", err)
 		writeError(w, http.StatusInternalServerError, "Failed to create presigned upload")
@@ -301,6 +308,7 @@ func (h *UploadHandler) CompletePresignedUpload(w http.ResponseWriter, r *http.R
 		writeError(w, http.StatusBadRequest, "upload_token is required")
 		return
 	}
+	token := strings.TrimSpace(req.UploadToken)
 
 	presignProvider, ok := h.storage.(storage.PresignCapableProvider)
 	if !ok {
@@ -308,7 +316,12 @@ func (h *UploadHandler) CompletePresignedUpload(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if err := h.verifyPresignedUploadToken(userID.String(), req.ObjectKey, req.UploadToken, time.Now()); err != nil {
+	if err := h.verifyPresignedUploadToken(userID.String(), req.ObjectKey, token, time.Now()); err != nil {
+		if errors.Is(err, errPresignSigningKeyNotConfigured) {
+			slog.Error("Failed to verify presigned upload token", "error", err)
+			writeError(w, http.StatusInternalServerError, "Failed to verify upload token")
+			return
+		}
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/backend/internal/handlers/upload_handler_test.go
+++ b/backend/internal/handlers/upload_handler_test.go
@@ -486,6 +486,76 @@ func TestCompletePresignedUpload_InvalidToken_Returns400(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "invalid upload token")
 }
 
+func TestCompletePresignedUpload_MissingUploadToken_Returns400(t *testing.T) {
+	h := NewUploadHandler(t.TempDir(), nil)
+	h.SetStorageProvider(&mockPresignProvider{})
+	h.SetPresignSigningKey(strings.Repeat("k", 32))
+	userID := uuid.New()
+	objectKey := userID.String() + "/abc.jpg"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+objectKey+`","upload_token":"   "}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	h.CompletePresignedUpload(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "upload_token is required")
+}
+
+func TestCompletePresignedUpload_ExpiredToken_Returns400(t *testing.T) {
+	h := NewUploadHandler(t.TempDir(), nil)
+	h.SetStorageProvider(&mockPresignProvider{})
+	h.SetPresignSigningKey(strings.Repeat("k", 32))
+	userID := uuid.New()
+	objectKey := userID.String() + "/abc.jpg"
+	token, err := h.issuePresignedUploadToken(userID.String(), objectKey, time.Now().Add(-1*time.Minute))
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+objectKey+`","upload_token":"`+token+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	h.CompletePresignedUpload(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "upload token expired")
+}
+
+func TestCompletePresignedUpload_MismatchedObjectKeyToken_Returns400(t *testing.T) {
+	h := NewUploadHandler(t.TempDir(), nil)
+	h.SetStorageProvider(&mockPresignProvider{})
+	h.SetPresignSigningKey(strings.Repeat("k", 32))
+	userID := uuid.New()
+	token, err := h.issuePresignedUploadToken(userID.String(), userID.String()+"/abc.jpg", time.Now().Add(1*time.Minute))
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+userID.String()+`/other.jpg","upload_token":"`+token+`"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	h.CompletePresignedUpload(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "upload token does not match object key")
+}
+
+func TestCompletePresignedUpload_MissingSigningKey_Returns500(t *testing.T) {
+	h := NewUploadHandler(t.TempDir(), nil)
+	h.SetStorageProvider(&mockPresignProvider{})
+	userID := uuid.New()
+	objectKey := userID.String() + "/abc.jpg"
+
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+objectKey+`","upload_token":"abc.def"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	h.CompletePresignedUpload(rr, req)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Failed to verify upload token")
+}
+
 // ---------------------------------------------------------------------------
 // Security tests — Upload magic-byte validation
 // ---------------------------------------------------------------------------

--- a/backend/internal/handlers/upload_handler_test.go
+++ b/backend/internal/handlers/upload_handler_test.go
@@ -15,11 +15,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
-	"github.com/tiagofur/solennix-backend/internal/storage"
 	"github.com/tiagofur/solennix-backend/internal/middleware"
+	"github.com/tiagofur/solennix-backend/internal/storage"
 )
 
 type mockPresignProvider struct{}
@@ -420,6 +421,7 @@ func TestPresignImage_UnsupportedProvider_Returns400(t *testing.T) {
 func TestPresignImage_Success(t *testing.T) {
 	h := NewUploadHandler(t.TempDir(), nil)
 	h.SetStorageProvider(&mockPresignProvider{})
+	h.SetPresignSigningKey(strings.Repeat("k", 32))
 	userID := uuid.New()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/uploads/presign", strings.NewReader(`{"filename":"photo.jpg","content_type":"image/jpeg"}`))
@@ -431,13 +433,14 @@ func TestPresignImage_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "upload_url")
 	assert.Contains(t, rr.Body.String(), "object_key")
+	assert.Contains(t, rr.Body.String(), "upload_token")
 }
 
 func TestCompletePresignedUpload_UnsupportedProvider_Returns400(t *testing.T) {
 	h := NewUploadHandler(t.TempDir(), nil)
 	userID := uuid.New()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"u/abc.jpg"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"u/abc.jpg","upload_token":"token"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
 	rr := httptest.NewRecorder()
@@ -450,9 +453,13 @@ func TestCompletePresignedUpload_UnsupportedProvider_Returns400(t *testing.T) {
 func TestCompletePresignedUpload_Success(t *testing.T) {
 	h := NewUploadHandler(t.TempDir(), nil)
 	h.SetStorageProvider(&mockPresignProvider{})
+	h.SetPresignSigningKey(strings.Repeat("k", 32))
 	userID := uuid.New()
+	objectKey := userID.String() + "/abc.jpg"
+	token, err := h.issuePresignedUploadToken(userID.String(), objectKey, time.Now().Add(presignedUploadTokenTTL))
+	assert.NoError(t, err)
 
-	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+userID.String()+`/abc.jpg"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+objectKey+`","upload_token":"`+token+`"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
 	rr := httptest.NewRecorder()
@@ -461,6 +468,22 @@ func TestCompletePresignedUpload_Success(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "thumbnail_object_key")
 	assert.Contains(t, rr.Body.String(), "content_type")
+}
+
+func TestCompletePresignedUpload_InvalidToken_Returns400(t *testing.T) {
+	h := NewUploadHandler(t.TempDir(), nil)
+	h.SetStorageProvider(&mockPresignProvider{})
+	h.SetPresignSigningKey(strings.Repeat("k", 32))
+	userID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/uploads/complete", strings.NewReader(`{"object_key":"`+userID.String()+`/abc.jpg","upload_token":"invalid"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(context.WithValue(req.Context(), middleware.UserIDKey, userID))
+	rr := httptest.NewRecorder()
+
+	h.CompletePresignedUpload(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "invalid upload token")
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Linked Issue
- Closes #384

## What
- Added server-signed upload_token generation in PresignImage (HMAC-SHA256, base64url payload+signature).
- Bound completion requests to the issued token in CompletePresignedUpload (user_id + object_key + expiry verification).
- Added explicit upload_token validation errors for missing/invalid/expired/mismatched tokens.
- Wired signing key setup from server bootstrap using cfg.JWTSecret.
- Added tests for token emission and invalid-token rejection.

## Why
- Completing presigned uploads with object_key alone allowed key spoofing risk.
- The new token ensures only server-issued object keys for the same user can be finalized.

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Validation
- go test ./internal/handlers -run 'PresignImage|CompletePresignedUpload'
- go test ./cmd/server

## Risk and Rollback
- Risk: Low-medium. Upload completion now requires upload_token; clients must pass the token returned by presign endpoint.
- Rollback: Revert this PR commit.
