### PR TITLE
perf(backend): add indexed search strategy with pg_trgm

### DIFF
--- a/backend/internal/database/migrations/057_add_search_trgm_column_indexes.down.sql
+++ b/backend/internal/database/migrations/057_add_search_trgm_column_indexes.down.sql
@@ -1,0 +1,14 @@
+DROP INDEX IF EXISTS idx_events_location_trgm;
+DROP INDEX IF EXISTS idx_events_service_type_trgm;
+
+DROP INDEX IF EXISTS idx_inventory_type_trgm;
+DROP INDEX IF EXISTS idx_inventory_unit_trgm;
+DROP INDEX IF EXISTS idx_inventory_ingredient_name_trgm;
+
+DROP INDEX IF EXISTS idx_products_category_trgm;
+DROP INDEX IF EXISTS idx_products_name_trgm;
+
+DROP INDEX IF EXISTS idx_clients_city_trgm;
+DROP INDEX IF EXISTS idx_clients_phone_trgm;
+DROP INDEX IF EXISTS idx_clients_email_trgm;
+DROP INDEX IF EXISTS idx_clients_name_trgm;

--- a/backend/internal/database/migrations/057_add_search_trgm_column_indexes.down.sql
+++ b/backend/internal/database/migrations/057_add_search_trgm_column_indexes.down.sql
@@ -12,3 +12,20 @@ DROP INDEX IF EXISTS idx_clients_city_trgm;
 DROP INDEX IF EXISTS idx_clients_phone_trgm;
 DROP INDEX IF EXISTS idx_clients_email_trgm;
 DROP INDEX IF EXISTS idx_clients_name_trgm;
