### PR TITLE
feat(backend): implement nonce-based CSP for HTML endpoints

### DIFF
--- a/backend/internal/middleware/security.go
+++ b/backend/internal/middleware/security.go
@@ -1,8 +1,53 @@
 package middleware
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"net/http"
+	"strings"
 )
+
+type cspNonceContextKey struct{}
+
+// GetCSPNonce returns the request-scoped CSP nonce for HTML responses.
+// Handlers that render HTML can use this value in nonce="..." script tags.
+func GetCSPNonce(ctx context.Context) string {
+	nonce, _ := ctx.Value(cspNonceContextKey{}).(string)
+	return nonce
+}
+
+func generateCSPNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawStdEncoding.EncodeToString(b), nil
+}
+
+func buildDefaultCSP() string {
+	return "default-src 'self'; " +
+		"script-src 'self'; " +
+		"style-src 'self'; " +
+		"img-src 'self' data: https:; " +
+		"font-src 'self' data:; " +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'"
+}
+
+func buildHTMLCSP(nonce string) string {
+	return "default-src 'self'; " +
+		"script-src 'self' 'nonce-" + nonce + "'; " +
+		"style-src 'self'; " +
+		"img-src 'self' data: https:; " +
+		"font-src 'self' data:; " +
+		"connect-src 'self'; " +
+		"frame-ancestors 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'"
+}
 
 // SecurityHeaders adds essential security headers to all HTTP responses.
 // Implements OWASP recommended security headers to protect against common web vulnerabilities.
@@ -32,29 +77,17 @@ func SecurityHeaders(next http.Handler) http.Handler {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}
 
-		// Content Security Policy (CSP)
-		// Restricts sources from which resources can be loaded
-		// Mitigates: XSS attacks, data injection attacks, malicious script execution
-		//
-		// Policy breakdown:
-		// - default-src 'self': Only load resources from same origin by default
-		// - script-src 'self': Only execute scripts from same origin
-		// - style-src 'self' 'unsafe-inline': Styles from same origin + inline styles (for React/Tailwind)
-		// - img-src 'self' data: https:: Images from same origin, data URIs, and HTTPS
-		// - font-src 'self' data:: Fonts from same origin and data URIs
-		// - connect-src 'self': API calls only to same origin (or specific domains if needed)
-		// - frame-ancestors 'none': Don't allow embedding in frames (redundant with X-Frame-Options)
-		// - base-uri 'self': Restrict base URL to same origin
-		// - form-action 'self': Forms can only submit to same origin
-		csp := "default-src 'self'; " +
-			"script-src 'self'; " +
-			"style-src 'self' 'unsafe-inline'; " +
-			"img-src 'self' data: https:; " +
-			"font-src 'self' data:; " +
-			"connect-src 'self'; " +
-			"frame-ancestors 'none'; " +
-			"base-uri 'self'; " +
-			"form-action 'self'"
+		acceptHeader := strings.ToLower(r.Header.Get("Accept"))
+		isHTML := strings.Contains(acceptHeader, "text/html")
+
+		csp := buildDefaultCSP()
+		if isHTML {
+			nonce, err := generateCSPNonce()
+			if err == nil {
+				r = r.WithContext(context.WithValue(r.Context(), cspNonceContextKey{}, nonce))
+				csp = buildHTMLCSP(nonce)
+			}
+		}
 		w.Header().Set("Content-Security-Policy", csp)
 
 		// Referrer Policy

--- a/backend/internal/middleware/security.go
+++ b/backend/internal/middleware/security.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"log/slog"
 	"net/http"
 	"strings"
 )
 
 type cspNonceContextKey struct{}
+
+var cspNonceGenerator = generateCSPNonce
 
 // GetCSPNonce returns the request-scoped CSP nonce for HTML responses.
 // Handlers that render HTML can use this value in nonce="..." script tags.
@@ -25,9 +28,9 @@ func generateCSPNonce() (string, error) {
 	return base64.RawStdEncoding.EncodeToString(b), nil
 }
 