+
+-- Restore legacy concatenated trigram indexes from migration 033
+CREATE INDEX IF NOT EXISTS idx_clients_search ON clients USING GIN (
+	(COALESCE(name, '') || ' ' || COALESCE(email, '') || ' ' || COALESCE(phone, '') || ' ' || COALESCE(city, '')) gin_trgm_ops
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_search ON events USING GIN (
+	(COALESCE(service_type, '') || ' ' || COALESCE(location, '')) gin_trgm_ops
+);
+
+CREATE INDEX IF NOT EXISTS idx_products_search ON products USING GIN (
+	(COALESCE(name, '') || ' ' || COALESCE(category, '')) gin_trgm_ops
+);
+
+CREATE INDEX IF NOT EXISTS idx_inventory_search ON inventory USING GIN (
+	(COALESCE(ingredient_name, '') || ' ' || COALESCE(type, '')) gin_trgm_ops
+);

--- a/backend/internal/database/migrations/057_add_search_trgm_column_indexes.up.sql
+++ b/backend/internal/database/migrations/057_add_search_trgm_column_indexes.up.sql
@@ -1,0 +1,21 @@
+-- Ensure pg_trgm is available for trigram operator/index usage
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Clients
+CREATE INDEX IF NOT EXISTS idx_clients_name_trgm ON clients USING GIN (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_clients_email_trgm ON clients USING GIN (email gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_clients_phone_trgm ON clients USING GIN (phone gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_clients_city_trgm ON clients USING GIN (city gin_trgm_ops);
+
+-- Products
+CREATE INDEX IF NOT EXISTS idx_products_name_trgm ON products USING GIN (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_products_category_trgm ON products USING GIN (category gin_trgm_ops);
+
+-- Inventory
+CREATE INDEX IF NOT EXISTS idx_inventory_ingredient_name_trgm ON inventory USING GIN (ingredient_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_inventory_unit_trgm ON inventory USING GIN (unit gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_inventory_type_trgm ON inventory USING GIN (type gin_trgm_ops);
+
+-- Events
+CREATE INDEX IF NOT EXISTS idx_events_service_type_trgm ON events USING GIN (service_type gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_events_location_trgm ON events USING GIN (location gin_trgm_ops);

--- a/backend/internal/database/migrations/057_add_search_trgm_column_indexes.up.sql
+++ b/backend/internal/database/migrations/057_add_search_trgm_column_indexes.up.sql
@@ -1,6 +1,13 @@
 -- Ensure pg_trgm is available for trigram operator/index usage
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
+-- Replace legacy concatenated trigram indexes from migration 033 to avoid
+-- duplicate index maintenance and planner ambiguity.
+DROP INDEX IF EXISTS idx_clients_search;
+DROP INDEX IF EXISTS idx_events_search;
+DROP INDEX IF EXISTS idx_products_search;
+DROP INDEX IF EXISTS idx_inventory_search;
+
 -- Clients
 CREATE INDEX IF NOT EXISTS idx_clients_name_trgm ON clients USING GIN (name gin_trgm_ops);
 CREATE INDEX IF NOT EXISTS idx_clients_email_trgm ON clients USING GIN (email gin_trgm_ops);

--- a/backend/internal/repository/client_repo.go
+++ b/backend/internal/repository/client_repo.go
@@ -137,13 +137,21 @@ func (r *ClientRepo) Search(ctx context.Context, userID uuid.UUID, query string)
 		FROM clients
 		WHERE user_id = $1
 		AND (
+			name % $2 OR
+			email % $2 OR
+			phone % $2 OR
+			city % $2 OR
 			name ILIKE '%' || $2 || '%' OR
 			email ILIKE '%' || $2 || '%' OR
 			phone ILIKE '%' || $2 || '%' OR
-			city ILIKE '%' || $2 || '%' OR
-			similarity(name, $2) > 0.3
+			city ILIKE '%' || $2 || '%'
 		)
-		ORDER BY similarity(name, $2) DESC, created_at DESC
+		ORDER BY GREATEST(
+			similarity(COALESCE(name, ''), $2),
+			similarity(COALESCE(email, ''), $2),
+			similarity(COALESCE(phone, ''), $2),
+			similarity(COALESCE(city, ''), $2)
+		) DESC, created_at DESC
 		LIMIT 10`
 
 	rows, err := r.pool.Query(ctx, sqlQuery, userID, query)

--- a/backend/internal/repository/event_repo.go
+++ b/backend/internal/repository/event_repo.go
@@ -1137,12 +1137,18 @@ func (r *EventRepo) Search(ctx context.Context, userID uuid.UUID, query string) 
 		LEFT JOIN clients c ON e.client_id = c.id
 		WHERE e.user_id = $1
 		AND (
+			e.service_type %% $2 OR
+			e.location %% $2 OR
+			c.name %% $2 OR
 			e.service_type ILIKE '%%' || $2 || '%%' OR
 			e.location ILIKE '%%' || $2 || '%%' OR
-			c.name ILIKE '%%' || $2 || '%%' OR
-			similarity(coalesce(c.name, ''), $2) > 0.3
+			c.name ILIKE '%%' || $2 || '%%'
 		)
-		ORDER BY similarity(coalesce(c.name, ''), $2) DESC, e.event_date DESC
+		ORDER BY GREATEST(
+			similarity(COALESCE(c.name, ''), $2),
+			similarity(COALESCE(e.service_type, ''), $2),
+			similarity(COALESCE(e.location, ''), $2)
+		) DESC, e.event_date DESC
 		LIMIT 10`, eventSelectFields)
 
 	rows, err := r.pool.Query(ctx, sqlQuery, userID, query)

--- a/backend/internal/repository/inventory_repo.go
+++ b/backend/internal/repository/inventory_repo.go
@@ -127,12 +127,18 @@ func (r *InventoryRepo) Search(ctx context.Context, userID uuid.UUID, query stri
 		FROM inventory
 		WHERE user_id = $1
 		AND (
+			ingredient_name % $2 OR
+			unit % $2 OR
+			type % $2 OR
 			ingredient_name ILIKE '%' || $2 || '%' OR
 			unit ILIKE '%' || $2 || '%' OR
-			type ILIKE '%' || $2 || '%' OR
-			similarity(ingredient_name, $2) > 0.3
+			type ILIKE '%' || $2 || '%'
 		)
-		ORDER BY similarity(ingredient_name, $2) DESC, last_updated DESC
+		ORDER BY GREATEST(
+			similarity(COALESCE(ingredient_name, ''), $2),
+			similarity(COALESCE(unit, ''), $2),
+			similarity(COALESCE(type, ''), $2)
+		) DESC, last_updated DESC
 		LIMIT 10`
 
 	rows, err := r.pool.Query(ctx, sqlQuery, userID, query)

--- a/backend/internal/repository/product_repo.go
+++ b/backend/internal/repository/product_repo.go
@@ -222,11 +222,15 @@ func (r *ProductRepo) Search(ctx context.Context, userID uuid.UUID, query string
 		FROM products
 		WHERE user_id = $1
 		AND (
+			name % $2 OR
+			category % $2 OR
 			name ILIKE '%' || $2 || '%' OR
-			category ILIKE '%' || $2 || '%' OR
-			similarity(name, $2) > 0.3
+			category ILIKE '%' || $2 || '%'
 		)
-		ORDER BY similarity(name, $2) DESC, created_at DESC
+		ORDER BY GREATEST(
+			similarity(COALESCE(name, ''), $2),
+			similarity(COALESCE(category, ''), $2)
+		) DESC, created_at DESC
 		LIMIT 10`
 
 	rows, err := r.pool.Query(ctx, sqlQuery, userID, query)

--- a/docs/PRD/11_CURRENT_STATUS.md
+++ b/docs/PRD/11_CURRENT_STATUS.md
@@ -730,6 +730,7 @@ status: active
 - ✅ 045: Product staff_team_id (Personal Ola 3)
 - ✅ 046: Event public link tiers + shape gating (Tier Enforcement)
 - ✅ 047: Payment submissions table (Pagos Phase 1)
+- ✅ 057: Indexed search v2 (pg_trgm por columna) y retiro de índices heredados `idx_*_search` para evitar duplicación de mantenimiento/planificación
 
 ### MVP Contract Freeze — Cerrado 2026-04-10 ✅
 


### PR DESCRIPTION
## Linked Issue
- Closes #380

## What
- Added migration 057 with pg_trgm GIN indexes per searchable column for clients, products, inventory, and events.
- Refactored repository search queries to use trigram `%` matching plus ILIKE fallback.
- Updated result ranking to use combined multi-field similarity scoring (GREATEST(similarity(...))).

## Why
- Existing broad ILIKE-only patterns degrade with data growth and were not consistently aligned with index-friendly similarity patterns.
- This implements phase 1 of indexed search strategy while preserving behavior.

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Validation
- go test ./internal/repository/...
- go test ./internal/database/...

## Follow-up (Phase 2)
- Evaluate targeted migration paths to tsvector/tsquery where stemming/ranking semantics are required.

## Risk and Rollback
- Risk: Low/Medium. Query plans may shift; migration adds new indexes with storage overhead.
- Rollback: Revert migration 057 and this PR commit.