-func buildDefaultCSP() string {
+func buildCSP(scriptSrc string) string {
 	return "default-src 'self'; " +
-		"script-src 'self'; " +
+		scriptSrc + "; " +
 		"style-src 'self'; " +
 		"img-src 'self' data: https:; " +
 		"font-src 'self' data:; " +
@@ -37,16 +40,12 @@ func buildDefaultCSP() string {
 		"form-action 'self'"
 }
 
+func buildDefaultCSP() string {
+	return buildCSP("script-src 'self'")
+}
+
 func buildHTMLCSP(nonce string) string {
-	return "default-src 'self'; " +
-		"script-src 'self' 'nonce-" + nonce + "'; " +
-		"style-src 'self'; " +
-		"img-src 'self' data: https:; " +
-		"font-src 'self' data:; " +
-		"connect-src 'self'; " +
-		"frame-ancestors 'none'; " +
-		"base-uri 'self'; " +
-		"form-action 'self'"
+	return buildCSP("script-src 'self' 'nonce-" + nonce + "'")
 }
 
 // SecurityHeaders adds essential security headers to all HTTP responses.
@@ -82,11 +81,14 @@ func SecurityHeaders(next http.Handler) http.Handler {
 
 		csp := buildDefaultCSP()
 		if isHTML {
-			nonce, err := generateCSPNonce()
-			if err == nil {
-				r = r.WithContext(context.WithValue(r.Context(), cspNonceContextKey{}, nonce))
-				csp = buildHTMLCSP(nonce)
+			nonce, err := cspNonceGenerator()
+			if err != nil {
+				slog.Error("security.middleware: failed to generate CSP nonce", "error", err)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
 			}
+			r = r.WithContext(context.WithValue(r.Context(), cspNonceContextKey{}, nonce))
+			csp = buildHTMLCSP(nonce)
 		}
 		w.Header().Set("Content-Security-Policy", csp)
 

--- a/backend/internal/middleware/security_test.go
+++ b/backend/internal/middleware/security_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
@@ -80,6 +81,26 @@ func TestSecurityHeadersHTMLUsesNonceCSP(t *testing.T) {
 	}
 	if strings.Contains(csp, "'unsafe-inline'") {
 		t.Fatalf("HTML CSP should avoid unsafe-inline for scripts, got: %s", csp)
+	}
+}
+
+func TestSecurityHeadersHTMLNonceFailureReturns500(t *testing.T) {
+	originalGenerator := cspNonceGenerator
+	cspNonceGenerator = func() (string, error) { return "", errors.New("rng failure") }
+	defer func() { cspNonceGenerator = originalGenerator }()
+
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called when nonce generation fails")
+	}))
+
+	req := httptest.NewRequest("GET", "/callback", nil)
+	req.Header.Set("Accept", "text/html")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusInternalServerError)
 	}
 }
 

--- a/backend/internal/middleware/security_test.go
+++ b/backend/internal/middleware/security_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestSecurityHeaders(t *testing.T) {
+	var nonceFromContext string
 	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nonceFromContext = GetCSPNonce(r.Context())
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))
 	}))
@@ -38,11 +40,46 @@ func TestSecurityHeaders(t *testing.T) {
 	if !strings.Contains(csp, "default-src 'self'") {
 		t.Errorf("CSP missing default-src, got: %s", csp)
 	}
+	if strings.Contains(csp, "'unsafe-inline'") {
+		t.Errorf("default CSP should not use unsafe-inline, got: %s", csp)
+	}
+	if strings.Contains(csp, "'nonce-") {
+		t.Errorf("default API CSP should not include nonce, got: %s", csp)
+	}
+	if nonceFromContext != "" {
+		t.Errorf("expected empty nonce for non-HTML request, got %q", nonceFromContext)
+	}
 
 	// Check HTTP behavior for strict transport security
 	// non-https request without X-Forwarded-Proto
 	if hsts := rr.Header().Get("Strict-Transport-Security"); hsts != "" {
 		t.Errorf("expected empty HSTS header for standard HTTP req, got %q", hsts)
+	}
+}
+
+func TestSecurityHeadersHTMLUsesNonceCSP(t *testing.T) {
+	var nonceFromContext string
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nonceFromContext = GetCSPNonce(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/callback", nil)
+	req.Header.Set("Accept", "text/html")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if nonceFromContext == "" {
+		t.Fatal("expected nonce in request context for HTML request")
+	}
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if !strings.Contains(csp, "script-src 'self' 'nonce-"+nonceFromContext+"'") {
+		t.Fatalf("expected CSP nonce to match context nonce, got: %s", csp)
+	}
+	if strings.Contains(csp, "'unsafe-inline'") {
+		t.Fatalf("HTML CSP should avoid unsafe-inline for scripts, got: %s", csp)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue
- Closes #386

## What
- Implemented nonce-aware CSP generation for HTML requests in security middleware.
- Added request-scoped nonce accessor for handlers that render HTML (`GetCSPNonce`).
- Split CSP building into strict default API policy and HTML nonce policy.
- Added middleware tests to verify:
  - default API requests do not include nonce and do not use unsafe-inline
  - HTML requests include a nonce in CSP and request context

## Why
- Issue #386 requires a nonce-based CSP pipeline for backend-served HTML surfaces.
- This keeps JSON/API responses on a stricter default CSP while enabling secure inline handling for HTML responses.

## Scope
- [x] Backend
- [ ] Web
- [ ] iOS
- [ ] Android
- [ ] Docs/PRD

## Validation
- `go test ./internal/middleware -run SecurityHeaders`
- `go test ./internal/middleware`

## Risk and Rollback
- Risk: Low. Changes are isolated to middleware CSP header generation.
- Rollback: Revert this PR commit.
